### PR TITLE
fix: update Makefile entitlements validation to check for build variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ generate: ## Generate Xcode project from project.yml
 		exit 1; \
 	fi
 	xcodegen generate
-	@if ! grep -q '$(APP_GROUP)' "$(ENTITLEMENTS)" 2>/dev/null; then \
-		echo "ERROR: $(ENTITLEMENTS) missing App Group '$(APP_GROUP)'" >&2; \
+	@if ! grep -q 'APP_GROUP_IDENTIFIER' "$(ENTITLEMENTS)" 2>/dev/null; then \
+		echo "ERROR: $(ENTITLEMENTS) missing APP_GROUP_IDENTIFIER build variable" >&2; \
 		exit 1; \
 	fi
 	@echo "Project generated — entitlements validated."


### PR DESCRIPTION
## Summary
- After #25 switched `Murmur.entitlements` from a hardcoded app group string to `$(APP_GROUP_IDENTIFIER)`, the `make generate` validation check broke on fresh checkouts — it was grepping for the literal group ID which no longer exists in the file
- Now checks for the variable name `APP_GROUP_IDENTIFIER` instead

## Test plan
- [ ] Run `make generate` on a fresh checkout — should pass without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)