### PR TITLE
Align spec + mockups for Phase 2 readiness

### DIFF
--- a/.claude/project-spec.yml
+++ b/.claude/project-spec.yml
@@ -10,7 +10,7 @@ meta:
   author: gudnuf
   philosophy: "WHISPER to CANVAS — start radically simple. The app grows with the user. Features unlock through usage, not menus. The AI and user learn about each other together."
   pillars:
-    - "Privacy-first: cypherpunk aesthetic, encryption ambient, lock icon always visible"
+    - "Privacy-first: cypherpunk aesthetic, encryption ambient, privacy is structural not decorative"
     - "Voice-first: speak don't type, mic is the primary interface"
     - "Credits as fuel: tokens power the AI, user sees them flow in and out"
 
@@ -41,8 +41,8 @@ progressive_unlock:
     - level: 0
       name: "The Void"
       trigger: "First launch, 0 entries"
-      what_appears: "Empty screen. Pulsing mic. Lock icon. Token balance. 'Say anything.' No nav, no chrome."
-      screens: [S1, S2, S3, S4, S5]
+      what_appears: "Empty screen. Pulsing mic center. Token balance. 'Say anything.' No nav, no chrome."
+      screens: [S1, S2, S3, S4]
 
     - level: 1
       name: "First Light"
@@ -60,7 +60,7 @@ progressive_unlock:
       name: "Views Emerge"
       trigger: "20+ entries, AI detects patterns"
       what_appears: "AI suggests views via focus card. Bottom nav appears (Home / Views / Settings)."
-      screens: [S10, S11]
+      screens: [S5, S10, S11]
 
     - level: 4
       name: "Full Power"
@@ -79,7 +79,7 @@ tokens:
   starter_balance: 5000
   display:
     header: "Small pill in app header. Shows remaining balance as a plain number with subtle token icon. Always visible."
-    recording: "Hidden during recording (transcription is on-device, free). Appears when processing begins."
+    recording: "Counters visible at ↑ 0 · ↓ 0 during recording (on-device transcription = free). Animate when processing begins."
     processing: "Two counters appear during AI processing: ↑ (input, fast burst ~0.8s) and ↓ (output, streaming ~3s). Input is the transcript being sent. Output is the structured entries coming back. Monospace, muted, directional arrows in subtle colors."
     confirm: "Session summary in confirm footer: '↑ 247 in · ↓ 312 out' — clean breakdown of what was sent and received."
     settings: "Full breakdown: balance, total in/out lifetime, average per session."
@@ -152,8 +152,7 @@ tokens:
 
 # Privacy & Cypherpunk Aesthetic
 privacy:
-  lock_icon: "Always visible top-left on every screen. Green dot = all encrypted. Tap → encryption detail."
-  encryption_detail: "AES-256-GCM. Key in Secure Enclave. N entries encrypted."
+  encryption_detail: "AES-256-GCM. Key in Secure Enclave. N entries encrypted. Viewable in Settings."
   data_split:
     encrypted:
       - "rawTranscript (always encrypted, only decrypted in memory when viewing)"
@@ -690,8 +689,8 @@ milestones:
         description: "Set up the Nix flake, XcodeGen project.yml, Makefile, Theme.swift with design tokens, and CI pipeline."
       - title: "SwiftData models (Entry, Tag, CreditBalance, UserProgress) + encryption"
         description: "Implement all data models with SwiftData. EncryptionService + EncryptedString type with CryptoKit AES-GCM. CreditBalance and UserProgress as singletons."
-      - title: "Void state (S1) — the empty app with lock icon + token balance"
-        description: "Deep dark screen. Pulsing mic center. Lock icon top-left (tappable → settings). Token balance top-right. 'Say anything.' No nav, no chrome."
+      - title: "Void state (S1) — the empty app with pulsing mic + token balance"
+        description: "Deep dark screen. Pulsing mic center. Token balance top-right. 'Say anything.' No nav, no chrome."
       - title: "Recording overlay (S2) — mic states, waveform, live transcript, token counter"
         description: "Full-screen overlay. Active mic with pulse rings. Waveform. Live transcript. Duration counter. Token flow counter (↑ in · ↓ out)."
       - title: "Processing state (S3) — transition animation, item materialization"
@@ -707,7 +706,7 @@ milestones:
     description: "Sparse home, focus cards, AI-composed home, entry detail, progressive unlock tracking"
     issues:
       - title: "Sparse home (S7) — basic card layout with encrypted entries"
