### PR TITLE
fix: toast auto-dismiss, due date picker UX, and swipe action sizing

### DIFF
--- a/Murmur/Components/EntryCard.swift
+++ b/Murmur/Components/EntryCard.swift
@@ -78,62 +78,73 @@ struct EntryCard: View {
     // MARK: - Body
 
     var body: some View {
-        Button(action: { onTap?() }) {
-            VStack(alignment: .leading, spacing: 12) {
-                // Category badge (suppress dot glow for timeless entries)
-                if showCategory {
-                    CategoryBadge(category: entry.category, size: .small, showDotGlow: !isIdea)
-                }
+        cardContent
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Entry: \(entry.summary)")
+    }
 
-                // Summary text
-                Text(entry.summary)
-                    .font(Theme.Typography.body)
-                    .foregroundStyle(isCompleted ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
-                    .strikethrough(isCompleted, color: Theme.Colors.textTertiary)
-                    .lineLimit(3)
-                    .multilineTextAlignment(.leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+    @ViewBuilder
+    private var cardContent: some View {
+        if let onTap {
+            Button(action: onTap) { cardBody }
+                .buttonStyle(.plain)
+        } else {
+            cardBody
+        }
+    }
 
-                // Metadata row — suppressed for timeless entries (ideas, thoughts)
-                if !isIdea && !isCompleted {
-                    HStack(spacing: 12) {
+    private var cardBody: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Category badge (suppress dot glow for timeless entries)
+            if showCategory {
+                CategoryBadge(category: entry.category, size: .small, showDotGlow: !isIdea)
+            }
+
+            // Summary text
+            Text(entry.summary)
+                .font(Theme.Typography.body)
+                .foregroundStyle(isCompleted ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
+                .strikethrough(isCompleted, color: Theme.Colors.textTertiary)
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Metadata row — suppressed for timeless entries (ideas, thoughts)
+            if !isIdea && !isCompleted {
+                HStack(spacing: 12) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "clock")
+                            .font(.caption2)
+                        Text(timeAgo)
+                            .font(Theme.Typography.label)
+                    }
+                    .foregroundStyle(Theme.Colors.textTertiary)
+
+                    if let dueText {
                         HStack(spacing: 4) {
-                            Image(systemName: "clock")
+                            Image(systemName: isOverdue ? "exclamationmark.circle.fill" : "calendar")
                                 .font(.caption2)
-                            Text(timeAgo)
+                            Text(dueText)
+                                .font(Theme.Typography.label)
+                                .fontWeight(.medium)
+                        }
+                        .foregroundStyle(isOverdue ? Theme.Colors.accentRed : Theme.Colors.accentYellow)
+                    } else if entry.priority.map({ $0 <= 2 }) ?? false {
+                        HStack(spacing: 4) {
+                            Image(systemName: "exclamationmark.circle.fill")
+                                .font(.caption2)
+                            Text("High")
                                 .font(Theme.Typography.label)
                         }
-                        .foregroundStyle(Theme.Colors.textTertiary)
-
-                        if let dueText {
-                            HStack(spacing: 4) {
-                                Image(systemName: isOverdue ? "exclamationmark.circle.fill" : "calendar")
-                                    .font(.caption2)
-                                Text(dueText)
-                                    .font(Theme.Typography.label)
-                                    .fontWeight(.medium)
-                            }
-                            .foregroundStyle(isOverdue ? Theme.Colors.accentRed : Theme.Colors.accentYellow)
-                        } else if entry.priority.map({ $0 <= 2 }) ?? false {
-                            HStack(spacing: 4) {
-                                Image(systemName: "exclamationmark.circle.fill")
-                                    .font(.caption2)
-                                Text("High")
-                                    .font(Theme.Typography.label)
-                            }
-                            .foregroundStyle(Theme.Colors.accentRed)
-                        }
-
-                        Spacer()
+                        .foregroundStyle(Theme.Colors.accentRed)
                     }
+
+                    Spacer()
                 }
             }
-            .cardStyle(accent: cardAccent, intensity: cardIntensity)
-            .opacity(cardOpacity)
         }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Entry: \(entry.summary)")
+        .cardStyle(accent: cardAccent, intensity: cardIntensity)
+        .opacity(cardOpacity)
     }
 }
 

--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -165,17 +165,11 @@ struct EntryDetailView: View {
                 EntryActionBar(
                     isArchived: entry.status == .archived,
                     onArchive: {
-                        entry.status = .archived
-                        entry.updatedAt = Date()
-                        save()
-                        NotificationService.shared.cancel(entry)
+                        entry.perform(.archive, in: modelContext, preferences: notifPrefs)
                         onArchive()
                     },
                     onUnarchive: {
-                        entry.status = .active
-                        entry.updatedAt = Date()
-                        save()
-                        NotificationService.shared.sync(entry, preferences: notifPrefs)
+                        entry.perform(.unarchive, in: modelContext, preferences: notifPrefs)
                         onBack()
                     },
                     onSnooze: { showSnoozeDialog = true },
@@ -223,7 +217,7 @@ struct EntryDetailView: View {
         }
         .alert("Delete entry?", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive) {
-                NotificationService.shared.cancel(entry)
+                entry.perform(.delete, in: modelContext, preferences: notifPrefs)
                 onDelete()
             }
             Button("Cancel", role: .cancel) {}
@@ -270,11 +264,7 @@ struct EntryDetailView: View {
     }
 
     private func snooze(until date: Date?) {
-        entry.snoozeUntil = date
-        entry.status = .snoozed
-        entry.updatedAt = Date()
-        save()
-        NotificationService.shared.sync(entry, preferences: notifPrefs)
+        entry.perform(.snooze(until: date), in: modelContext, preferences: notifPrefs)
         onSnooze()
     }
 


### PR DESCRIPTION
- Wire RootView to use ToastContainer (auto-dismiss + tap-to-dismiss); error toasts now show in red instead of green
- Remove toggle from DueDateEditSheet — calendar shows immediately; add "Remove Date" destructive toolbar button
- Fix swipe action buttons bleeding through semi-transparent stack cards
- Fix swipe action button height on non-front stack cards by measuring card content height via GeometryReader and clamping the button HStack