### PR TITLE
feat: onboarding redesign — 3-moment flow + habit check-off fix

### DIFF
--- a/Murmur/Services/AppState.swift
+++ b/Murmur/Services/AppState.swift
@@ -14,7 +14,11 @@ final class AppState {
     var recordingState: RecordingState = .idle
     var showOnboarding: Bool = false
     var showFocusCard: Bool = false
+    #if DEBUG
+    var isDevMode: Bool = true
+    #else
     var isDevMode: Bool = false
+    #endif
 
     // Pipeline
     var pipeline: Pipeline?

--- a/Murmur/Views/Onboarding/OnboardingResultView.swift
+++ b/Murmur/Views/Onboarding/OnboardingResultView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import MurmurCore
+
+struct OnboardingResultView: View {
+    let entries: [Entry]
+    let onSaveAndComplete: () -> Void
+
+    @State private var cardVisible = false
+
+    var body: some View {
+        ZStack {
+            // Background — matches welcome screen
+            ZStack {
+                Theme.Colors.bgDeep
+                    .ignoresSafeArea()
+
+                LinearGradient(
+                    colors: [
+                        Theme.Colors.accentPurple.opacity(0.10),
+                        Color.clear
+                    ],
+                    startPoint: .bottom,
+                    endPoint: .center
+                )
+                .ignoresSafeArea()
+            }
+
+            VStack(spacing: 0) {
+                Spacer()
+
+                // Small caps label
+                Text("MURMUR CAPTURED")
+                    .font(Theme.Typography.badge)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .kerning(1.5)
+                    .opacity(cardVisible ? 1 : 0)
+                    .animation(.easeOut(duration: 0.35), value: cardVisible)
+
+                Spacer().frame(height: 20)
+
+                // Entry cards — spring-animated in as a group
+                VStack(spacing: 10) {
+                    ForEach(entries) { entry in
+                        EntryCard(entry: entry, showCategory: true, onTap: nil)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+                .scaleEffect(cardVisible ? 1.0 : 0.88)
+                .opacity(cardVisible ? 1 : 0)
+                .animation(.spring(response: 0.5, dampingFraction: 0.75), value: cardVisible)
+
+                Spacer().frame(height: 24)
+
+                // Body
+                Text("One thought, three things captured. Say anything — Murmur sorts it out.")
+                    .font(Theme.Typography.body)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+                    .opacity(cardVisible ? 1 : 0)
+                    .animation(.easeOut(duration: 0.4).delay(0.15), value: cardVisible)
+
+                Spacer()
+
+                // CTA
+                Button(action: onSaveAndComplete) {
+                    Text("Start capturing")
+                        .font(Theme.Typography.bodyMedium)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 18)
+                        .background(Theme.purpleGradient)
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.Spacing.cardRadius))
+                }
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+                .padding(.bottom, 48)
+                .opacity(cardVisible ? 1 : 0)
+                .animation(.easeOut(duration: 0.4).delay(0.25), value: cardVisible)
+            }
+        }
+        .onAppear {
+            withAnimation {
+                cardVisible = true
+            }
+        }
+    }
+}
+
+#Preview("Onboarding Result") {
+    let transcript = "Gotta call mom before the weekend. We're out of milk and eggs too. Oh — what if you could share entries with other people?"
+    OnboardingResultView(
+        entries: [
+            Entry(transcript: transcript, content: "Call mom before the weekend", category: .reminder, sourceText: "Gotta call mom before the weekend.", summary: "Call mom before the weekend"),
+            Entry(transcript: transcript, content: "Pick up milk and eggs", category: .todo, sourceText: "We're out of milk and eggs too.", summary: "Pick up milk and eggs"),
+            Entry(
+                transcript: transcript,
+                content: "Let users share entries with friends",
+                category: .idea,
+                sourceText: "What if you could share entries with other people?",
+                summary: "Share entries with friends"
+            ),
+        ],
+        onSaveAndComplete: { print("save and complete") }
+    )
+}