-        description: "Level 1 home. 'Murmur' header + greeting. A few cards. Lock icon + token balance in header. Floating mic. No bottom nav."
+        description: "Level 1 home. 'Murmur' header + greeting. A few cards. Token balance in header. Floating mic. No bottom nav."
       - title: "Focus card (S6) — AI selection logic, act/dismiss"
         description: "ONE item centered. Ghost of home behind. Act (complete/explore/dismiss) or tap anywhere for home. Priority: todo due today > reminder 24h > unchecked habit > AI insight > skip."
       - title: "AI-composed home (S8) — rule-based layout with LLM fallback"
@@ -725,7 +724,7 @@ milestones:
       - title: "Credit burn tracking during AI calls"
         description: "CreditService.deduct() called during AI operations. Per-entry creditCost recorded. Real-time counter during recording."
       - title: "Settings minimal (S5) — encryption status, credits, model selector"
-        description: "Level 0-2 settings: 3 sections. Security (encryption active, key status, entries encrypted), Credits (balance, top up), Processing (AI model with TEE badge, mode)."
+        description: "Level 3+ settings (accessible via bottom nav): 3 sections. Security (encryption active, key status, entries encrypted), Credits (balance, top up), Processing (AI model with TEE badge, mode)."
       - title: "TEE badges for model selector"
         description: "Model selector shows badges: [TEE] for trusted execution, [On-Device] for local, [Cloud] for standard. Badge colors: TEE=green, On-Device=blue, Cloud=gray."
       - title: "Top-up flow (S12) — Apple Pay, Cashu, Subscribe"
@@ -748,12 +747,15 @@ milestones:
         description: "AI backend config (transcription service, LLM endpoint, API key). Heat visualization slider. Manage views. Data export / clear."
 
 # V1 Screen Inventory (12 screens, progressive)
+# NOTE: The `level` field indicates the minimum unlock level for each screen.
+# Screens may appear with additional chrome (e.g., bottom nav) at higher levels.
+# Mockups may depict a screen as seen by a Level 3+ user even if the screen itself unlocks earlier.
 ui_mockups:
   # Always Present (Level 0+)
   - name: "S1: Void"
     file: "mockups/15-void.html"
     level: 0
-    description: "Deep dark. Pulsing mic center. Lock icon top-left (tappable → settings). Token balance top-right. 'Say anything.' No nav."
+    description: "Deep dark. Pulsing mic center. Token balance top-right. 'Say anything.' No nav, no chrome."
 
   - name: "S2: Recording"
     file: "mockups/16-recording-credits.html"
@@ -773,8 +775,8 @@ ui_mockups:
 
   - name: "S5: Settings (minimal)"
     file: "mockups/18-settings-minimal.html"
-    level: 0
-    description: "Progressive — starts as 3 sections (Encryption / Credits / Processing Mode), grows to full config at Level 4. Entry via lock icon (Level 0-2) or Settings tab (Level 3+)."
+    level: 3
+    description: "Progressive — starts as 3 sections (Encryption / Credits / Processing Mode), grows to full config at Level 4. Accessible via Settings tab in bottom nav (Level 3+)."
 
   # Level 1+ (1-5 entries)
   - name: "S6: Focus Card"
@@ -785,7 +787,7 @@ ui_mockups:
   - name: "S7: Home (Sparse)"
     file: "mockups/21-home-sparse.html"
     level: 1
-    description: "'Murmur' header + greeting. A few cards. Lock icon + token balance in header. Floating mic. No bottom nav yet."
+    description: "'Murmur' header + greeting. A few cards. Token balance in header. Floating mic. No bottom nav yet."
 
   # Level 2+ (10+ entries)
   - name: "S8: Home (AI-Composed)"

--- a/mockups/01-home-ai.html
+++ b/mockups/01-home-ai.html
@@ -109,33 +109,6 @@
     justify-content: space-between;
     margin-bottom: 4px;
   }
