### PR TITLE
fix: use xcode-select to resolve DEVELOPER_DIR in swift-clean

### DIFF
--- a/Packages/MurmurCore/swift-clean
+++ b/Packages/MurmurCore/swift-clean
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Run Swift commands without Nix SDK interference
+DEVELOPER_DIR="$(xcode-select -p 2>/dev/null || echo /Applications/Xcode.app/Contents/Developer)"
 exec env -i \
   HOME="$HOME" \
   USER="$USER" \
   PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" \
-  DEVELOPER_DIR="/Applications/Xcode-26.2.0.app/Contents/Developer" \
+  DEVELOPER_DIR="$DEVELOPER_DIR" \
   ${PPQ_API_KEY:+PPQ_API_KEY="$PPQ_API_KEY"} \
   /usr/bin/swift "$@"


### PR DESCRIPTION
## Summary
- `swift-clean` had `DEVELOPER_DIR` hardcoded to `/Applications/Xcode-26.2.0.app/Contents/Developer`, which only works on machines where Xcode is installed with that exact versioned name
- Changed to use `xcode-select -p` at runtime, which resolves the active Xcode path on any machine

## Test plan
- [ ] `make core-test` passes on both machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)