### PR TITLE
feat: surface AI briefing message above focus strip

### DIFF
--- a/Murmur/Services/AppState.swift
+++ b/Murmur/Services/AppState.swift
@@ -168,7 +168,7 @@ final class AppState {
         let items = focusEntries.prefix(3).map { FocusItem(id: $0.entry.shortID, reason: $0.reason) }
         let message = items.isEmpty
             ? "All clear — nothing pressing today."
-            : "\(Greeting.current). Focus on these things today."
+            : "Focus on these things today."
         return DailyFocus(items: items, message: message)
     }
 

--- a/Murmur/Services/ConversationState.swift
+++ b/Murmur/Services/ConversationState.swift
@@ -184,7 +184,11 @@ final class ConversationState {
 
         Task { @MainActor in
             let liveText = await pipeline.currentTranscript
-            if liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            // Fall back to the last stream transcript if the pipeline transcript is empty
+            let finalText = liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? currentTranscript
+                : liveText
+            if finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 await pipeline.cancelRecording()
                 inputState = .idle
                 displayTranscript = nil
@@ -192,16 +196,16 @@ final class ConversationState {
                 return
             }
             // Update with final transcript
-            displayTranscript = liveText
+            displayTranscript = finalText
 
             await pipeline.cancelRecording()
 
             // Replace processing status with user input, then submit
             removeStatusItem()
-            threadItems.append(.userInput(text: liveText, isCollapsed: true))
+            threadItems.append(.userInput(text: finalText, isCollapsed: true))
 
             submitDirect(
-                text: liveText,
+                text: finalText,
                 generation: gen,
                 entries: entries,
                 modelContext: modelContext,

--- a/Murmur/Views/Home/HomeView.swift
+++ b/Murmur/Views/Home/HomeView.swift
@@ -237,8 +237,7 @@ private struct FocusContainerView: View {
     }
 
     private var showStrip: Bool {
-        if let focus = dailyFocus, !focus.items.isEmpty { return true }
-        return false
+        dailyFocus != nil
     }
 
     var body: some View {
@@ -254,7 +253,7 @@ private struct FocusContainerView: View {
                     )
 
                 // Cards: overlay on top, same space
-                if let focus = dailyFocus, !focus.items.isEmpty {
+                if let focus = dailyFocus {
                     FocusStripView(
                         dailyFocus: focus,
                         allEntries: allEntries,
@@ -294,23 +293,23 @@ private struct FocusStripView: View {
 
     var body: some View {
         let items = resolvedItems
-        if !items.isEmpty {
-            VStack(spacing: 12) {
-                // Greeting + briefing
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(Greeting.current + ".")
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(Theme.Colors.textPrimary)
+        VStack(spacing: 12) {
+            // Greeting + briefing — always shown when focus is available
+            VStack(alignment: .leading, spacing: 4) {
+                Text(Greeting.current + ".")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Theme.Colors.textPrimary)
 
-                    Text(dailyFocus.message)
-                        .font(Theme.Typography.caption)
-                        .foregroundStyle(Theme.Colors.textSecondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .opacity(messageVisible ? 1 : 0)
-                .offset(y: messageVisible ? 0 : 6)
+                Text(dailyFocus.message)
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .opacity(messageVisible ? 1 : 0)
+            .offset(y: messageVisible ? 0 : 6)
 
-                // Focus cards — stagger in one at a time
+            // Focus cards — stagger in one at a time, only when there are items
+            if !items.isEmpty {
                 VStack(spacing: 10) {
                     ForEach(Array(items.enumerated()), id: \.element.entry.id) { index, item in
                         if index < visibleCardCount {
@@ -334,10 +333,10 @@ private struct FocusStripView: View {
                     }
                 }
             }
-            .padding(.vertical, 8)
-            .padding(.horizontal, Theme.Spacing.screenPadding)
-            .onAppear { staggerIn(count: items.count) }
         }
+        .padding(.vertical, 8)
+        .padding(.horizontal, Theme.Spacing.screenPadding)
+        .onAppear { staggerIn(count: items.count) }
     }
 
     private func staggerIn(count: Int) {

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,7 +6,7 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Habit check-off UX fixes + home screen polish.
+AI briefing message surfaced above focus strip (#74).
 
 ## Recent decisions
 
@@ -21,6 +21,8 @@ Habit check-off UX fixes + home screen polish.
 - **appliesToday gates focus strip and circle button** — weekday habits are now excluded from the focus strip on weekends and the check-off circle is hidden. Semantically correct: no point surfacing a habit you can't check off today.
 - **Category color remapping** — differentiated colors per category (todo=purple, reminder=yellow, idea=orange, habit=green, note=slate, thought=blue, question=fuchsia, list=teal). Previous mapping had duplicates (reminder=yellow, idea=yellow; thought=blue, habit=blue).
 - **Post-onboarding card hints** — "Swipe to act · Tap to edit" tooltip appears at bottom after onboarding completes. Auto-dismisses after 4s, tappable to dismiss early.
+- **Briefing message always surfaces** — `FocusStripView` previously hid the entire section when items were empty. Now the greeting+message always renders when `dailyFocus != nil`; focus cards are conditional inside it.
+- **Greeting not doubled** — deterministic fallback was prepending `Greeting.current` to the message string, which the view also renders as a bold header. Removed from the fallback message so the LLM and deterministic paths are consistent.
 
 ## Open questions
 


### PR DESCRIPTION
## Thinking

The focus strip had a structural bug: the AI briefing message was trapped inside a guard that required focus items to exist. When the LLM (or deterministic fallback) returns zero items — "All clear — nothing pressing today." — the entire section disappeared. The message, which is the most human part of the feature, was the first thing to vanish when there was nothing to focus on.

The fix is simple in concept but requires restructuring the render condition: the greeting+message should always appear when a `DailyFocus` exists, regardless of whether there are cards below it. Cards are now a conditional sub-section inside the strip.

A second bug was also present: the deterministic fallback was writing `"\(Greeting.current). Focus on these things today."` as the message, while the view renders `Greeting.current + "."` as a bold header. This caused the greeting to appear twice. The LLM prompt correctly produces messages without a greeting (e.g. "Busy Monday — tackle these first.") — the fallback just wasn't consistent with that contract. Removed the greeting from the fallback message.

The `ConversationState` change is a pre-existing fix (fallback to stream transcript when the pipeline returns empty) that was sitting uncommitted.

## Summary

- `FocusContainerView.showStrip` now triggers on `dailyFocus != nil` instead of requiring non-empty items
- `FocusStripView` restructured: greeting+message always render, cards are conditional on `!items.isEmpty`
- Deterministic focus fallback message no longer prefixes the greeting — consistent with LLM behavior
- ConversationState: use `currentTranscript` as fallback when pipeline transcript is empty on stop

## State changes

Updated focus and recent decisions in STATE.md. No new open questions. No canon candidates from this change.

## Related

Closes #74

## Test plan

- [ ] On home with focus items: "Good afternoon." header + short message + cards below it
- [ ] On home with no focus items: "Good afternoon." header + "All clear — nothing pressing today." with no cards
- [ ] Regenerate daily focus (dev mode) — message animates in before cards stagger
- [ ] LLM-generated message (when available): no double greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)