-  .lock-icon {
-    position: relative;
-    width: 22px;
-    height: 22px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-  }
-  .lock-icon svg {
-    width: 18px;
-    height: 18px;
-    fill: none;
-    stroke: #8E8E9A;
-    stroke-width: 1.8;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-  .lock-dot {
-    position: absolute;
-    top: -1px;
-    right: -1px;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #34D399;
-  }
   .token-balance {
     font-size: 13px;
     color: #8E8E9A;
@@ -360,10 +333,6 @@
   <div class="screen-content">
     <div class="header">
       <div class="header-row">
-        <div class="lock-icon">
-          <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
-          <div class="lock-dot"></div>
-        </div>
         <span class="token-balance">4,312 tokens</span>
       </div>
       <h1>Murmur</h1>

--- a/mockups/04-pinned-views.html
+++ b/mockups/04-pinned-views.html
@@ -299,7 +299,7 @@
         </div>
         <div class="view-card-name">Habits</div>
       </div>
-      <!-- All Thoughts -->
+      <!-- All Entries -->
       <div class="view-card">
         <div class="view-icon view-icon-all">
           <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#60A5FA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -309,7 +309,7 @@
             <line x1="16" y1="17" x2="8" y2="17"/>
           </svg>
         </div>
-        <div class="view-card-name">All Thoughts</div>
+        <div class="view-card-name">All Entries</div>
       </div>
       <!-- Create View -->
       <div class="view-card view-card-create">

--- a/mockups/06-thought-detail.html
+++ b/mockups/06-thought-detail.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Murmur - Thought Detail</title>
+<title>Murmur - Entry Detail</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
@@ -340,7 +340,7 @@
           <polyline points="15 18 9 12 15 6"/>
         </svg>
       </div>
-      <div class="nav-title">Thought</div>
+      <div class="nav-title">Entry</div>
     </div>
     <div class="nav-actions">
       <div class="nav-icon-btn">

--- a/mockups/06b-thought-detail-expanded.html
+++ b/mockups/06b-thought-detail-expanded.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Murmur - Thought Detail (Expanded)</title>
+<title>Murmur - Entry Detail (Expanded)</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
@@ -322,7 +322,7 @@
           <polyline points="15 18 9 12 15 6"/>
         </svg>
       </div>
-      <div class="nav-title">Thought</div>
+      <div class="nav-title">Entry</div>
     </div>
     <div class="nav-actions">
       <div class="nav-icon-btn">

--- a/mockups/11-focus-dismissed.html
+++ b/mockups/11-focus-dismissed.html
@@ -115,33 +115,6 @@
     justify-content: space-between;
     margin-bottom: 4px;
   }
-  .lock-icon {
-    position: relative;
-    width: 22px;
-    height: 22px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-  }
-  .lock-icon svg {
-    width: 18px;
-    height: 18px;
-    fill: none;
-    stroke: #8E8E9A;
-    stroke-width: 1.8;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-  .lock-dot {
-    position: absolute;
-    top: -1px;
-    right: -1px;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #34D399;
-  }
   .token-balance {
     font-size: 13px;
     color: #8E8E9A;
@@ -418,10 +391,6 @@
   <div class="screen-content">
     <div class="header">
       <div class="header-row">
-        <div class="lock-icon">
-          <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
-          <div class="lock-dot"></div>
-        </div>
         <span class="token-balance">4,265 tokens</span>
       </div>
       <h1>Murmur</h1>

--- a/mockups/15-void.html
+++ b/mockups/15-void.html
@@ -93,40 +93,12 @@
     border-radius: 1px;
   }
 
-  /* App Header Row — lock + tokens */
+  /* App Header Row — token balance */
   .app-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 12px 24px 0;
-  }
-  .lock-icon {
-    position: relative;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-  }
-  .lock-icon svg {
-    width: 18px;
-    height: 18px;
-    fill: none;
-    stroke: #8E8E9A;
-    stroke-width: 1.8;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-  .lock-dot {
-    position: absolute;
-    top: 2px;
-    right: 2px;
-    width: 6px;
-    height: 6px;
-    background: #34D399;
-    border-radius: 50%;
-    box-shadow: 0 0 4px rgba(52,211,153,0.6);
   }
   .token-balance {
     font-size: 13px;
@@ -213,15 +185,8 @@
     </div>
   </div>
 
-  <!-- App Header: Lock + Token Balance -->
+  <!-- App Header: Token Balance -->
   <div class="app-header">
-    <div class="lock-icon">
-      <svg viewBox="0 0 24 24">
-        <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-        <path d="M7 11V7a5 5 0 0110 0v4"/>
-      </svg>
-      <div class="lock-dot"></div>
-    </div>
     <div class="token-balance">4,953 tokens</div>
   </div>
 

--- a/mockups/21-home-sparse.html
+++ b/mockups/21-home-sparse.html
@@ -102,32 +102,6 @@
     justify-content: space-between;
     padding: 12px 24px 0;
   }
-  .header-left {
-    position: relative;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-  .header-left svg {
-    width: 18px;
-    height: 18px;
-    fill: none;
-    stroke: #8E8E9A;
-    stroke-width: 1.8;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-  .lock-dot {
-    position: absolute;
-    top: -1px;
-    right: -1px;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #34D399;
-  }
   .header-center {
     font-size: 20px;
     font-weight: 700;
@@ -272,13 +246,6 @@
 
   <!-- App Header Row -->
   <div class="app-header">
-    <div class="header-left">
-      <svg viewBox="0 0 24 24">
-        <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-        <path d="M7 11V7a5 5 0 0110 0v4"/>
-      </svg>
-      <div class="lock-dot"></div>
-    </div>
     <div class="header-center">Murmur</div>
     <div class="header-right">4,953 tokens</div>
   </div>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -236,7 +236,7 @@
       <div class="nav-number num-new">S1</div>
       <div class="nav-text">
         <div class="nav-title">Void</div>
-        <div class="nav-subtitle">First launch — mic + lock + tokens</div>
+        <div class="nav-subtitle">First launch — mic + tokens</div>
       </div>
     </a>
   </div>

--- a/workflows/meta/gudnuf/003-spec-mockup-alignment.md
+++ b/workflows/meta/gudnuf/003-spec-mockup-alignment.md
@@ -1,0 +1,113 @@
+---
+id: "003"
+title: "Spec + Mockup Alignment for Phase 2 Readiness"
+status: completed
+author: gudnuf
+project: Murmur
+tags: [spec, mockups, alignment, lock-icon, settings, terminology, progressive-disclosure]
+previous: "002"
+sessions:
+  - id: aea1ffac
+    slug: spec-mockup-alignment
+    dir: -Users-claude-Murmur
+  - id: 807b3c38
+    slug: audit-and-plan
+    dir: -Users-claude-Murmur
+prompts: []
+created: "2026-02-11T01:57:00Z"
+updated: "2026-02-11T01:57:00Z"
+---
+
+# 003: Spec + Mockup Alignment for Phase 2 Readiness
+
+## Context
+
+After the V1 UX revision (entry 002: 21 mockups + 860-line spec), an audit revealed several mismatches between `project-spec.yml` and the HTML mockups. Two design decisions also crystallized: **remove the lock icon entirely** and **remove settings from Level 0**. This entry documents the cleanup pass that brings everything into alignment before Phase 2 (project scaffold + code).
+
+## What Changed
+
+### 1. Lock Icon Removed Everywhere
+
+**Decision**: The lock icon was a carryover from the cypherpunk aesthetic brainstorm, but it was solving a problem users don't have at Level 0. Privacy in Murmur is *structural* (AES-256-GCM, Secure Enclave keys) not *decorative* (a green dot on a padlock). The lock icon added visual noise to an app whose entire identity is "start empty, earn complexity."
+
+**Spec changes**:
+- Deleted `privacy.lock_icon` field
+- Updated pillar wording: "lock icon always visible" -> "privacy is structural not decorative"
+- Cleaned Level 0 `what_appears`, S1/S7 descriptions, M1/M2 milestone issue descriptions
+
+**Mockup changes** (4 files):
+- `15-void.html` — removed lock icon + green dot, header is now token-balance-only (right-aligned)
+- `21-home-sparse.html` — removed lock icon from header-left
+- `01-home-ai.html` — removed lock icon from header-row
+- `11-focus-dismissed.html` — removed lock icon from header-row
+- `index.html` — updated nav subtitle "mic + lock + tokens" -> "mic + tokens"
+
+### 2. Settings Moved from Level 0 to Level 3
+
+**Decision**: At Level 0, the user has zero entries — there's nothing to configure. Settings becomes meaningful when bottom nav appears (Level 3+, 20+ entries). This simplifies the void state and removes the question "how do you even reach settings at Level 0 without a lock icon?"
+
+**Changes**:
+- Level 0 screens: `[S1, S2, S3, S4, S5]` -> `[S1, S2, S3, S4]`
+- Level 3 screens: `[S10, S11]` -> `[S5, S10, S11]`
+- S5 level: `0` -> `3`
+- S5 description: removed "Entry via lock icon (Level 0-2)", now "Accessible via Settings tab in bottom nav (Level 3+)"
+- M3 settings issue description updated to reflect Level 3+
+
+### 3. Token Display Contradiction Fixed
+
+**Problem**: Spec said tokens are "Hidden during recording" but the S2 recording mockup already showed `↑ 0 · ↓ 0` counters during recording.
+
+**Fix**: Changed `tokens.display.recording` to "Counters visible at ↑ 0 · ↓ 0 during recording (on-device transcription = free). Animate when processing begins." This matches both the mockup and the intent — the counters *exist* during recording, they just don't move until processing starts.
+
+### 4. "Thought" -> "Entry" Terminology
+
+**Problem**: Several mockups still used "Thought" as a screen/model name, but the data model renamed it to "Entry" during the V1 revision. Not all entries are thoughts — some are todos, reminders, lists.
+
+**Changes**:
+- `06-thought-detail.html` — nav title "Thought" -> "Entry", page title updated
+- `06b-thought-detail-expanded.html` — same nav title + page title fix
+- `04-pinned-views.html` — "All Thoughts" -> "All Entries" (view name + comment)
+
+**Left alone**: `08-settings.html` "Export Thoughts" — this is a legacy mockup (`level: null`, replaced by progressive settings) so no fix needed.
+
+### 5. Bottom Nav Clarification Note
+
+**Problem**: Some mockups show bottom nav on screens that unlock at Level 1 (focus cards, sparse home). This looks like a contradiction — spec says bottom nav appears at Level 3+.
+
+**Resolution**: Not a bug. The mockups depict screens as seen by a Level 3+ user. The `level` field is the *minimum* unlock level, not the *only* level. Added a clarifying comment to `ui_mockups` section:
+
+> "The `level` field indicates the minimum unlock level for each screen. Screens may appear with additional chrome (e.g., bottom nav) at higher levels."
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `.claude/project-spec.yml` | Lock icon removal, settings level change, token display fix, nav note, milestone updates |
+| `mockups/15-void.html` | Removed lock icon element + CSS |
+| `mockups/21-home-sparse.html` | Removed lock icon element + CSS |
+| `mockups/01-home-ai.html` | Removed lock icon element + CSS |
+| `mockups/11-focus-dismissed.html` | Removed lock icon element + CSS |
+| `mockups/06-thought-detail.html` | "Thought" -> "Entry" |
+| `mockups/06b-thought-detail-expanded.html` | "Thought" -> "Entry" |
+| `mockups/04-pinned-views.html` | "All Thoughts" -> "All Entries" |
+| `mockups/index.html` | "lock" removed from S1 subtitle |
+
+## Verification
+
+All grep checks pass:
+- `lock` in mockups: zero UI references (only CSS `display: block` hits)
+- `lock` in spec: zero UI references (only "unlock", "locked behind Level 4", encryption context)
+- `Thought` in mockups: zero as screen/model name (only legacy `08-settings.html` "Export Thoughts")
+- Level 0 screens confirmed `[S1, S2, S3, S4]`
+- S5 level confirmed `3`
+- `tokens.display.recording` no longer says "Hidden"
+
+## Developer Patterns Observed
+
+- **Audit before scaffold** — catching these mismatches now saves significant rework in Phase 2. A lock icon baked into SwiftUI components would have been much harder to remove.
+- **Decisions cascade** — removing the lock icon forced the question "how do you reach settings?" which forced settings to Level 3+, which simplified the void state. One decision cleaned up three issues.
+- **Grep is the spec test suite** — systematic grep verification caught the `index.html` and `06b` references that the plan missed.
+
+## What's Next
+
+Phase 2: project scaffold, SwiftData models, and the first buildable screen (S1: The Void). The spec and mockups are now aligned and ready to drive implementation.


### PR DESCRIPTION
## Summary
- Remove lock icon from spec (`project-spec.yml`) and 4 mockups — privacy is structural, not decorative
- Move Settings (S5) from Level 0 to Level 3 — accessible via bottom nav, not a lock icon tap
- Fix token display contradiction: recording counters visible at `↑ 0 · ↓ 0`, not hidden
- Rename "Thought" → "Entry" in detail mockups (`06`, `06b`) and "All Thoughts" → "All Entries" in views (`04`)
- Add clarification note: `level` field = minimum unlock level, mockups may show higher-level chrome

## Test plan
- [ ] Grep mockups for "lock" — zero UI references (only CSS `display: block` hits)
- [ ] Grep spec for `lock_icon` — zero matches
- [ ] Grep mockups for capital "Thought" as screen name — zero (only legacy `08-settings.html`)
- [ ] Confirm Level 0 screens = `[S1, S2, S3, S4]` (no S5)
- [ ] Confirm S5 level = 3
- [ ] Confirm `tokens.display.recording` says "Counters visible", not "Hidden"
- [ ] Open mockup index in browser, verify void/sparse-home/ai-home render without lock icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)