### PR TITLE
feat: home screen visual polish — focus strip redesign, reduced noise

### DIFF
--- a/Murmur/Components/CategoryBadge.swift
+++ b/Murmur/Components/CategoryBadge.swift
@@ -19,19 +19,11 @@ struct CategoryBadge: View {
             }
         }
 
-        var font: Font {
-            switch self {
-            case .small: return Theme.Typography.badge
-            case .medium: return Theme.Typography.label
-            case .large: return Font.system(size: 13, weight: .semibold)
-            }
-        }
-
         var padding: EdgeInsets {
             switch self {
-            case .small: return EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 10)
-            case .medium: return EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 12)
-            case .large: return EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 14)
+            case .small: return EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8)
+            case .medium: return EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10)
+            case .large: return EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
             }
         }
     }
@@ -40,24 +32,12 @@ struct CategoryBadge: View {
         Theme.categoryColor(category)
     }
 
-    private var categoryLabel: String {
-        category.rawValue.uppercased()
-    }
-
     var body: some View {
-        HStack(spacing: 6) {
-            // Category indicator dot with glow
-            Circle()
-                .fill(categoryColor)
-                .frame(width: size.dotSize, height: size.dotSize)
-                .shadow(color: showDotGlow ? categoryColor.opacity(0.5) : .clear, radius: 3, x: 0, y: 0)
-
-            // Category label
-            Text(categoryLabel)
-                .font(size.font)
-                .foregroundStyle(Theme.Colors.textPrimary)
-                .tracking(0.5) // Letter spacing for uppercase text
-        }
+        // Category indicator dot with glow
+        Circle()
+            .fill(categoryColor)
+            .frame(width: size.dotSize, height: size.dotSize)
+            .shadow(color: showDotGlow ? categoryColor.opacity(0.5) : .clear, radius: 3, x: 0, y: 0)
         .padding(size.padding)
         .background(
             Capsule()

--- a/Murmur/Components/EntryCard.swift
+++ b/Murmur/Components/EntryCard.swift
@@ -36,17 +36,6 @@ struct EntryCard: View {
         return dueDate >= Date() && !isCompleted
     }
 
-    private var cardAccent: Color? {
-        if isCompleted || isIdea { return nil }
-        if isOverdue { return Theme.Colors.accentRed }
-        if hasActiveDue { return Theme.Colors.accentYellow }
-        return nil
-    }
-
-    private var cardIntensity: Double {
-        isOverdue ? 1.2 : 1.0
-    }
-
     private var cardOpacity: Double {
         if isCompleted { return 0.55 }
         if isIdea { return 0.88 }
@@ -143,7 +132,7 @@ struct EntryCard: View {
                 }
             }
         }
-        .cardStyle(accent: cardAccent, intensity: cardIntensity)
+        .cardStyle()
         .opacity(cardOpacity)
     }
 }

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,27 +6,26 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Home screen redesign — focus strip + collapsible category sections + habit check-off.
-
-Two commits shipping together:
-1. **Focus strip + collapsible sections** — replaced flat sorted list with a horizontal "FOCUS" chip strip at top (always visible) and per-category collapsible sections below. Collapse state persists via `@AppStorage`.
-2. **Habit check-off** — added circle button to habit cards that toggles `isDoneForPeriod`. Cadence-aware (daily/weekdays/weekly/monthly). Tap animates via haptic feedback.
+Home screen visual polish — reduced noise, improved focus section UX.
 
 ## Recent decisions
 
-- **Focus strip always visible** — originally conditionally rendered (hidden when no urgent items). Changed to always show because the user expects it as a permanent landmark at the top. Shows "All clear" when nothing qualifies.
-- **Focus strip criteria** — overdue = `dueDate < Date()` (not start of day); high-priority = `priority <= 2` with no due date requirement. P2 items without a due date still qualify.
-- **Gesture fix** — `SwipeableCard` used `.onTapGesture` on its content wrapper, which intercepted taps before child `Button`s could receive them. Changed to `.gesture(TapGesture().onEnded {...})` which has lower priority than interactive children.
-- **Items in strip also appear in category section** — intentional duplication. Strip is a lens, not a separate bucket.
-- **`RootView` action methods moved to extension** — SwiftLint `type_body_length` was blocking commits (467 lines vs 400 limit). Moved all handler methods into a `private extension RootView` block. Struct body is now ~240 meaningful lines.
+- **Category badges text-free** — removed category name label (e.g. "TODO") from `CategoryBadge`, keeping only the colored dot + capsule. Less clutter, color alone carries the signal.
+- **No red overdue dot in section headers** — removed the small red indicator dot next to category names when overdue items exist. Redundant given the focus strip.
+- **Focus strip redesigned as vertical cards** — replaced horizontal chip scroll with up to 3 full `FocusCardView`s. Each card shows category badge, Overdue/P1/P2 reason badge, and summary text. Capped at 3.
+- **Focus zone uses yellow not red** — yellow (`accentYellow`) feels softer and less alarming than red for the attention container. Background `opacity(0.05)`, border `opacity(0.18)`.
+- **No colored card outlines anywhere** — removed `cardAccent` / `cardIntensity` from both `SmartListRow` and `EntryCard`. All cards use plain `.cardStyle()`. Urgency communicated via text badges, not border color.
+- **Focus cards pulse** — staggered opacity animation (1.0 → 0.72, 2.4s easeInOut, delays 0s/0.6s/1.2s) draws the eye without being jarring.
+- **Focus strip header** — two-line: bold `Greeting.current + "."` (title3.semibold) + softer "Focus on these things today." (body, textSecondary). Left-aligned — consistent with the rest of the UI.
+- **No greeting popup** — tried a popup on app open but it didn't feel right. Removed. Greeting lives in the focus strip header instead.
+- **Focus strip hidden when empty** — conditionally rendered; if no focus entries, the section doesn't appear at all.
 
 ## Open questions
 