--- a/Murmur/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/Murmur/Views/Onboarding/OnboardingWelcomeView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct OnboardingWelcomeView: View {
+    let onContinue: () -> Void
+    let onSkip: () -> Void
+
+    @State private var showContent = false
+
+    var body: some View {
+        ZStack {
+            // Background — deep dark with faint purple at bottom
+            ZStack {
+                Theme.Colors.bgDeep
+                    .ignoresSafeArea()
+
+                LinearGradient(
+                    colors: [
+                        Theme.Colors.accentPurple.opacity(0.14),
+                        Color.clear
+                    ],
+                    startPoint: .bottom,
+                    endPoint: .center
+                )
+                .ignoresSafeArea()
+            }
+
+            // Skip button — top-right corner
+            VStack {
+                HStack {
+                    Spacer()
+                    Button(action: onSkip) {
+                        Text("Skip")
+                            .font(Theme.Typography.bodyMedium)
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                    }
+                    .padding(.trailing, Theme.Spacing.screenPadding)
+                    .padding(.top, 16)
+                }
+                Spacer()
+            }
+            .opacity(showContent ? 1 : 0)
+            .animation(.easeOut(duration: 0.3).delay(0.5), value: showContent)
+
+            // Main content
+            VStack(spacing: 0) {
+                Spacer()
+
+                // Visual anchor
+                PulsingMicView()
+                    .opacity(showContent ? 1 : 0)
+                    .offset(y: showContent ? 0 : 24)
+                    .animation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.1), value: showContent)
+
+                Spacer().frame(height: 48)
+
+                // Headline
+                Text("Stop losing\nyour thoughts.")
+                    .font(.system(size: 34, weight: .bold))
+                    .tracking(-0.5)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .opacity(showContent ? 1 : 0)
+                    .offset(y: showContent ? 0 : 16)
+                    .animation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.2), value: showContent)
+
+                Spacer().frame(height: 16)
+
+                // Body
+                Text("Just speak — Murmur captures and organizes everything automatically.")
+                    .font(Theme.Typography.body)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+                    .opacity(showContent ? 1 : 0)
+                    .offset(y: showContent ? 0 : 12)
+                    .animation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.3), value: showContent)
+
+                Spacer()
+
+                // CTA
+                Button(action: onContinue) {
+                    HStack(spacing: 8) {
+                        Text("See how it works")
+                            .font(Theme.Typography.bodyMedium)
+                        Image(systemName: "arrow.right")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .background(Theme.purpleGradient)
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.Spacing.cardRadius))
+                }
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+                .padding(.bottom, 48)
+                .opacity(showContent ? 1 : 0)
+                .offset(y: showContent ? 0 : 12)
+                .animation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.4), value: showContent)
+            }
+        }
+        .onAppear {
+            showContent = true
+        }
+    }
+}
+
+#Preview("Onboarding Welcome") {
+    OnboardingWelcomeView(
+        onContinue: { print("continue") },
+        onSkip: { print("skip") }
+    )
+}

--- a/meta/sac/PROCESS.md
+++ b/meta/sac/PROCESS.md
@@ -1,3 +1,4 @@
+
 # Sac's Process
 
 How sac works with Claude. Conventions, preferences, patterns.

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,26 +6,26 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Home screen visual polish — reduced noise, improved focus section UX.
+Onboarding redesign + habit check-off button fix.
 
 ## Recent decisions
 
-- **Category badges text-free** — removed category name label (e.g. "TODO") from `CategoryBadge`, keeping only the colored dot + capsule. Less clutter, color alone carries the signal.
-- **No red overdue dot in section headers** — removed the small red indicator dot next to category names when overdue items exist. Redundant given the focus strip.
-- **Focus strip redesigned as vertical cards** — replaced horizontal chip scroll with up to 3 full `FocusCardView`s. Each card shows category badge, Overdue/P1/P2 reason badge, and summary text. Capped at 3.
-- **Focus zone uses yellow not red** — yellow (`accentYellow`) feels softer and less alarming than red for the attention container. Background `opacity(0.05)`, border `opacity(0.18)`.
-- **No colored card outlines anywhere** — removed `cardAccent` / `cardIntensity` from both `SmartListRow` and `EntryCard`. All cards use plain `.cardStyle()`. Urgency communicated via text badges, not border color.
-- **Focus cards pulse** — staggered opacity animation (1.0 → 0.72, 2.4s easeInOut, delays 0s/0.6s/1.2s) draws the eye without being jarring.
-- **Focus strip header** — two-line: bold `Greeting.current + "."` (title3.semibold) + softer "Focus on these things today." (body, textSecondary). Left-aligned — consistent with the rest of the UI.
-- **No greeting popup** — tried a popup on app open but it didn't feel right. Removed. Greeting lives in the focus strip header instead.
-- **Focus strip hidden when empty** — conditionally rendered; if no focus entries, the section doesn't appear at all.
+- **Onboarding now 3 moments** — welcome → demo → result. Previously dropped straight into the transcript demo with no hook. Added `OnboardingWelcomeView` (hook + CTA) and `OnboardingResultView` (payoff — see what was captured).
+- **Multiple demo entries** — changed from single-entry demo to 3 entries (reminder + todo + idea) to show the full breadth of what Murmur captures in one voice note.
+- **Skip on welcome screen** — added skip button top-right. Calls `skipAndComplete()` without saving any entries. The demo is ~5s but some users will reject all onboarding.
+- **Processing auto-advances to result** — reduced delay from 2s → 1.5s; result screen is where the payoff happens. User explicitly taps "Start capturing" to save and proceed.
+- **isDevMode defaults true in DEBUG** — was always `false`; means every dev build needs to manually toggle dev mode. Now `#if DEBUG` sets it to `true` automatically.
+- **Focus cards got swipe actions** — FocusCardView now participates in the shared `activeSwipeEntryID` binding and receives swipe actions from the parent. Previously it had no swipe actions.
+- **Habit check-off button fix** — replaced `onTapGesture` on background with a proper `Button` wrapper in `SwipeableCard`. SwiftUI's inner-Button-wins rule means the habit circle button now correctly takes priority over card navigation.
+- **Done habits excluded from focus strip** — habits already checked off for the period are filtered out of `focusEntries`. Reduces noise; no point showing a done item as urgent.
+- **Focus strip visual cleanup** — removed yellow zone container (background + border). Cards sit directly in the list without a bounding box.
 
 ## Open questions
 
