### PR TITLE
feat: focus strip + collapsible category sections on home screen

### DIFF
--- a/Murmur/Views/Home/HomeView.swift
+++ b/Murmur/Views/Home/HomeView.swift
@@ -145,23 +145,30 @@ struct HomeView: View {
                     .padding(.bottom, 4)
             }
 
-            // Flat smart list
+            // Scrollable content: focus strip + category sections
             ScrollView {
-                LazyVStack(spacing: 12) {
-                    ForEach(sortedEntries) { entry in
-                        SwipeableCard(
-                            actions: swipeActions(for: entry),
-                            activeSwipeID: $activeSwipeEntryID,
-                            entryID: entry.id,
-                            onTap: { onEntryTap(entry) }
-                        ) {
-                            SmartListRow(entry: entry)
+                VStack(spacing: 0) {
+                    // Focus strip (hidden when no urgent entries)
+                    if !focusEntries.isEmpty {
+                        FocusStripView(entries: focusEntries, onEntryTap: onEntryTap)
+                            .padding(.top, 12)
+                            .padding(.bottom, 16)
+                    }
+
+                    // Category sections
+                    LazyVStack(spacing: 0) {
+                        ForEach(entriesByCategory, id: \.category) { group in
+                            CategorySectionView(
+                                category: group.category,
+                                entries: group.entries,
+                                activeSwipeEntryID: $activeSwipeEntryID,
+                                onEntryTap: onEntryTap,
+                                swipeActionsProvider: swipeActions(for:)
+                            )
                         }
                     }
+                    .padding(.bottom, 16)
                 }
-                .padding(.horizontal, Theme.Spacing.screenPadding)
-                .padding(.top, 10)
-                .padding(.bottom, 16)
             }
         }
     }
@@ -199,20 +206,52 @@ struct HomeView: View {
         return parts.joined(separator: ", ")
     }
 
-    /// Sort entries by relevance: priority (urgent first), due date (soonest first), then recency.
-    private var sortedEntries: [Entry] {
-        entries.sorted { lhs, rhs in
-            let pa = lhs.priority ?? Int.max
-            let pb = rhs.priority ?? Int.max
-            if pa != pb { return pa < pb }
+    // MARK: - Focus Strip Data
 
-            let da = lhs.dueDate ?? Date.distantFuture
-            let db = rhs.dueDate ?? Date.distantFuture
-            if da != db { return da < db }
+    /// Entries qualifying for the focus strip: priority ≤ 2 or overdue.
+    private var focusEntries: [Entry] {
+        entries
+            .filter { entry in
+                let isHighPriority = (entry.priority ?? Int.max) <= 2
+                let isOverdue = entry.dueDate.map { $0 < Date() } ?? false
+                return isHighPriority || isOverdue
+            }
+            .sorted { lhs, rhs in
+                let lo = lhs.dueDate.map { $0 < Date() } ?? false
+                let ro = rhs.dueDate.map { $0 < Date() } ?? false
+                if lo != ro { return lo }
+                let pa = lhs.priority ?? Int.max
+                let pb = rhs.priority ?? Int.max
+                if pa != pb { return pa < pb }
+                return (lhs.dueDate ?? .distantFuture) < (rhs.dueDate ?? .distantFuture)
+            }
+    }
 
-            return lhs.createdAt > rhs.createdAt
+    // MARK: - Category Section Data
+
+    private static let categoryDisplayOrder: [EntryCategory] = [
+        .todo, .reminder, .habit, .idea, .list, .note, .question, .thought
+    ]
+
+    /// Entries grouped by category, in fixed display order, only non-empty categories.
+    private var entriesByCategory: [(category: EntryCategory, entries: [Entry])] {
+        let grouped = Dictionary(grouping: entries) { $0.category }
+        return Self.categoryDisplayOrder.compactMap { category in
+            guard let items = grouped[category], !items.isEmpty else { return nil }
+            let sorted = items.sorted { lhs, rhs in
+                let pa = lhs.priority ?? Int.max
+                let pb = rhs.priority ?? Int.max
+                if pa != pb { return pa < pb }
+                let da = lhs.dueDate ?? Date.distantFuture
+                let db = rhs.dueDate ?? Date.distantFuture
+                if da != db { return da < db }
+                return lhs.createdAt > rhs.createdAt
+            }
+            return (category: category, entries: sorted)
         }
     }
+
+    // MARK: - Swipe Actions
 
     private func swipeActions(for entry: Entry) -> [CardSwipeAction] {
         let isCompletable = entry.category == .todo
@@ -239,6 +278,190 @@ struct HomeView: View {
         ) { onAction(entry, .snooze(until: nil)) })
 
         return actions
+    }
+}
+
+// MARK: - Focus Strip
+
+private struct FocusStripView: View {
+    let entries: [Entry]
+    let onEntryTap: (Entry) -> Void
+
+    private let maxVisible = 4
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("FOCUS")
+                .font(Theme.Typography.badge)
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Array(entries.prefix(maxVisible))) { entry in
+                        FocusChipView(entry: entry) { onEntryTap(entry) }
+                    }
+
+                    if entries.count > maxVisible {
+                        Text("+\(entries.count - maxVisible) more →")
+                            .font(Theme.Typography.badge)
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(
+                                Capsule()
+                                    .fill(Theme.Colors.bgCard)
+                                    .overlay(Capsule().stroke(Theme.Colors.borderSubtle, lineWidth: 1))
+                            )
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+                .padding(.vertical, 2)
+            }
+        }
+    }
+}
+
+// MARK: - Focus Chip
+
+private struct FocusChipView: View {
+    let entry: Entry
+    let onTap: () -> Void
+
+    private var color: Color { Theme.categoryColor(entry.category) }
+    private var isOverdue: Bool { entry.dueDate.map { $0 < Date() } ?? false }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 6, height: 6)
+                    .shadow(color: color.opacity(0.5), radius: 3)
+
+                Text(entry.summary)
+                    .font(Theme.Typography.badge)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+                    .lineLimit(1)
+                    .frame(maxWidth: 130)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(isOverdue ? Theme.Colors.accentRed.opacity(0.12) : color.opacity(0.10))
+                    .overlay(
+                        Capsule().stroke(
+                            isOverdue ? Theme.Colors.accentRed.opacity(0.35) : color.opacity(0.25),
+                            lineWidth: 1
+                        )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Category Section
+
+private struct CategorySectionView: View {
+    let category: EntryCategory
+    let entries: [Entry]
+    @Binding var activeSwipeEntryID: UUID?
+    let onEntryTap: (Entry) -> Void
+    let swipeActionsProvider: (Entry) -> [CardSwipeAction]
+
+    @AppStorage private var isCollapsed: Bool
+
+    init(
+        category: EntryCategory,
+        entries: [Entry],
+        activeSwipeEntryID: Binding<UUID?>,
+        onEntryTap: @escaping (Entry) -> Void,
+        swipeActionsProvider: @escaping (Entry) -> [CardSwipeAction]
+    ) {
+        self.category = category
+        self.entries = entries
+        self._activeSwipeEntryID = activeSwipeEntryID
+        self.onEntryTap = onEntryTap
+        self.swipeActionsProvider = swipeActionsProvider
+        self._isCollapsed = AppStorage(wrappedValue: false, "section_\(category.rawValue)_collapsed")
+    }
+
+    private var color: Color { Theme.categoryColor(category) }
+    private var hasOverdue: Bool { entries.contains { $0.dueDate.map { $0 < Date() } ?? false } }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Section header
+            Button {
+                withAnimation(Animations.smoothSlide) { isCollapsed.toggle() }
+            } label: {
+                HStack(spacing: 0) {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(color)
+                            .frame(width: 8, height: 8)
+                            .shadow(color: color.opacity(0.6), radius: 4)
+
+                        Text(category.displayName.uppercased())
+                            .font(Theme.Typography.badge)
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                            .tracking(0.8)
+                    }
+
+                    if hasOverdue {
+                        Circle()
+                            .fill(Theme.Colors.accentRed)
+                            .frame(width: 5, height: 5)
+                            .padding(.leading, 6)
+                    }
+
+                    Spacer()
+
+                    HStack(spacing: 8) {
+                        Text("\(entries.count)")
+                            .font(Theme.Typography.badge)
+                            .foregroundStyle(Theme.Colors.textTertiary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(
+                                Capsule()
+                                    .fill(Theme.Colors.bgCard)
+                                    .overlay(Capsule().stroke(Theme.Colors.borderSubtle, lineWidth: 1))
+                            )
+
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Theme.Colors.textTertiary)
+                            .rotationEffect(.degrees(isCollapsed ? -90 : 0))
+                            .animation(Animations.smoothSlide, value: isCollapsed)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, Theme.Spacing.screenPadding)
+            .padding(.top, 20)
+            .padding(.bottom, isCollapsed ? 8 : 12)
+
+            // Section body
+            if !isCollapsed {
+                LazyVStack(spacing: 12) {
+                    ForEach(entries) { entry in
+                        SwipeableCard(
+                            actions: swipeActionsProvider(entry),
+                            activeSwipeID: $activeSwipeEntryID,
+                            entryID: entry.id,
+                            onTap: { onEntryTap(entry) }
+                        ) {
+                            SmartListRow(entry: entry)
+                        }
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
     }
 }
 
@@ -427,7 +650,7 @@ struct SwipeableCard<Content: View>: View {
     }
 }
 
-#Preview("Home - Smart List") {
+#Preview("Home - Category Sections") {
     @Previewable @State var appState = AppState()
     @Previewable @State var inputText = ""
 
@@ -440,7 +663,7 @@ struct SwipeableCard<Content: View>: View {
                 category: .reminder,
                 sourceText: "",
                 summary: "DMV appointment Thursday",
-                dueDate: Calendar.current.date(byAdding: .day, value: 2, to: Date())
+                dueDate: Calendar.current.date(byAdding: .day, value: -1, to: Date())
             ),
             Entry(
                 transcript: "",

--- a/mockups/home-screen.html
+++ b/mockups/home-screen.html
@@ -1,0 +1,973 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Murmur — Home Screen Mockups</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: #12121A;
+      font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 48px 32px 80px;
+      gap: 0;
+      min-height: 100vh;
+    }
+
+    h1 {
+      color: #F5F5F7;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: -0.5px;
+      margin-bottom: 6px;
+    }
+    .subtitle {
+      color: #5C5C6A;
+      font-size: 13px;
+      margin-bottom: 52px;
+      letter-spacing: 0.2px;
+    }
+
+    .phones-row {
+      display: flex;
+      gap: 48px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .phone-col {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+    }
+
+    .phone-label {
+      font-size: 11px;
+      font-weight: 600;
+      color: #5C5C6A;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    /* ── iPhone frame ── */
+    .phone {
+      width: 375px;
+      background: #0A0A0F;
+      border-radius: 50px;
+      box-shadow:
+        0 0 0 1.5px #2A2A35,
+        0 0 0 3px #0A0A0F,
+        0 0 0 4.5px #1A1A24,
+        0 48px 96px rgba(0,0,0,0.7);
+      overflow: hidden;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    .status-bar {
+      height: 54px;
+      background: #0A0A0F;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 28px 0;
+      position: relative;
+    }
+    .status-time { font-size: 15px; font-weight: 600; color: #F5F5F7; }
+    .status-icons { display: flex; align-items: center; gap: 5px; color: #F5F5F7; font-size: 12px; }
+    .dynamic-island {
+      position: absolute; top: 12px; left: 50%; transform: translateX(-50%);
+      width: 120px; height: 34px; background: #000; border-radius: 20px;
+    }
+
+    .screen {
+      height: 760px;
+      overflow-y: scroll;
+      background: #0A0A0F;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+    }
+    .screen::-webkit-scrollbar { display: none; }
+
+    .home-bar {
+      height: 34px;
+      background: #0A0A0F;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .home-bar::after {
+      content: '';
+      width: 134px; height: 5px;
+      background: rgba(255,255,255,0.25);
+      border-radius: 3px;
+    }
+
+    /* ── Header ── */
+    .header { padding: 20px 24px 0; }
+    .header-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 3px;
+    }
+    .greeting {
+      font-size: 22px;
+      font-weight: 600;
+      color: #F5F5F7;
+      letter-spacing: -0.4px;
+    }
+    .settings-btn {
+      width: 30px; height: 30px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.08);
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer;
+      font-size: 13px; color: #5C5C6A;
+      transition: background 0.15s;
+    }
+    .settings-btn:hover { background: rgba(255,255,255,0.1); }
+    .date-text { font-size: 14px; color: #8E8E9A; margin-bottom: 3px; }
+    .brief-text { font-size: 12px; color: #5C5C6A; margin-bottom: 18px; }
+
+    /* ── Needs Attention strip ── */
+    .strip {
+      margin: 0 24px 18px;
+      background: #1A1A24;
+      border: 1px solid rgba(239, 68, 68, 0.18);
+      border-radius: 18px;
+      padding: 14px 14px 14px;
+      box-shadow: 0 2px 20px rgba(239, 68, 68, 0.06);
+    }
+    .strip-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 11px;
+    }
+    .strip-icon { font-size: 11px; }
+    .strip-label {
+      font-size: 10px;
+      font-weight: 700;
+      color: #5C5C6A;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    .chips-scroll {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      scrollbar-width: none;
+      padding-bottom: 1px;
+    }
+    .chips-scroll::-webkit-scrollbar { display: none; }
+
+    .chip {
+      background: #0A0A0F;
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 12px;
+      padding: 8px 12px;
+      min-width: 118px;
+      max-width: 150px;
+      flex-shrink: 0;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .chip:hover { background: #14141C; border-color: rgba(255,255,255,0.1); }
+    .chip-top {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      margin-bottom: 4px;
+    }
+    .chip-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+    .chip-name {
+      font-size: 12px;
+      font-weight: 500;
+      color: #D8D8E0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .chip-tag {
+      font-size: 10px;
+      font-weight: 600;
+      padding-left: 11px;
+    }
+    .chip-tag.overdue { color: #EF4444; }
+    .chip-tag.today   { color: #FBBF24; }
+    .chip-tag.p1      { color: #7C6FF7; }
+
+    .chip-more {
+      background: transparent;
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 12px;
+      padding: 8px 12px;
+      min-width: 56px;
+      flex-shrink: 0;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      color: #5C5C6A;
+      transition: color 0.15s;
+    }
+    .chip-more:hover { color: #8E8E9A; }
+
+    /* ── Section ── */
+    .section { margin-bottom: 2px; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 24px;
+      cursor: pointer;
+      user-select: none;
+      transition: background 0.12s;
+      border-radius: 4px;
+    }
+    .section-header:hover { background: rgba(255,255,255,0.02); }
+
+    .chevron {
+      font-size: 9px;
+      color: #3A3A48;
+      width: 12px;
+      text-align: center;
+      transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+      flex-shrink: 0;
+    }
+    .chevron.open { transform: rotate(90deg); color: #5C5C6A; }
+
+    .section-name {
+      font-size: 11px;
+      font-weight: 700;
+      color: #5C5C6A;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      flex: 1;
+    }
+    .section-count {
+      font-size: 11px;
+      color: #3A3A48;
+      background: rgba(255,255,255,0.04);
+      padding: 2px 7px;
+      border-radius: 8px;
+      font-weight: 600;
+    }
+    .urgency-pip {
+      width: 5px; height: 5px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    /* Peek line (shown under collapsed section header) */
+    .peek {
+      font-size: 12px;
+      color: #3A3A48;
+      padding: 0 24px 10px 44px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: none;
+    }
+    .peek.visible { display: block; }
+
+    /* Section body */
+    .section-body {
+      overflow: hidden;
+    }
+    .section-divider {
+      height: 1px;
+      background: rgba(255,255,255,0.04);
+      margin: 0 24px 12px;
+    }
+    .cards { padding: 0 24px; display: flex; flex-direction: column; gap: 10px; margin-bottom: 12px; }
+
+    /* ── Card ── */
+    .card {
+      background: #1A1A24;
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 16px;
+      padding: 14px 16px;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .card:hover { background: #1E1E2C; }
+    .card.overdue  { border-color: rgba(239, 68, 68, 0.22); }
+    .card.due-today { border-color: rgba(251, 191, 36, 0.22); }
+
+    .card-meta {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 8px;
+    }
+    .badge {
+      font-size: 10px;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 6px;
+      text-transform: lowercase;
+      letter-spacing: 0.2px;
+    }
+    .badge-todo     { background: rgba(124,111,247,0.15); color: #9D93F9; }
+    .badge-reminder { background: rgba(251,191,36,0.13);  color: #FCD34D; }
+    .badge-habit    { background: rgba(96,165,250,0.13);  color: #93C5FD; }
+    .badge-idea     { background: rgba(251,191,36,0.13);  color: #FCD34D; }
+    .badge-note     { background: rgba(142,142,154,0.13); color: #8E8E9A; }
+
+    .meta-spacer { flex: 1; }
+
+    .priority {
+      font-size: 10px; font-weight: 700; color: #EF4444;
+      display: flex; align-items: center; gap: 2px;
+    }
+    .due {
+      font-size: 10px; font-weight: 700;
+      display: flex; align-items: center; gap: 3px;
+    }
+    .due.overdue  { color: #EF4444; }
+    .due.today    { color: #FBBF24; }
+    .due.upcoming { color: #FBBF24; }
+
+    .card-summary {
+      font-size: 15px;
+      color: #E8E8F2;
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    /* ── Input bar ── */
+    .input-bar {
+      margin: 8px 24px 0;
+      background: #1A1A24;
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 16px;
+      padding: 12px 16px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .input-placeholder {
+      flex: 1;
+      font-size: 15px;
+      color: #3A3A48;
+    }
+    .mic-btn {
+      width: 32px; height: 32px;
+      border-radius: 50%;
+      background: #7C6FF7;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 14px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Murmur — Home Screen</h1>
+  <p class="subtitle">Focus Strip + Collapsible Categories · Click section headers to expand/collapse</p>
+
+  <div class="phones-row">
+
+    <!-- ─────────────────────────────────────
+         STATE 1: Urgency present
+         Strip visible, Todos expanded, rest collapsed
+    ───────────────────────────────────────── -->
+    <div class="phone-col">
+      <div class="phone-label">State 1 — Urgency Present</div>
+      <div class="phone">
+        <div class="status-bar">
+          <span class="status-time">9:41</span>
+          <div class="dynamic-island"></div>
+          <div class="status-icons">
+            <svg width="17" height="12" viewBox="0 0 17 12" fill="currentColor" opacity="0.9"><rect x="0" y="3" width="3" height="9" rx="1"/><rect x="4.5" y="2" width="3" height="10" rx="1"/><rect x="9" y="0.5" width="3" height="11.5" rx="1"/><rect x="13.5" y="0" width="3" height="12" rx="1" opacity="0.3"/></svg>
+            <svg width="16" height="12" viewBox="0 0 16 12" fill="currentColor" opacity="0.9"><path d="M8 2C10.8 2 13.3 3.1 15.1 4.9L16 4C13.9 1.9 11.1 0.5 8 0.5S2.1 1.9 0 4l0.9 0.9C2.7 3.1 5.2 2 8 2z"/><path d="M8 5C9.9 5 11.6 5.8 12.8 7L13.7 6.1C12.2 4.6 10.2 3.7 8 3.7S3.8 4.6 2.3 6.1L3.2 7C4.4 5.8 6.1 5 8 5z"/><circle cx="8" cy="10" r="1.8"/></svg>
+            <svg width="25" height="12" viewBox="0 0 25 12" fill="currentColor"><rect x="0" y="1" width="21" height="10" rx="3" stroke="currentColor" stroke-width="1" fill="none" opacity="0.35"/><rect x="1.5" y="2.5" width="15" height="7" rx="2" fill="currentColor"/><path d="M22.5 4.5v3c.8-.4 1.5-1 1.5-1.5s-.7-1.1-1.5-1.5z" fill="currentColor" opacity="0.4"/></svg>
+          </div>
+        </div>
+
+        <div class="screen">
+          <!-- Header -->
+          <div class="header">
+            <div class="header-row">
+              <span class="greeting">Good evening</span>
+              <div class="settings-btn">⚙</div>
+            </div>
+            <div class="date-text">Friday, February 28</div>
+            <div class="brief-text">2 overdue · 1 due today</div>
+          </div>
+
+          <!-- Needs Attention -->
+          <div class="strip">
+            <div class="strip-header">
+              <span class="strip-icon">⚡</span>
+              <span class="strip-label">Needs Attention</span>
+            </div>
+            <div class="chips-scroll">
+              <div class="chip">
+                <div class="chip-top">
+                  <div class="chip-dot" style="background:#9D93F9"></div>
+                  <span class="chip-name">Call dentist</span>
+                </div>
+                <div class="chip-tag overdue">Overdue</div>
+              </div>
+              <div class="chip">
+                <div class="chip-top">
+                  <div class="chip-dot" style="background:#FCD34D"></div>
+                  <span class="chip-name">DMV appt Thu</span>
+                </div>
+                <div class="chip-tag today">Due today</div>
+              </div>
+              <div class="chip-more">+1 →</div>
+            </div>
+          </div>
+
+          <!-- Todos — expanded -->
+          <div class="section" id="s1-todos">
+            <div class="section-header" onclick="toggle(this, 's1-todos', true)">
+              <span class="chevron open">▶</span>
+              <span class="section-name">Todos</span>
+              <span class="section-count">4</span>
+              <span class="urgency-pip" style="background:#EF4444"></span>
+            </div>
+            <div class="peek">Call dentist about appointment</div>
+            <div class="section-body">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card overdue">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                    <span class="due overdue">● Overdue</span>
+                  </div>
+                  <div class="card-summary">Call dentist about appointment</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                    <span class="priority">P1</span>
+                  </div>
+                  <div class="card-summary">Review design system and provide feedback</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Buy groceries</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Email contractor about invoice</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Reminders — collapsed -->
+          <div class="section" id="s1-reminders">
+            <div class="section-header" onclick="toggle(this, 's1-reminders', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Reminders</span>
+              <span class="section-count">1</span>
+              <span class="urgency-pip" style="background:#FBBF24"></span>
+            </div>
+            <div class="peek visible">DMV appointment Thursday</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card due-today">
+                  <div class="card-meta">
+                    <span class="badge badge-reminder">reminder</span>
+                    <div class="meta-spacer"></div>
+                    <span class="due today">● Due today</span>
+                  </div>
+                  <div class="card-summary">DMV appointment Thursday</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Habits — collapsed -->
+          <div class="section" id="s1-habits">
+            <div class="section-header" onclick="toggle(this, 's1-habits', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Habits</span>
+              <span class="section-count">1</span>
+            </div>
+            <div class="peek visible">Meditate for 10 minutes</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-habit">habit</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Meditate for 10 minutes</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Ideas — collapsed -->
+          <div class="section" id="s1-ideas">
+            <div class="section-header" onclick="toggle(this, 's1-ideas', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Ideas</span>
+              <span class="section-count">2</span>
+            </div>
+            <div class="peek visible">Voice-controlled garden watering</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-idea">idea</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Voice-controlled home garden watering system</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-idea">idea</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">App that turns grocery receipts into meal plans</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Input bar -->
+          <div class="input-bar" style="margin-top:16px">
+            <span class="input-placeholder">Say or type anything…</span>
+            <div class="mic-btn">🎙</div>
+          </div>
+        </div>
+
+        <div class="home-bar"></div>
+      </div>
+    </div>
+
+    <!-- ─────────────────────────────────────
+         STATE 2: All clear — no strip
+         No urgent items, sections with peek
+    ───────────────────────────────────────── -->
+    <div class="phone-col">
+      <div class="phone-label">State 2 — All Clear</div>
+      <div class="phone">
+        <div class="status-bar">
+          <span class="status-time">9:41</span>
+          <div class="dynamic-island"></div>
+          <div class="status-icons">
+            <svg width="17" height="12" viewBox="0 0 17 12" fill="currentColor" opacity="0.9"><rect x="0" y="3" width="3" height="9" rx="1"/><rect x="4.5" y="2" width="3" height="10" rx="1"/><rect x="9" y="0.5" width="3" height="11.5" rx="1"/><rect x="13.5" y="0" width="3" height="12" rx="1" opacity="0.3"/></svg>
+            <svg width="16" height="12" viewBox="0 0 16 12" fill="currentColor" opacity="0.9"><path d="M8 2C10.8 2 13.3 3.1 15.1 4.9L16 4C13.9 1.9 11.1 0.5 8 0.5S2.1 1.9 0 4l0.9 0.9C2.7 3.1 5.2 2 8 2z"/><path d="M8 5C9.9 5 11.6 5.8 12.8 7L13.7 6.1C12.2 4.6 10.2 3.7 8 3.7S3.8 4.6 2.3 6.1L3.2 7C4.4 5.8 6.1 5 8 5z"/><circle cx="8" cy="10" r="1.8"/></svg>
+            <svg width="25" height="12" viewBox="0 0 25 12" fill="currentColor"><rect x="0" y="1" width="21" height="10" rx="3" stroke="currentColor" stroke-width="1" fill="none" opacity="0.35"/><rect x="1.5" y="2.5" width="18" height="7" rx="2" fill="currentColor"/><path d="M22.5 4.5v3c.8-.4 1.5-1 1.5-1.5s-.7-1.1-1.5-1.5z" fill="currentColor" opacity="0.4"/></svg>
+          </div>
+        </div>
+
+        <div class="screen">
+          <div class="header">
+            <div class="header-row">
+              <span class="greeting">Good morning</span>
+              <div class="settings-btn">⚙</div>
+            </div>
+            <div class="date-text">Monday, March 3</div>
+            <div class="brief-text">8 entries</div>
+          </div>
+
+          <!-- No strip in this state -->
+
+          <!-- Todos — expanded -->
+          <div class="section" id="s2-todos">
+            <div class="section-header" onclick="toggle(this, 's2-todos', true)">
+              <span class="chevron open">▶</span>
+              <span class="section-name">Todos</span>
+              <span class="section-count">4</span>
+            </div>
+            <div class="peek">Call dentist about appointment</div>
+            <div class="section-body">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                    <span class="priority">P1</span>
+                  </div>
+                  <div class="card-summary">Review design system and provide feedback</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Call dentist about appointment</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Buy groceries</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Email contractor about invoice</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Reminders — collapsed with peek -->
+          <div class="section" id="s2-reminders">
+            <div class="section-header" onclick="toggle(this, 's2-reminders', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Reminders</span>
+              <span class="section-count">1</span>
+            </div>
+            <div class="peek visible">DMV appointment Thursday</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-reminder">reminder</span>
+                    <div class="meta-spacer"></div>
+                    <span class="due upcoming">Due in 2d</span>
+                  </div>
+                  <div class="card-summary">DMV appointment Thursday</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Habits — collapsed with peek -->
+          <div class="section" id="s2-habits">
+            <div class="section-header" onclick="toggle(this, 's2-habits', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Habits</span>
+              <span class="section-count">1</span>
+            </div>
+            <div class="peek visible">Meditate for 10 minutes</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-habit">habit</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Meditate for 10 minutes</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Ideas — collapsed with peek -->
+          <div class="section" id="s2-ideas">
+            <div class="section-header" onclick="toggle(this, 's2-ideas', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Ideas</span>
+              <span class="section-count">2</span>
+            </div>
+            <div class="peek visible">Voice-controlled garden watering</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-idea">idea</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Voice-controlled home garden watering system</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-idea">idea</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">App that turns grocery receipts into meal plans</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Notes — collapsed with peek -->
+          <div class="section" id="s2-notes">
+            <div class="section-header" onclick="toggle(this, 's2-notes', false)">
+              <span class="chevron">▶</span>
+              <span class="section-name">Notes</span>
+              <span class="section-count">2</span>
+            </div>
+            <div class="peek visible">Started reading Atomic Habits again</div>
+            <div class="section-body" style="display:none">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-note">note</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Started reading Atomic Habits again — really good chapter on identity-based goals</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-note">note</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Good coffee spot: Pilot Coffee on King St</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Input bar -->
+          <div class="input-bar" style="margin-top:16px">
+            <span class="input-placeholder">Say or type anything…</span>
+            <div class="mic-btn">🎙</div>
+          </div>
+        </div>
+
+        <div class="home-bar"></div>
+      </div>
+    </div>
+
+    <!-- ─────────────────────────────────────
+         STATE 3: All expanded
+         Strip + every section open
+    ───────────────────────────────────────── -->
+    <div class="phone-col">
+      <div class="phone-label">State 3 — All Expanded</div>
+      <div class="phone">
+        <div class="status-bar">
+          <span class="status-time">9:41</span>
+          <div class="dynamic-island"></div>
+          <div class="status-icons">
+            <svg width="17" height="12" viewBox="0 0 17 12" fill="currentColor" opacity="0.9"><rect x="0" y="3" width="3" height="9" rx="1"/><rect x="4.5" y="2" width="3" height="10" rx="1"/><rect x="9" y="0.5" width="3" height="11.5" rx="1"/><rect x="13.5" y="0" width="3" height="12" rx="1" opacity="0.3"/></svg>
+            <svg width="16" height="12" viewBox="0 0 16 12" fill="currentColor" opacity="0.9"><path d="M8 2C10.8 2 13.3 3.1 15.1 4.9L16 4C13.9 1.9 11.1 0.5 8 0.5S2.1 1.9 0 4l0.9 0.9C2.7 3.1 5.2 2 8 2z"/><path d="M8 5C9.9 5 11.6 5.8 12.8 7L13.7 6.1C12.2 4.6 10.2 3.7 8 3.7S3.8 4.6 2.3 6.1L3.2 7C4.4 5.8 6.1 5 8 5z"/><circle cx="8" cy="10" r="1.8"/></svg>
+            <svg width="25" height="12" viewBox="0 0 25 12" fill="currentColor"><rect x="0" y="1" width="21" height="10" rx="3" stroke="currentColor" stroke-width="1" fill="none" opacity="0.35"/><rect x="1.5" y="2.5" width="15" height="7" rx="2" fill="currentColor"/><path d="M22.5 4.5v3c.8-.4 1.5-1 1.5-1.5s-.7-1.1-1.5-1.5z" fill="currentColor" opacity="0.4"/></svg>
+          </div>
+        </div>
+
+        <div class="screen">
+          <div class="header">
+            <div class="header-row">
+              <span class="greeting">Good evening</span>
+              <div class="settings-btn">⚙</div>
+            </div>
+            <div class="date-text">Friday, February 28</div>
+            <div class="brief-text">2 overdue · 1 due today</div>
+          </div>
+
+          <!-- Strip -->
+          <div class="strip">
+            <div class="strip-header">
+              <span class="strip-icon">⚡</span>
+              <span class="strip-label">Needs Attention</span>
+            </div>
+            <div class="chips-scroll">
+              <div class="chip">
+                <div class="chip-top">
+                  <div class="chip-dot" style="background:#9D93F9"></div>
+                  <span class="chip-name">Call dentist</span>
+                </div>
+                <div class="chip-tag overdue">Overdue</div>
+              </div>
+              <div class="chip">
+                <div class="chip-top">
+                  <div class="chip-dot" style="background:#FCD34D"></div>
+                  <span class="chip-name">DMV appt Thu</span>
+                </div>
+                <div class="chip-tag today">Due today</div>
+              </div>
+              <div class="chip">
+                <div class="chip-top">
+                  <div class="chip-dot" style="background:#9D93F9"></div>
+                  <span class="chip-name">Review design</span>
+                </div>
+                <div class="chip-tag p1">P1</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Todos — expanded -->
+          <div class="section" id="s3-todos">
+            <div class="section-header" onclick="toggle(this, 's3-todos', true)">
+              <span class="chevron open">▶</span>
+              <span class="section-name">Todos</span>
+              <span class="section-count">4</span>
+              <span class="urgency-pip" style="background:#EF4444"></span>
+            </div>
+            <div class="peek">Call dentist about appointment</div>
+            <div class="section-body">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card overdue">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                    <span class="due overdue">● Overdue</span>
+                  </div>
+                  <div class="card-summary">Call dentist about appointment</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                    <span class="priority">P1</span>
+                  </div>
+                  <div class="card-summary">Review design system and provide feedback</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Buy groceries</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-todo">todo</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Email contractor about invoice</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Reminders — expanded -->
+          <div class="section" id="s3-reminders">
+            <div class="section-header" onclick="toggle(this, 's3-reminders', true)">
+              <span class="chevron open">▶</span>
+              <span class="section-name">Reminders</span>
+              <span class="section-count">1</span>
+              <span class="urgency-pip" style="background:#FBBF24"></span>
+            </div>
+            <div class="peek">DMV appointment Thursday</div>
+            <div class="section-body">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card due-today">
+                  <div class="card-meta">
+                    <span class="badge badge-reminder">reminder</span>
+                    <div class="meta-spacer"></div>
+                    <span class="due today">● Due today</span>
+                  </div>
+                  <div class="card-summary">DMV appointment Thursday</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Habits — expanded -->
+          <div class="section" id="s3-habits">
+            <div class="section-header" onclick="toggle(this, 's3-habits', true)">
+              <span class="chevron open">▶</span>
+              <span class="section-name">Habits</span>
+              <span class="section-count">1</span>
+            </div>
+            <div class="peek">Meditate for 10 minutes</div>
+            <div class="section-body">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-habit">habit</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Meditate for 10 minutes</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Ideas — expanded -->
+          <div class="section" id="s3-ideas">
+            <div class="section-header" onclick="toggle(this, 's3-ideas', true)">
+              <span class="chevron open">▶</span>
+              <span class="section-name">Ideas</span>
+              <span class="section-count">2</span>
+            </div>
+            <div class="peek">Voice-controlled garden watering</div>
+            <div class="section-body">
+              <div class="section-divider"></div>
+              <div class="cards">
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-idea">idea</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">Voice-controlled home garden watering system</div>
+                </div>
+                <div class="card">
+                  <div class="card-meta">
+                    <span class="badge badge-idea">idea</span>
+                    <div class="meta-spacer"></div>
+                  </div>
+                  <div class="card-summary">App that turns grocery receipts into meal plans</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Input bar -->
+          <div class="input-bar" style="margin-top:16px">
+            <span class="input-placeholder">Say or type anything…</span>
+            <div class="mic-btn">🎙</div>
+          </div>
+        </div>
+
+        <div class="home-bar"></div>
+      </div>
+    </div>
+
+  </div><!-- /phones-row -->
+
+  <script>
+    function toggle(header, sectionId, startsOpen) {
+      const section  = document.getElementById(sectionId);
+      const chevron  = header.querySelector('.chevron');
+      const body     = section.querySelector('.section-body');
+      const peek     = section.querySelector('.peek');
+      const isOpen   = chevron.classList.contains('open');
+
+      if (isOpen) {
+        // Collapse
+        chevron.classList.remove('open');
+        body.style.display = 'none';
+        if (peek) peek.classList.add('visible');
+      } else {
+        // Expand
+        chevron.classList.add('open');
+        body.style.display = 'block';
+        if (peek) peek.classList.remove('visible');
+      }
+    }
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Replaced the flat smart list with a two-layer home screen layout
- **Focus Strip**: horizontal scrolling chip row at the top for entries with priority ≤ 2 or an overdue due date; hidden entirely when no urgent entries exist
- **Category Sections**: all active entries grouped by category (Todo, Reminder, Habit, Idea, List, Note, Question, Thought) in a fixed display order; only non-empty categories render
- Section headers show a colored dot, category name, urgency pip (red dot when any entry is overdue), entry count badge, and a collapse chevron
- Tapping a section header collapses/expands the row list with a smooth spring animation
- Collapse state is persisted per-category via `@AppStorage` (survives app restarts)
- Items in the Focus Strip also appear in their category section (intentional — strip is a lens)
- Swipe coordination unchanged: single `activeSwipeEntryID` binding flows through all sections so swiping one card auto-closes others

## Design

Mockup: `mockups/home-screen.html` — State 3 "All Expanded" was selected as the target design.

## Test plan

- [ ] Populated list shows entries grouped by category (not flat)
- [ ] Focus Strip appears when any entry has priority ≤ 2 or overdue due date; hidden otherwise
- [ ] Tapping a section header collapses the entries with animation; tapping again expands
- [ ] Collapse state persists after killing and relaunching the app
- [ ] Urgency pip (red dot) appears on section header when any entry in that section is overdue
- [ ] Swiping a card in one section auto-closes any open swipe in another section
- [ ] Empty state still shows correctly when there are no entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)