-- Should focus strip chips be tappable to jump to the entry directly (currently they do open the detail sheet — working fine)?
-- Should there be a "View all" button on the focus strip that opens a filtered list of all urgent items (beyond the 4 chip limit)?
-- Habit cadence display — currently cadence isn't shown on the card; should there be a subtle label (e.g. "daily")?
+- Should focus cards support swipe actions (complete/snooze) directly, or just tap-to-open?
+- Is 3 the right cap for focus items, or should it adapt based on available screen space?
 
 ## What I need from dam
 
-- Review the gesture fix in `SwipeableCard` — specifically that `.gesture(TapGesture().onEnded {...})` vs `.onTapGesture` is the right long-term approach. Could also explore `simultaneousGesture` if needed.
-- Any thoughts on the always-visible focus strip UX — does it feel right when there are no urgent items?
+- Any thoughts on the focus strip UX overall — does the yellow zone + vertical cards feel right?
+- The `Greeting.current` call is duplicated in `FocusStripView` — if you add a proper date/time context model, it should replace this.


### PR DESCRIPTION
## Thinking

The home screen had too much signalling competing for attention — colored card borders, text labels on every badge, a red dot on section headers, an always-visible greeting header. None of it was wrong individually, but together it read as noisy. The fix was to strip back to essentials: urgency should come from content (text badges like "Overdue", "P1"), not from decorative color on every surface.

The focus strip was the biggest change. Horizontal chips with small text didn't convey enough weight for something that's supposed to be the first thing you act on. Full vertical cards with a category badge, a reason badge, and readable summary text feel appropriately prominent. Capping at 3 forces prioritization — if everything is urgent, nothing is.

Yellow over red for the focus zone was a deliberate call. Red reads as "something is broken." Yellow reads as "pay attention." The app isn't broken, it's just telling you what matters today.

The greeting in the focus strip header (time-aware: "Good morning.", "Good afternoon.", etc.) adds a personal touch without requiring a separate popup or persistent header bar. Two lines: greeting in title weight, subtitle in secondary color — prominent but not screaming.

## Summary

- `CategoryBadge` is now dot-only — text label removed, color alone carries the category signal
- Removed red overdue indicator dot from category section headers (redundant with focus strip)
- Focus strip redesigned: up to 3 full `FocusCardView`s in a yellow-tinted zone container, replacing the horizontal chip scroll
- Each focus card shows category badge, reason badge (Overdue / P1 / P2), and 2-line summary
- Staggered opacity pulse animation on focus cards (delays: 0s, 0.6s, 1.2s)
- All colored card outlines removed — `SmartListRow` and `EntryCard` both use plain `.cardStyle()`
- Focus strip header: `Greeting.current` in title3.semibold + "Focus on these things today." in body/secondary
- Focus strip conditionally rendered — hidden entirely when no qualifying entries

## State changes

- Closed out the old focus strip / collapsible section work as shipped
- New open questions: swipe actions directly on focus cards? adaptive cap beyond 3?
- Canon candidate: "urgency via text badges, not border color" — consistent with existing no-outline direction

## Test plan

- [ ] Launch app with overdue entries — focus strip appears with yellow zone, correct reason badges
- [ ] Launch app with no overdue/high-priority entries — focus strip hidden entirely
- [ ] Category badges throughout app show dot only (no "TODO", "REMINDER" etc. text)
- [ ] All cards (home list rows, entry cards) have no colored outlines
- [ ] Focus cards pulse with staggered timing
- [ ] Header shows correct time-of-day greeting
- [ ] Tapping a focus card opens the entry detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)