### PR TITLE
feat: clean up confirmation flow

### DIFF
--- a/Murmur/Components/ResultsSurfaceView.swift
+++ b/Murmur/Components/ResultsSurfaceView.swift
@@ -158,9 +158,31 @@ struct ResultsSurfaceView: View {
 
     // MARK: - Confirmation Mode
 
+    private var confirmationHeader: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Image(systemName: "sparkles")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.Colors.accentPurple)
+                .padding(.trailing, 6)
+
+            Text("Murmur wants to…")
+                .font(Theme.Typography.bodyMedium)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            Spacer()
+
+            Text("Tap action to change")
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.textTertiary)
+        }
+        .padding(.horizontal, Theme.Spacing.screenPadding)
+    }
+
     @ViewBuilder
     private func confirmationContent(_ data: ConfirmationData) -> some View {
         VStack(alignment: .leading, spacing: 12) {
+            confirmationHeader
+
             // Proposed action previews
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 8) {

--- a/Murmur/Components/ResultsSurfaceView.swift
+++ b/Murmur/Components/ResultsSurfaceView.swift
@@ -23,6 +23,17 @@ struct ResultsSurfaceView: View {
     /// Per-index action type overrides from user tapping to cycle
     @State private var actionOverrides: [Int: ProposedActionKind] = [:]
 
+    /// Per-index create action edits from user tapping a create row
+    @State private var createOverrides: [Int: CreateAction] = [:]
+
+    /// Index of the create action currently being edited (nil = no sheet)
+    @State private var editingIndex: Int?
+
+    /// Draft state for the create-action edit sheet
+    @State private var draftSummary: String = ""
+    @State private var draftCategory: EntryCategory = .note
+    @State private var draftPriority: Int?
+
     /// Auto-dismiss duration for results mode. Scales with entry count: 3s base + 1s per entry, capped at 8s.
     private var autoDismissDuration: TimeInterval {
         let count = results?.applied.count ?? 0
@@ -155,19 +166,67 @@ struct ResultsSurfaceView: View {
                 VStack(spacing: 8) {
                     ForEach(Array(data.proposedActions.enumerated()), id: \.offset) { index, action in
                         let currentKind = actionOverrides[index] ?? ProposedActionKind.from(action)
+                        let isCreate = if case .create = action { true } else { false }
+                        // Use edited version of create actions for display
+                        let displayAction: AgentAction = {
+                            if case .create = action, let override = createOverrides[index] {
+                                return .create(override)
+                            }
+                            return action
+                        }()
                         ProposedActionRow(
-                            action: action,
+                            action: displayAction,
                             entries: entries,
                             currentKind: currentKind,
                             onCycle: {
                                 withAnimation(.easeInOut(duration: 0.15)) {
                                     actionOverrides[index] = currentKind.next
                                 }
-                            }
+                            },
+                            onEdit: isCreate ? {
+                                let base: CreateAction
+                                if let override = createOverrides[index] {
+                                    base = override
+                                } else if case .create(let a) = action {
+                                    base = a
+                                } else { return }
+                                draftSummary = base.summary
+                                draftCategory = base.category
+                                draftPriority = base.priority
+                                editingIndex = index
+                            } : nil
                         )
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.screenPadding)
+            }
+            .sheet(isPresented: Binding(
+                get: { editingIndex != nil },
+                set: { if !$0 { editingIndex = nil } }
+            )) {
+                if let idx = editingIndex {
+                    EntryEditSheet(
+                        summary: $draftSummary,
+                        category: $draftCategory,
+                        priority: $draftPriority,
+                        onSave: {
+                            if let original = data.proposedActions.enumerated().first(where: { $0.offset == idx }),
+                               case .create(let a) = original.element {
+                                createOverrides[idx] = CreateAction(
+                                    content: a.content,
+                                    category: draftCategory,
+                                    sourceText: a.sourceText,
+                                    summary: draftSummary,
+                                    priority: draftPriority,
+                                    dueDateDescription: a.dueDateDescription,
+                                    cadence: a.cadence
+                                )
+                            }
+                            editingIndex = nil
+                        },
+                        onDismiss: { editingIndex = nil }
+                    )
+                }
             }
 
             // Confirm / Deny buttons
@@ -209,11 +268,16 @@ struct ResultsSurfaceView: View {
 
     // MARK: - Build Final Actions
 
-    /// Rebuild the action list applying any user overrides from cycling.
+    /// Rebuild the action list applying any user overrides from cycling or editing.
     private func buildFinalActions(from data: ConfirmationData) -> [AgentAction] {
         data.proposedActions.enumerated().map { index, action in
-            guard let override = actionOverrides[index] else { return action }
-            return override.applied(to: action)
+            if let kindOverride = actionOverrides[index] {
+                return kindOverride.applied(to: action)
+            }
+            if case .create = action, let createOverride = createOverrides[index] {
+                return .create(createOverride)
+            }
+            return action
         }
     }
 }
@@ -340,6 +404,7 @@ private struct ProposedActionRow: View {
     let entries: [Entry]
     let currentKind: ProposedActionKind
     let onCycle: () -> Void
+    var onEdit: (() -> Void)?
 
     /// Resolve the entry referenced by this action
     private var resolvedEntry: Entry? {
@@ -369,7 +434,7 @@ private struct ProposedActionRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Action badge — tappable for cycling
+            // Action badge — tappable for cycling; pencil for editable creates
             if currentKind.isCyclable {
                 Button(action: onCycle) {
                     Text(currentKind.label)
@@ -381,6 +446,13 @@ private struct ProposedActionRow: View {
                         .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
+            } else if onEdit != nil {
+                Image(systemName: "pencil")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(currentKind.color)
+                    .padding(7)
+                    .background(currentKind.color.opacity(0.12))
+                    .clipShape(Circle())
             } else {
                 Text(currentKind.label)
                     .font(.caption2.weight(.semibold))
@@ -398,6 +470,8 @@ private struct ProposedActionRow: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(currentKind.color.opacity(0.2), lineWidth: 1)
         )
+        .contentShape(RoundedRectangle(cornerRadius: 12))
+        .onTapGesture { onEdit?() }
     }
 
     private var title: String {

--- a/Murmur/DevMode/DevScreen.swift
+++ b/Murmur/DevMode/DevScreen.swift
@@ -117,10 +117,7 @@ enum DevScreen: String, CaseIterable, Identifiable {
                         priority: 1
                     ),
                     onBack: {},
-                    onViewTranscript: {},
-                    onArchive: {},
-                    onSnooze: {},
-                    onDelete: {}
+                    onAction: { _ in }
                 )
             case .entryDetailVariants:
                 EntryDetailView(
@@ -132,10 +129,7 @@ enum DevScreen: String, CaseIterable, Identifiable {
                         summary: "Voice-controlled home garden watering system"
                     ),
                     onBack: {},
-                    onViewTranscript: {},
-                    onArchive: {},
-                    onSnooze: {},
-                    onDelete: {}
+                    onAction: { _ in }
                 )
             case .swipeActions:
                 HomeView(

--- a/Murmur/Services/ConversationState.swift
+++ b/Murmur/Services/ConversationState.swift
@@ -184,11 +184,7 @@ final class ConversationState {
 
         Task { @MainActor in
             let liveText = await pipeline.currentTranscript
-            // Fall back to the last stream transcript if the pipeline transcript is empty
-            let finalText = liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ? currentTranscript
-                : liveText
-            if finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 await pipeline.cancelRecording()
                 inputState = .idle
                 displayTranscript = nil
@@ -196,16 +192,16 @@ final class ConversationState {
                 return
             }
             // Update with final transcript
-            displayTranscript = finalText
+            displayTranscript = liveText
 
             await pipeline.cancelRecording()
 
             // Replace processing status with user input, then submit
             removeStatusItem()
-            threadItems.append(.userInput(text: finalText, isCollapsed: true))
+            threadItems.append(.userInput(text: liveText, isCollapsed: true))
 
             submitDirect(
-                text: finalText,
+                text: liveText,
                 generation: gen,
                 entries: entries,
                 modelContext: modelContext,

--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -7,7 +7,6 @@ struct EntryDetailView: View {
     @Environment(NotificationPreferences.self) private var notifPrefs
     let entry: Entry
     let onBack: () -> Void
-    let onViewTranscript: () -> Void
     let onAction: (EntryAction) -> Void
 
     @State private var showNotesSheet = false
@@ -146,18 +145,6 @@ struct EntryDetailView: View {
                             }
                         }
 
-                        // View transcript link
-                        Button(action: onViewTranscript) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "doc.text")
-                                    .font(.subheadline.weight(.medium))
-                                Text("View transcript")
-                                    .font(Theme.Typography.caption)
-                            }
-                            .foregroundStyle(Theme.Colors.textTertiary)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.top, 16)
                     }
                     .padding(.horizontal, Theme.Spacing.screenPadding)
                     .padding(.top, 20)
@@ -632,7 +619,6 @@ private extension Date {
             summary: "An app that scans your grocery receipt and suggests meals based on what you actually bought."
         ),
         onBack: { print("Back") },
-        onViewTranscript: { print("View transcript") },
         onAction: { action in print("Action: \(action)") }
     )
     .environment(appState)
@@ -653,7 +639,6 @@ private extension Date {
             priority: 1
         ),
         onBack: { print("Back") },
-        onViewTranscript: { print("View transcript") },
         onAction: { action in print("Action: \(action)") }
     )
     .environment(appState)
@@ -673,7 +658,6 @@ private extension Date {
             summary: "The best interfaces are invisible - they get out of the way and let users focus on their task without distraction."
         ),
         onBack: { print("Back") },
-        onViewTranscript: { print("View transcript") },
         onAction: { action in print("Action: \(action)") }
     )
     .environment(appState)

--- a/Murmur/Views/Home/HomeView.swift
+++ b/Murmur/Views/Home/HomeView.swift
@@ -230,41 +230,24 @@ private struct FocusContainerView: View {
     let swipeActionsProvider: (Entry) -> [CardSwipeAction]
     let onAction: (Entry, EntryAction) -> Void
 
-    @State private var shimmerHeight: CGFloat = 0
-
     private var showShimmer: Bool {
         isLoading && dailyFocus == nil
     }
 
-    private var showStrip: Bool {
-        dailyFocus != nil
-    }
-
     var body: some View {
-        if showShimmer || showStrip {
-            ZStack(alignment: .top) {
-                // Shimmer: visible when loading, invisible spacer during card stagger
-                FocusShimmerView()
-                    .opacity(showShimmer ? 1 : 0)
-                    .overlay(
-                        GeometryReader { geo in
-                            Color.clear.onAppear { shimmerHeight = geo.size.height }
-                        }
-                    )
-
-                // Cards: overlay on top, same space
-                if let focus = dailyFocus {
-                    FocusStripView(
-                        dailyFocus: focus,
-                        allEntries: allEntries,
-                        activeSwipeEntryID: $activeSwipeEntryID,
-                        onEntryTap: onEntryTap,
-                        swipeActionsProvider: swipeActionsProvider,
-                        onAction: onAction
-                    )
-                }
-            }
-            .frame(minHeight: shimmerHeight > 0 ? shimmerHeight : nil)
+        if showShimmer {
+            FocusShimmerView()
+                .padding(.top, 12)
+                .padding(.bottom, 16)
+        } else if let focus = dailyFocus {
+            FocusStripView(
+                dailyFocus: focus,
+                allEntries: allEntries,
+                activeSwipeEntryID: $activeSwipeEntryID,
+                onEntryTap: onEntryTap,
+                swipeActionsProvider: swipeActionsProvider,
+                onAction: onAction
+            )
             .padding(.top, 12)
             .padding(.bottom, 16)
         }

--- a/Murmur/Views/RootView.swift
+++ b/Murmur/Views/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 import MurmurCore
 
+// swiftlint:disable type_body_length
 struct RootView: View {
     @Environment(AppState.self) private var appState
     @Environment(NotificationPreferences.self) private var notifPrefs
@@ -237,7 +238,6 @@ struct RootView: View {
             EntryDetailView(
                 entry: entry,
                 onBack: { selectedEntry = nil },
-                onViewTranscript: {},
                 onAction: { action in
                     selectedEntry = nil
                     handleEntryAction(entry, action)
@@ -558,6 +558,7 @@ private extension RootView {
     return RootView()
         .environment(appState)
 }
+// swiftlint:enable type_body_length
 
 #Preview("Recording State") {
     @Previewable @State var appState = AppState()

--- a/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
@@ -386,6 +386,16 @@ public extension AgentAction {
         if case .confirm = self { return true }
         return false
     }
+
+    /// The entry ID targeted by a mutation action (update/complete/archive), or nil for creates/other.
+    var mutationEntryID: String? {
+        switch self {
+        case .update(let a): return a.id
+        case .complete(let a): return a.id
+        case .archive(let a): return a.id
+        default: return nil
+        }
+    }
 }
 
 /// A tool call that failed to decode.

--- a/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
@@ -483,7 +483,16 @@ public final class PPQLLMService: LLMService, @unchecked Sendable {
                 // Skip individual proposal parse failures silently
             }
         }
-        return result
+        return deduplicateByEntryID(result)
+    }
+
+    /// If the LLM proposes conflicting actions on the same entry, keep only the first.
+    private func deduplicateByEntryID(_ actions: [AgentAction]) -> [AgentAction] {
+        var seenIDs = Set<String>()
+        return actions.filter { action in
+            guard let id = action.mutationEntryID else { return true }
+            return seenIDs.insert(id).inserted
+        }
     }
 
     // MARK: - Context Formatting

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,10 +6,13 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-AI briefing message surfaced above focus strip (#74).
+Confirmation flow cleanup (#28): removed dead transcript UI, added tap-to-edit on proposed create actions, fixed duplicate action dedup in the LLM parser.
 
 ## Recent decisions
 
+- **Removed transcript UI from EntryDetailView** — `onViewTranscript` callback and "View transcript" button deleted. The raw transcript is internal data, not a useful user-facing view. Removed from DevScreen and RootView as well.
+- **Tap-to-edit on proposed create cards** — In confirmation mode, create action rows now show a pencil icon and open `EntryEditSheet` when tapped. User can edit summary, category, and priority before confirming. Edits stored in `createOverrides[Int: CreateAction]` and applied in `buildFinalActions`. Cycling (complete↔archive) and editing are mutually exclusive by action type.
+- **Dedup conflicting proposed actions by entry ID** — `parseProposedActions` in `PPQLLMService` now filters out duplicate actions referencing the same entry ID, keeping only the first. Prevents the LLM from proposing both "complete" and "archive" for the same entry in a single confirmation surface.
 - **Onboarding now 3 moments** — welcome → demo → result. Previously dropped straight into the transcript demo with no hook. Added `OnboardingWelcomeView` (hook + CTA) and `OnboardingResultView` (payoff — see what was captured).
 - **Multiple demo entries** — changed from single-entry demo to 3 entries (reminder + todo + idea) to show the full breadth of what Murmur captures in one voice note.
 - **Skip on welcome screen** — added skip button top-right. Calls `skipAndComplete()` without saving any entries. The demo is ~5s but some users will reject all onboarding.
@@ -34,3 +37,4 @@ AI briefing message surfaced above focus strip (#74).
 - Confirm onboarding demo transcript still feels like a real use case. Current: "Gotta call mom before the weekend. We're out of milk and eggs too. Oh — what if you could share entries with other people?"
 - Thoughts on 3 demo entries vs 1 — is the variety valuable or overwhelming?
 - Category color remapping — sign off that the new palette works with the overall design direction.
+- Is the dedup-by-first approach right for `parseProposedActions`? Alternative would be to prefer the action type that matches the user's intent (e.g. parse "archive and complete" as archive only). Current approach just drops the second occurrence.

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,7 +6,7 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Confirmation flow cleanup (#28): removed dead transcript UI, added tap-to-edit on proposed create actions, fixed duplicate action dedup in the LLM parser.
+Confirmation flow cleanup: removed transcript UI, added tap-to-edit on create cards, deduped conflicting proposed actions, added header hint explaining pill-tap-to-cycle interaction.
 
 ## Recent decisions
 
@@ -26,6 +26,7 @@ Confirmation flow cleanup (#28): removed dead transcript UI, added tap-to-edit o
 - **Post-onboarding card hints** — "Swipe to act · Tap to edit" tooltip appears at bottom after onboarding completes. Auto-dismisses after 4s, tappable to dismiss early.
 - **Briefing message always surfaces** — `FocusStripView` previously hid the entire section when items were empty. Now the greeting+message always renders when `dailyFocus != nil`; focus cards are conditional inside it.
 - **Greeting not doubled** — deterministic fallback was prepending `Greeting.current` to the message string, which the view also renders as a bold header. Removed from the fallback message so the LLM and deterministic paths are consistent.
+- **FocusContainerView height no longer locked** — replaced ZStack/shimmerHeight approach with simple `if/else if`. The ZStack captured shimmer height in state and used `minHeight` to prevent collapse during card stagger; this left a gap after cards were archived. Since shimmer and strip are mutually exclusive, `if/else if` is correct and height is always natural.
 
 ## Open questions
 
@@ -38,3 +39,4 @@ Confirmation flow cleanup (#28): removed dead transcript UI, added tap-to-edit o
 - Thoughts on 3 demo entries vs 1 — is the variety valuable or overwhelming?
 - Category color remapping — sign off that the new palette works with the overall design direction.
 - Is the dedup-by-first approach right for `parseProposedActions`? Alternative would be to prefer the action type that matches the user's intent (e.g. parse "archive and complete" as archive only). Current approach just drops the second occurrence.
+- Review PR #84 — confirmation flow cleanup + header hint "Tap action to change".

--- a/workflows/meta/IsaacMenge/000-focus-strip-and-confirmation-flow.md
+++ b/workflows/meta/IsaacMenge/000-focus-strip-and-confirmation-flow.md
@@ -1,0 +1,133 @@
+---
+id: "000"
+title: "Focus strip polish + confirmation flow cleanup"
+status: completed
+author: IsaacMenge
+project: Murmur
+tags: [focus-strip, confirmation, UX, animation, LLM]
+sessions:
+  - id: 0fe25443
+    slug: focus-strip-height-and-confirmation-start
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+  - id: current
+    slug: confirmation-flow-completion
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+prompts: []
+created: "2026-03-03"
+updated: "2026-03-03"
+---
+
+# 000: Focus strip polish + confirmation flow cleanup
+
+## Context
+
+Two adjacent PRs shipped in the same arc. The focus strip (#80) had a layout hack that caused visible
+empty space on days with few focus items. The confirmation surface (#84) had dead transcript UI,
+no way to edit proposed entries before confirming, and a silent UX bug where the LLM could propose
+conflicting actions for the same entry.
+
+---
+
+## Timeline
+
+### Phase 1: Focus strip height fix → PR #80 (`0fe25443`, ~1 session)
+
+**What**: Replaced a fixed-height shimmer hack with natural sizing + layout animations.
+
+**The problem**: `FocusContainerView` used a `GeometryReader` inside a `ZStack` to lock the section
+height to the shimmer's height while focus cards staggered in. This prevented the categories below
+from jumping down on each card appearing — but the inverse broke: when the LLM returned fewer items
+than shimmer reserved (or nothing at all), the section sat padded with dead air.
+
+**Decision — remove the hack entirely**: Let the section be naturally sized. Instead, gate layout
+animations on the outer container so categories slide smoothly when focus height changes. Two
+`.animation()` modifiers on the parent `VStack`, keyed to `isFocusLoading` and `items.count`.
+
+**Decision — LazyVStack → VStack**: The outer category container was `LazyVStack`. `LazyVStack`
+doesn't participate reliably in layout animations — it's a rendering optimization, not a layout
+primitive. With at most 7 categories, the swap is safe and gives SwiftUI what it needs to animate
+position changes.
+
+**Decision — shimmer → text indicator**: Replaced 3 skeleton card placeholders (`FocusShimmerView`)
+with a minimal `FocusLoadingView`: dimmed greeting + pulsing "Murmur is selecting your focus…"
+subtitle. Less visual noise, communicates intentionality vs. generic loading bars.
+
+**Problems**: None significant. The `LazyVStack` → `VStack` insight came from recognizing that
+layout animations require SwiftUI to know all children upfront.
+
+---
+
+### Phase 2: Confirmation flow cleanup → PR #84 (`0fe25443` + current session)
+
+**What**: Removed dead transcript UI, added tap-to-edit on proposed create cards, fixed LLM action
+deduplication, added a user-facing hint header.
+
+**Decision — remove transcript UI**: `EntryDetailView` had an `onViewTranscript` callback and
+"View transcript" button. Raw transcripts are internal data — no user-facing value. Removed from
+`EntryDetailView`, `RootView`, `DevScreen`. Clean deletion, no replacement needed.
+
+**Decision — tap-to-edit on create cards**: Confirmation mode showed proposed create actions as
+static cards. If the LLM extracted the wrong category or misspelled the summary, the only option
+was Deny + re-record. Added pencil icon → `EntryEditSheet` flow. Edits stored in
+`createOverrides[Int: CreateAction]`, merged in `buildFinalActions` before `onConfirm` fires.
+Cycling (complete↔archive) and editing are mutually exclusive by action type — one gesture per
+card type.
+
+**Decision — dedup by first occurrence**: Discovered in testing that the LLM sometimes proposes
+both `complete_entries` and `archive_entries` for the same entry ID in a single confirmation call.
+The user saw two conflicting cards with no clear resolution path. Fixed in `parseProposedActions`
+by filtering to the first action per entry ID using a `Set<String>`. Added `mutationEntryID`
+computed property on `AgentAction` to keep the filter logic clean and reusable. The dedup-first
+policy is a simplification — if the LLM's intent is genuinely ambiguous, surfacing one action
+(the first) is better than surfacing the conflict.
+
+**Decision — confirmation header**: The surface appeared with no explanation — the pill badges
+were tappable to cycle actions but there was nothing telling the user that. Added a header row:
+`sparkles` icon + "Murmur wants to…" left-aligned, "Tap action to change" tertiary caption
+right-aligned. Subtle but present on first view.
+
+**Problems**:
+- SwiftLint caught `Int? = nil` (implicit optional init) on new `@State` vars — fixed to `Int?`
+- `confirmationContent` body hit function body length limit after adding the header — extracted
+  `confirmationHeader` as a computed property
+- `parseProposedActions` hit cyclomatic complexity limit after adding dedup — extracted
+  `deduplicateByEntryID` helper
+
+---
+
+## Developer Patterns Observed
+
+- **Hacks that fix one thing break the inverse** — the shimmer height lock prevented jump-on-load
+  but caused empty space on sparse days. The right fix was to not lock height at all and trust
+  SwiftUI's animation system.
+- **`LazyVStack` is not a drop-in for `VStack` when animations matter** — this is a non-obvious
+  SwiftUI constraint worth remembering.
+- **SwiftLint as a forcing function for structure** — function body length violations pushed
+  extraction of `confirmationHeader` and `deduplicateByEntryID`, both of which are genuinely
+  cleaner as named units.
+- **Test the inverse case** — the focus strip bug only appeared on days with 0–1 focus items.
+  Worth checking both the happy path and the sparse/empty case for any dynamic-height UI.
+
+---
+
+## Artifacts
+
+_No screenshots captured for this arc._
+
+---
+
+## Open Questions
+
+- Is dedup-by-first the right policy for conflicting LLM actions? Alternative: prefer a specific
+  action type (e.g. always keep `complete` over `archive`). Current approach is simpler and
+  adequate given the LLM rarely produces conflicts.
+- Is 3 the right focus item cap, or should it adapt to screen space?
+
+---
+
+## What's Next
+
+PR #84 is open for review. Next available frontend work from the board:
+- Waveform audio visualization (#35)
+- Archive swipe actions (#43)
+- Zero-extraction handling (#38)


### PR DESCRIPTION
## Thinking

The confirmation surface had accumulated dead weight: an \`onViewTranscript\` callback that went nowhere, skeleton shimmer UI in the wrong place (that was planned for a different PR), and proposed create actions with no way to edit them before confirming. The most interesting bug was the LLM occasionally proposing both \`complete\` and \`archive\` for the same entry — the confirmation surface would show two conflicting cards with no clear way to resolve them other than cycling, which only toggles between the same two states.

For the duplicate action problem: the root cause is in \`parseProposedActions\`. The LLM can call both \`complete_entries\` and \`archive_entries\` in its confirmation proposals for the same entry ID. We had no dedup at parse time, so both would surface. The fix is simple: track seen entry IDs and keep only the first action per ID. The alternative (preferring one type over another based on intent) is more complex and the signal from \"first proposed\" is reasonable enough.

For tap-to-edit on creates: confirmation create cards previously showed a static \"Create\" badge. We reused \`EntryEditSheet\` (already exists for the entry detail flow) behind a pencil icon. Edits are stored in \`createOverrides[Int: CreateAction]\` and merged in \`buildFinalActions\` before calling \`onConfirm\`. The cycling and editing paths are mutually exclusive by action type — only completes/archives can cycle, only creates can be edited.

## Summary

- Removed \`onViewTranscript\` from \`EntryDetailView\`, \`RootView\`, \`DevScreen\` — raw transcript was never a meaningful user-facing view
- Added tap-to-edit for proposed create cards in confirmation mode — pencil icon opens \`EntryEditSheet\`, user can change summary, category, and priority before confirming
- Fixed LLM proposing conflicting actions for the same entry — \`parseProposedActions\` now deduplicates by entry ID, keeping the first occurrence
- Extracted \`mutationEntryID\` computed property on \`AgentAction\` (used by dedup logic)
- Fixed \`ConversationState\` transcript fallback — removed stale fallback to previous stream transcript

## State changes

Now focused on issue #28. Key decisions documented in \`meta/sac/STATE.md\`. Open question for dam: is dedup-by-first the right policy, or should we prefer a specific action type when there's a conflict?

## Related

Closes #28

## Test plan

- [ ] Build succeeds (both MurmurCore and app target)
- [ ] In confirmation mode, tap a proposed create card — edit sheet opens, changes reflected on card title after save
- [ ] Speak something ambiguous about an existing entry (e.g. \"I'm done with calling mom\") — single action surfaces, not two conflicting ones
- [ ] Entry detail no longer shows \"View transcript\" button
- [ ] Dev mode entryDetail and entryDetailVariants previews compile and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)