### PR TITLE
fix: clean up build environment and remove SDK workarounds

### DIFF
--- a/Murmur/DevMode/DevModeView.swift
+++ b/Murmur/DevMode/DevModeView.swift
@@ -39,7 +39,7 @@ struct DevModeView: View {
                                 }
                             }
 
-                            if let overrideLevel = appState.devOverrideLevel {
+                            if appState.devOverrideLevel != nil {
                                 HStack(spacing: 6) {
                                     Image(systemName: "info.circle.fill")
                                         .font(.system(size: 12))

--- a/Murmur/Murmur.entitlements
+++ b/Murmur/Murmur.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>$(APP_GROUP_IDENTIFIER)</string>
+		<string>group.com.damsac.murmur.shared</string>
 	</array>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -13,11 +13,8 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.9"
-    IPHONEOS_DEPLOYMENT_TARGET: "17.0"
     CODE_SIGN_STYLE: Automatic
     CODE_SIGN_IDENTITY: "Apple Development"
-    # Xcode 26 calls ld directly with -Xlinker flags; route through clang instead
-    LD: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
 
 targets:
   Murmur:


### PR DESCRIPTION
Removes Nix SDK pollution, xcodebuild signing overrides, and the LD linker hack — none are needed with Xcode 26.2. Adds `make run` for one-command simulator launch.

## After pulling

Verify your environment still builds: `direnv reload && make test && make run`

If anything breaks, give your agent this prompt:

> Enter the Murmur dev shell (`direnv allow`), run `make build` and `make test`. If either fails, diagnose the issue (check `env` for stale Nix SDK vars, verify `xcodebuild -version` shows Xcode 26+, ensure `project.local.yml` exists). Fix whatever is broken and open a PR with the fix.