-- Should focus cards support swipe actions (complete/snooze) directly, or just tap-to-open?
-- Is 3 the right cap for focus items, or should it adapt based on available screen space?
+- Habit button fix needs a test run — confirm the circle toggles and doesn't open the detail sheet
+- Is 3 the right cap for focus items, or should it adapt to screen space?
 
 ## What I need from dam
 
-- Any thoughts on the focus strip UX overall — does the yellow zone + vertical cards feel right?
-- The `Greeting.current` call is duplicated in `FocusStripView` — if you add a proper date/time context model, it should replace this.
+- Confirm onboarding demo transcript still feels like a real use case. Current: "Gotta call mom before the weekend. We're out of milk and eggs too. Oh — what if you could share entries with other people?"
+- Thoughts on 3 demo entries vs 1 — is the variety valuable or overwhelming?


### PR DESCRIPTION
## Thinking

The old onboarding dropped users straight into a streaming transcript demo with zero context. They watched text appear, a processing spinner spin, and then landed on an empty home screen. No hook, no payoff, no understanding of what they just saw.

The core problem: the demo is the *magic*, but without a before and after, it reads as noise. Users need to feel the problem first (losing thoughts), then see the solution (Murmur capturing and organizing), then feel the payoff (here's what it captured from that one sentence).

For the result screen, I moved from a single demo entry to 3 entries spanning different categories (reminder + todo + idea). A single entry undersells the product — it looks like a fancy reminders app. Three entries from one voice note shows the real value: you say things in a stream of consciousness and Murmur pulls out everything structured.

The skip button was a late addition. The demo is ~5s total, but some users viscerally reject all onboarding regardless of length. Giving them an escape valve is better than watching them force-close the app. Skip doesn't save any demo entries — clean slate.

The habit check-off fix is a recurring issue with SwiftUI gesture conflicts. `onTapGesture` on a `.background()` modifier and a `Button` inside the foreground content compete unpredictably — sometimes the background tap wins, preventing the button from firing. The fix: wrap the card content in a proper `Button` (`.buttonStyle(.plain)`) instead. SwiftUI has well-defined behavior for nested Buttons: the innermost one wins. No more gesture conflict.

## Summary

- Added `OnboardingWelcomeView` — full-screen welcome with `PulsingMicView`, hook copy, "See how it works" CTA, and a "Skip" button that exits without saving
- Added `OnboardingResultView` — shows 3 demo entry cards (reminder/todo/idea) with spring entrance animation; "Start capturing" CTA saves entries and completes onboarding
- Updated `OnboardingFlowView` — flow is now `.welcome → .transcript → .processing → .result`; processing auto-advances at 1.5s (was 2s + auto-complete); save is explicit (user taps CTA)
- Updated demo content — single "try capturing ideas" entry replaced with a multi-extraction demo transcript
- `SwipeableCard` now uses a `Button` wrapper for card navigation, fixing the habit circle button being swallowed by gesture conflict
- Focus strip: swipe actions wired up on focus cards; done habits excluded; yellow zone container removed
- `isDevMode` defaults to `true` in DEBUG builds

## State changes

Closed out focus strip polish work. Opened onboarding. Open question: habit button fix still needs a manual test run to confirm behavior in the simulator.

## Related

Closes #56
Closes #16

## Test plan

- [ ] Fresh install (or Dev → Reset Onboarding): welcome screen animates in cleanly
- [ ] "See how it works" → transcript streams → processing spinner → result cards appear
- [ ] "Start capturing" → land on home with 3 entries visible
- [ ] Entries actually saved (restart app, they persist)
- [ ] `hasCompletedOnboarding` set (onboarding doesn't re-appear on next launch)
- [ ] "Skip" on welcome → lands on home, no demo entries saved
- [ ] Habit entry: tap circle → toggles checked state, no navigation sheet opens
- [ ] Habit entry in focus strip: check it off → disappears from focus strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)