### PR TITLE
feat: recording UI — minimal wave line with real audio input

### DIFF
--- a/Murmur/Components/AudioWaveformView.swift
+++ b/Murmur/Components/AudioWaveformView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// Waveform visualization driven by real audio level data.
+/// Renders a horizontal bar chart that reacts to live microphone input.
+/// Falls back to a gentle idle pulse when no audio data is present.
+struct AudioWaveformView: View {
+    /// Rolling buffer of audio levels (0.0–1.0), most recent at end.
+    let levels: [Float]
+    /// Number of bars to display.
+    let barCount: Int
+
+    var barWidth: CGFloat = 3
+    var barSpacing: CGFloat = 3
+    var maxBarHeight: CGFloat = 80
+    var minBarHeight: CGFloat = 4
+
+    @State private var idlePulse: Bool = false
+
+    private var hasRealData: Bool {
+        levels.contains { $0 > 0.02 }
+    }
+
+    var body: some View {
+        HStack(spacing: barSpacing) {
+            ForEach(0..<barCount, id: \.self) { index in
+                RoundedRectangle(cornerRadius: barWidth / 2)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Theme.Colors.accentPurple,
+                                Theme.Colors.accentPurpleLight
+                            ],
+                            startPoint: .bottom,
+                            endPoint: .top
+                        )
+                    )
+                    .frame(
+                        width: barWidth,
+                        height: barHeight(index: index)
+                    )
+                    .opacity(hasRealData ? 1.0 : 0.5)
+                    .animation(.easeOut(duration: 0.07), value: barLevel(at: index))
+            }
+        }
+        .frame(height: maxBarHeight)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                idlePulse = true
+            }
+        }
+    }
+
+    private func barHeight(index: Int) -> CGFloat {
+        let level = barLevel(at: index)
+        if hasRealData && level > 0.01 {
+            // Real data — full dramatic range
+            return minBarHeight + CGFloat(level) * (maxBarHeight - minBarHeight)
+        }
+        if hasRealData {
+            // Has data but this particular bar is silent — stay small
+            return minBarHeight
+        }
+        // Idle pulse: gentle wave pattern when no data at all
+        let center = CGFloat(barCount) / 2.0
+        let dist = abs(CGFloat(index) - center) / center
+        let base: CGFloat = idlePulse ? 0.18 : 0.06
+        let factor = (1.0 - dist * 0.6) * base
+        return minBarHeight + factor * (maxBarHeight - minBarHeight)
+    }
+
+    private func barLevel(at index: Int) -> Float {
+        guard !levels.isEmpty else { return 0 }
+        let offset = levels.count - barCount + index
+        guard offset >= 0 else { return 0 }
+        return levels[offset]
+    }
+}
+
+#Preview("Idle") {
+    AudioWaveformView(levels: [], barCount: 35)
+        .padding()
+        .background(Theme.Colors.bgDeep)
+}
+
+#Preview("Active") {
+    let fakeLevels: [Float] = (0..<40).map { _ in Float.random(in: 0.1...0.9) }
+    AudioWaveformView(levels: fakeLevels, barCount: 35)
+        .padding()
+        .background(Theme.Colors.bgDeep)
+}

--- a/Murmur/Components/RecordingStateView.swift
+++ b/Murmur/Components/RecordingStateView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Recording state overlay — minimal wave line at top, floating transcript.
+/// No backdrop, content stays visible. Reactive sine wave driven by real audio input.
+struct RecordingStateView: View {
+    let transcript: String
+    let audioLevels: [Float]
+
+    private var avgLevel: Float {
+        guard !audioLevels.isEmpty else { return 0 }
+        let recent = audioLevels.suffix(8)
+        return recent.reduce(0, +) / Float(recent.count)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Reactive wave line at top
+            GeometryReader { geo in
+                let w = geo.size.width
+                let amplitude = CGFloat(avgLevel) * 30
+
+                Path { path in
+                    let steps = 60
+                    for i in 0...steps {
+                        let x = w * CGFloat(i) / CGFloat(steps)
+                        let bufIdx = Int(Float(i) / Float(steps) * Float(max(audioLevels.count - 1, 1)))
+                        let localLevel = bufIdx < audioLevels.count ? CGFloat(audioLevels[bufIdx]) : 0
+                        let y: CGFloat = 25 + sin(CGFloat(i) * .pi / 8) * amplitude * localLevel
+
+                        if i == 0 {
+                            path.move(to: CGPoint(x: x, y: y))
+                        } else {
+                            path.addLine(to: CGPoint(x: x, y: y))
+                        }
+                    }
+                }
+                .stroke(
+                    LinearGradient(
+                        colors: [
+                            Theme.Colors.accentPurple.opacity(0.3),
+                            Theme.Colors.accentPurple,
+                            Theme.Colors.accentPurpleLight,
+                            Theme.Colors.accentPurple,
+                            Theme.Colors.accentPurple.opacity(0.3)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    lineWidth: 2
+                )
+            }
+            .frame(height: 50)
+            .padding(.top, 12)
+            .padding(.horizontal, 16)
+            .animation(.easeOut(duration: 0.08), value: audioLevels.last ?? 0)
+
+            Spacer()
+
+            // Floating transcript — no container
+            if !transcript.isEmpty {
+                Text(transcript)
+                    .font(.system(.body, design: .default, weight: .regular))
+                    .foregroundStyle(Theme.Colors.textPrimary.opacity(0.9))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+                    .lineLimit(8)
+                    .padding(.horizontal, Theme.Spacing.screenPadding + 8)
+                    .animation(.easeOut(duration: 0.15), value: transcript)
+            } else {
+                Text("Listening...")
+                    .font(.system(.body, design: .default, weight: .regular))
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+
+            Spacer()
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+#Preview("Minimal — Empty") {
+    ZStack {
+        Theme.Colors.bgDeep.ignoresSafeArea()
+        RecordingStateView(transcript: "", audioLevels: [])
+    }
+}
+
+#Preview("Minimal — Active") {
+    let fakeLevels: [Float] = (0..<50).map { _ in Float.random(in: 0.1...0.8) }
+    ZStack {
+        Theme.Colors.bgDeep.ignoresSafeArea()
+        RecordingStateView(
+            transcript: "I need to pick up groceries tomorrow and call the dentist",
+            audioLevels: fakeLevels
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- New `AudioWaveformView` — minimal animated wave line driven by real microphone audio levels
- New `RecordingStateView` — unified recording overlay shown during voice capture
- `AppleSpeechTranscriber` now exposes audio level metering for visual feedback
- `ConversationState` wired to pass audio levels through the recording → processing flow

## Thinking
The recording state needed visual feedback that something is actually happening. Rather than a generic pulsing animation, this uses real audio input levels to drive a wave line — so you see your voice reflected in the UI. Kept it minimal: a single animated line, no chrome.

## Test plan
- [ ] Tap mic, speak — wave line responds to voice volume
- [ ] Stop recording — wave transitions to processing state
- [ ] Silent room — wave shows minimal idle animation
- [ ] Verify ScrollView scrolling still works with new overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)