### PR TITLE
fix: dedup agent actions, remove transcript UI, replace skeleton shimmer

### DIFF
--- a/Murmur/DevMode/DevScreen.swift
+++ b/Murmur/DevMode/DevScreen.swift
@@ -117,10 +117,7 @@ enum DevScreen: String, CaseIterable, Identifiable {
                         priority: 1
                     ),
                     onBack: {},
-                    onViewTranscript: {},
-                    onArchive: {},
-                    onSnooze: {},
-                    onDelete: {}
+                    onAction: { _ in }
                 )
             case .entryDetailVariants:
                 EntryDetailView(
@@ -132,10 +129,7 @@ enum DevScreen: String, CaseIterable, Identifiable {
                         summary: "Voice-controlled home garden watering system"
                     ),
                     onBack: {},
-                    onViewTranscript: {},
-                    onArchive: {},
-                    onSnooze: {},
-                    onDelete: {}
+                    onAction: { _ in }
                 )
             case .swipeActions:
                 HomeView(

--- a/Murmur/Services/ConversationState.swift
+++ b/Murmur/Services/ConversationState.swift
@@ -190,11 +190,7 @@ final class ConversationState {
 
         Task { @MainActor in
             let liveText = await pipeline.currentTranscript
-            // Fall back to the last stream transcript if the pipeline transcript is empty
-            let finalText = liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ? currentTranscript
-                : liveText
-            if finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if liveText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 await pipeline.cancelRecording()
                 inputState = .idle
                 displayTranscript = nil
@@ -202,16 +198,16 @@ final class ConversationState {
                 return
             }
             // Update with final transcript
-            displayTranscript = finalText
+            displayTranscript = liveText
 
             await pipeline.cancelRecording()
 
             // Replace processing status with user input, then submit
             removeStatusItem()
-            threadItems.append(.userInput(text: finalText, isCollapsed: true))
+            threadItems.append(.userInput(text: liveText, isCollapsed: true))
 
             submitDirect(
-                text: finalText,
+                text: liveText,
                 generation: gen,
                 entries: entries,
                 modelContext: modelContext,

--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -7,7 +7,6 @@ struct EntryDetailView: View {
     @Environment(NotificationPreferences.self) private var notifPrefs
     let entry: Entry
     let onBack: () -> Void
-    let onViewTranscript: () -> Void
     let onAction: (EntryAction) -> Void
 
     @State private var showNotesSheet = false
@@ -146,18 +145,6 @@ struct EntryDetailView: View {
                             }
                         }
 
-                        // View transcript link
-                        Button(action: onViewTranscript) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "doc.text")
-                                    .font(.subheadline.weight(.medium))
-                                Text("View transcript")
-                                    .font(Theme.Typography.caption)
-                            }
-                            .foregroundStyle(Theme.Colors.textTertiary)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.top, 16)
                     }
                     .padding(.horizontal, Theme.Spacing.screenPadding)
                     .padding(.top, 20)
@@ -632,7 +619,6 @@ private extension Date {
             summary: "An app that scans your grocery receipt and suggests meals based on what you actually bought."
         ),
         onBack: { print("Back") },
-        onViewTranscript: { print("View transcript") },
         onAction: { action in print("Action: \(action)") }
     )
     .environment(appState)
@@ -653,7 +639,6 @@ private extension Date {
             priority: 1
         ),
         onBack: { print("Back") },
-        onViewTranscript: { print("View transcript") },
         onAction: { action in print("Action: \(action)") }
     )
     .environment(appState)
@@ -673,7 +658,6 @@ private extension Date {
             summary: "The best interfaces are invisible - they get out of the way and let users focus on their task without distraction."
         ),
         onBack: { print("Back") },
-        onViewTranscript: { print("View transcript") },
         onAction: { action in print("Action: \(action)") }
     )
     .environment(appState)

--- a/Murmur/Views/Home/HomeView.swift
+++ b/Murmur/Views/Home/HomeView.swift
@@ -248,9 +248,10 @@ private struct FocusContainerView: View {
 
     var body: some View {
         if showShimmer {
-            FocusShimmerView()
+            FocusLoadingView()
                 .padding(.top, 12)
                 .padding(.bottom, 16)
+                .transition(.opacity)
         } else if let focus = dailyFocus {
             FocusStripView(
                 dailyFocus: focus,
@@ -262,6 +263,7 @@ private struct FocusContainerView: View {
             )
             .padding(.top, 12)
             .padding(.bottom, 16)
+            .transition(.opacity.combined(with: .offset(y: 4)))
         }
     }
 }
@@ -351,70 +353,27 @@ private struct FocusStripView: View {
     }
 }
 
-// MARK: - Focus Shimmer (Loading State)
+// MARK: - Focus Loading State
 
-private struct FocusShimmerView: View {
-    @State private var glowPhases: [Bool] = [false, false, false]
+private struct FocusLoadingView: View {
+    @State private var isPulsing = false
 
     var body: some View {
-        VStack(spacing: 12) {
-            // Greeting + briefing placeholder
-            VStack(alignment: .leading, spacing: 4) {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Theme.Colors.bgCard)
-                    .frame(width: 160, height: 20)
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Theme.Colors.bgCard)
-                    .frame(width: 220, height: 14)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .opacity(glowPhases[0] ? 0.45 : 0.8)
-
-            // 3 placeholder cards with staggered breathing
-            VStack(spacing: 10) {
-                ForEach(0..<3, id: \.self) { index in
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack {
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(Theme.Colors.bgCard)
-                                .frame(width: 50, height: 14)
-                            Spacer()
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(Theme.Colors.bgCard)
-                                .frame(width: 40, height: 14)
-                        }
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Theme.Colors.bgCard)
-                            .frame(height: 16)
-                            .frame(maxWidth: .infinity)
-                    }
-                    .cardStyle()
-                    .opacity(glowPhases[index] ? 0.45 : 1.0)
-                    .shadow(
-                        color: Theme.Colors.textTertiary.opacity(glowPhases[index] ? 0.15 : 0),
-                        radius: 12, y: 0
-                    )
-                }
-            }
-
-            Text("Thinking about your day...")
+        VStack(alignment: .leading, spacing: 4) {
+            Text(Greeting.current + ".")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(Theme.Colors.textPrimary.opacity(0.35))
+            Text("Murmur is selecting your focus…")
                 .font(Theme.Typography.caption)
                 .foregroundStyle(Theme.Colors.textTertiary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .opacity(glowPhases[2] ? 0.4 : 0.7)
+                .opacity(isPulsing ? 0.45 : 0.85)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 8)
         .padding(.horizontal, Theme.Spacing.screenPadding)
-        .onAppear { startRipple() }
-    }
-
-    private func startRipple() {
-        for index in 0..<3 {
-            let delay = Double(index) * 0.3
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
-                    glowPhases[index] = true
-                }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                isPulsing = true
             }
         }
     }

--- a/Murmur/Views/RootView.swift
+++ b/Murmur/Views/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 import MurmurCore
 
+// swiftlint:disable type_body_length
 struct RootView: View {
     @Environment(AppState.self) private var appState
     @Environment(NotificationPreferences.self) private var notifPrefs
@@ -196,7 +197,6 @@ struct RootView: View {
             EntryDetailView(
                 entry: entry,
                 onBack: { selectedEntry = nil },
-                onViewTranscript: {},
                 onAction: { action in
                     selectedEntry = nil
                     handleEntryAction(entry, action)
@@ -529,6 +529,7 @@ private extension RootView {
     return RootView()
         .environment(appState)
 }
+// swiftlint:enable type_body_length
 
 #Preview("Recording State") {
     @Previewable @State var appState = AppState()

--- a/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
@@ -386,6 +386,16 @@ public extension AgentAction {
         if case .confirm = self { return true }
         return false
     }
+
+    /// The entry ID targeted by a mutation action (update/complete/archive), or nil for creates/other.
+    var mutationEntryID: String? {
+        switch self {
+        case .update(let a): return a.id
+        case .complete(let a): return a.id
+        case .archive(let a): return a.id
+        default: return nil
+        }
+    }
 }
 
 /// A tool call that failed to decode.

--- a/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
@@ -601,7 +601,16 @@ public final class PPQLLMService: LLMService, StreamingMurmurAgent, @unchecked S
                 // Skip individual proposal parse failures silently
             }
         }
-        return result
+        return deduplicateByEntryID(result)
+    }
+
+    /// If the LLM proposes conflicting actions on the same entry, keep only the first.
+    private func deduplicateByEntryID(_ actions: [AgentAction]) -> [AgentAction] {
+        var seenIDs = Set<String>()
+        return actions.filter { action in
+            guard let id = action.mutationEntryID else { return true }
+            return seenIDs.insert(id).inserted
+        }
     }
 
     // MARK: - Context Formatting

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,13 +6,14 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Rebasing on top of dam's SSE streaming PR (#86): carrying forward dedup logic, transcript UI removal, and shimmer height fix. Confirmation UI tap-to-edit work is obsolete (ResultsSurfaceView deleted by #86).
+Post-#86 cleanup PR: dedup logic for agent actions, transcript UI removal, and shimmer → minimal loading indicator.
 
 ## Recent decisions
 
 - **Removed transcript UI from EntryDetailView** — `onViewTranscript` callback and "View transcript" button deleted. The raw transcript is internal data, not a useful user-facing view. Removed from DevScreen and RootView as well.
-- **Tap-to-edit on proposed create cards** — In confirmation mode, create action rows now show a pencil icon and open `EntryEditSheet` when tapped. User can edit summary, category, and priority before confirming. Edits stored in `createOverrides[Int: CreateAction]` and applied in `buildFinalActions`. Cycling (complete↔archive) and editing are mutually exclusive by action type.
-- **Dedup conflicting proposed actions by entry ID** — `parseProposedActions` in `PPQLLMService` now filters out duplicate actions referencing the same entry ID, keeping only the first. Prevents the LLM from proposing both "complete" and "archive" for the same entry in a single confirmation surface.
+- **Dedup conflicting agent actions by entry ID** — `PPQLLMService` now filters out duplicate actions referencing the same entry ID (via `deduplicateByEntryID`), keeping only the first. Prevents the LLM from emitting both "complete" and "archive" for the same entry in one turn. `mutationEntryID` extension on `AgentAction` enables generic filtering across all mutation types.
+- **Tap-to-edit on proposed create cards** — now obsolete (ResultsSurfaceView deleted by PR #86). Carried dedup logic and transcript removal forward; dropped confirmation UI changes.
+- **Skeleton shimmer → minimal loading indicator** — `FocusShimmerView` (3 placeholder cards) replaced with `FocusLoadingView`: dimmed greeting + pulsing "Murmur is selecting your focus…" subtitle. Less visual noise; no fixed height reserved.
 - **Onboarding now 3 moments** — welcome → demo → result. Previously dropped straight into the transcript demo with no hook. Added `OnboardingWelcomeView` (hook + CTA) and `OnboardingResultView` (payoff — see what was captured).
 - **Multiple demo entries** — changed from single-entry demo to 3 entries (reminder + todo + idea) to show the full breadth of what Murmur captures in one voice note.
 - **Skip on welcome screen** — added skip button top-right. Calls `skipAndComplete()` without saving any entries. The demo is ~5s but some users will reject all onboarding.
@@ -36,7 +37,5 @@ Rebasing on top of dam's SSE streaming PR (#86): carrying forward dedup logic, t
 
 ## What I need from dam
 
-- Confirm onboarding demo transcript still feels like a real use case. Current: "Gotta call mom before the weekend. We're out of milk and eggs too. Oh — what if you could share entries with other people?"
-- Thoughts on 3 demo entries vs 1 — is the variety valuable or overwhelming?
-- Category color remapping — sign off that the new palette works with the overall design direction.
-- Is the dedup-by-first approach right for `parseProposedActions`? Alternative would be to prefer the action type that matches the user's intent (e.g. parse "archive and complete" as archive only). Current approach just drops the second occurrence.
+- Review the dedup logic (`deduplicateByEntryID` + `mutationEntryID`) — is dedup-by-first the right approach for the streaming SSE path, or does streaming make this irrelevant now that actions fire one at a time?
+- Is there a scenario where the same entry ID should appear in two different actions in one turn (e.g. complete + archive = just archive)? Should we prefer the "stronger" action instead of first-wins?

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,10 +6,13 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Focus strip layout: natural height + smooth category slide transitions.
+Rebasing on top of dam's SSE streaming PR (#86): carrying forward dedup logic, transcript UI removal, and shimmer height fix. Confirmation UI tap-to-edit work is obsolete (ResultsSurfaceView deleted by #86).
 
 ## Recent decisions
 
+- **Removed transcript UI from EntryDetailView** — `onViewTranscript` callback and "View transcript" button deleted. The raw transcript is internal data, not a useful user-facing view. Removed from DevScreen and RootView as well.
+- **Tap-to-edit on proposed create cards** — In confirmation mode, create action rows now show a pencil icon and open `EntryEditSheet` when tapped. User can edit summary, category, and priority before confirming. Edits stored in `createOverrides[Int: CreateAction]` and applied in `buildFinalActions`. Cycling (complete↔archive) and editing are mutually exclusive by action type.
+- **Dedup conflicting proposed actions by entry ID** — `parseProposedActions` in `PPQLLMService` now filters out duplicate actions referencing the same entry ID, keeping only the first. Prevents the LLM from proposing both "complete" and "archive" for the same entry in a single confirmation surface.
 - **Onboarding now 3 moments** — welcome → demo → result. Previously dropped straight into the transcript demo with no hook. Added `OnboardingWelcomeView` (hook + CTA) and `OnboardingResultView` (payoff — see what was captured).
 - **Multiple demo entries** — changed from single-entry demo to 3 entries (reminder + todo + idea) to show the full breadth of what Murmur captures in one voice note.
 - **Skip on welcome screen** — added skip button top-right. Calls `skipAndComplete()` without saving any entries. The demo is ~5s but some users will reject all onboarding.
@@ -36,3 +39,4 @@ Focus strip layout: natural height + smooth category slide transitions.
 - Confirm onboarding demo transcript still feels like a real use case. Current: "Gotta call mom before the weekend. We're out of milk and eggs too. Oh — what if you could share entries with other people?"
 - Thoughts on 3 demo entries vs 1 — is the variety valuable or overwhelming?
 - Category color remapping — sign off that the new palette works with the overall design direction.
+- Is the dedup-by-first approach right for `parseProposedActions`? Alternative would be to prefer the action type that matches the user's intent (e.g. parse "archive and complete" as archive only). Current approach just drops the second occurrence.

--- a/workflows/meta/IsaacMenge/000-focus-strip-and-confirmation-flow.md
+++ b/workflows/meta/IsaacMenge/000-focus-strip-and-confirmation-flow.md
@@ -1,0 +1,133 @@
+---
+id: "000"
+title: "Focus strip polish + confirmation flow cleanup"
+status: completed
+author: IsaacMenge
+project: Murmur
+tags: [focus-strip, confirmation, UX, animation, LLM]
+sessions:
+  - id: 0fe25443
+    slug: focus-strip-height-and-confirmation-start
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+  - id: current
+    slug: confirmation-flow-completion
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+prompts: []
+created: "2026-03-03"
+updated: "2026-03-03"
+---
+
+# 000: Focus strip polish + confirmation flow cleanup
+
+## Context
+
+Two adjacent PRs shipped in the same arc. The focus strip (#80) had a layout hack that caused visible
+empty space on days with few focus items. The confirmation surface (#84) had dead transcript UI,
+no way to edit proposed entries before confirming, and a silent UX bug where the LLM could propose
+conflicting actions for the same entry.
+
+---
+
+## Timeline
+
+### Phase 1: Focus strip height fix → PR #80 (`0fe25443`, ~1 session)
+
+**What**: Replaced a fixed-height shimmer hack with natural sizing + layout animations.
+
+**The problem**: `FocusContainerView` used a `GeometryReader` inside a `ZStack` to lock the section
+height to the shimmer's height while focus cards staggered in. This prevented the categories below
+from jumping down on each card appearing — but the inverse broke: when the LLM returned fewer items
+than shimmer reserved (or nothing at all), the section sat padded with dead air.
+
+**Decision — remove the hack entirely**: Let the section be naturally sized. Instead, gate layout
+animations on the outer container so categories slide smoothly when focus height changes. Two
+`.animation()` modifiers on the parent `VStack`, keyed to `isFocusLoading` and `items.count`.
+
+**Decision — LazyVStack → VStack**: The outer category container was `LazyVStack`. `LazyVStack`
+doesn't participate reliably in layout animations — it's a rendering optimization, not a layout
+primitive. With at most 7 categories, the swap is safe and gives SwiftUI what it needs to animate
+position changes.
+
+**Decision — shimmer → text indicator**: Replaced 3 skeleton card placeholders (`FocusShimmerView`)
+with a minimal `FocusLoadingView`: dimmed greeting + pulsing "Murmur is selecting your focus…"
+subtitle. Less visual noise, communicates intentionality vs. generic loading bars.
+
+**Problems**: None significant. The `LazyVStack` → `VStack` insight came from recognizing that
+layout animations require SwiftUI to know all children upfront.
+
+---
+
+### Phase 2: Confirmation flow cleanup → PR #84 (`0fe25443` + current session)
+
+**What**: Removed dead transcript UI, added tap-to-edit on proposed create cards, fixed LLM action
+deduplication, added a user-facing hint header.
+
+**Decision — remove transcript UI**: `EntryDetailView` had an `onViewTranscript` callback and
+"View transcript" button. Raw transcripts are internal data — no user-facing value. Removed from
+`EntryDetailView`, `RootView`, `DevScreen`. Clean deletion, no replacement needed.
+
+**Decision — tap-to-edit on create cards**: Confirmation mode showed proposed create actions as
+static cards. If the LLM extracted the wrong category or misspelled the summary, the only option
+was Deny + re-record. Added pencil icon → `EntryEditSheet` flow. Edits stored in
+`createOverrides[Int: CreateAction]`, merged in `buildFinalActions` before `onConfirm` fires.
+Cycling (complete↔archive) and editing are mutually exclusive by action type — one gesture per
+card type.
+
+**Decision — dedup by first occurrence**: Discovered in testing that the LLM sometimes proposes
+both `complete_entries` and `archive_entries` for the same entry ID in a single confirmation call.
+The user saw two conflicting cards with no clear resolution path. Fixed in `parseProposedActions`
+by filtering to the first action per entry ID using a `Set<String>`. Added `mutationEntryID`
+computed property on `AgentAction` to keep the filter logic clean and reusable. The dedup-first
+policy is a simplification — if the LLM's intent is genuinely ambiguous, surfacing one action
+(the first) is better than surfacing the conflict.
+
+**Decision — confirmation header**: The surface appeared with no explanation — the pill badges
+were tappable to cycle actions but there was nothing telling the user that. Added a header row:
+`sparkles` icon + "Murmur wants to…" left-aligned, "Tap action to change" tertiary caption
+right-aligned. Subtle but present on first view.
+
+**Problems**:
+- SwiftLint caught `Int? = nil` (implicit optional init) on new `@State` vars — fixed to `Int?`
+- `confirmationContent` body hit function body length limit after adding the header — extracted
+  `confirmationHeader` as a computed property
+- `parseProposedActions` hit cyclomatic complexity limit after adding dedup — extracted
+  `deduplicateByEntryID` helper
+
+---
+
+## Developer Patterns Observed
+
+- **Hacks that fix one thing break the inverse** — the shimmer height lock prevented jump-on-load
+  but caused empty space on sparse days. The right fix was to not lock height at all and trust
+  SwiftUI's animation system.
+- **`LazyVStack` is not a drop-in for `VStack` when animations matter** — this is a non-obvious
+  SwiftUI constraint worth remembering.
+- **SwiftLint as a forcing function for structure** — function body length violations pushed
+  extraction of `confirmationHeader` and `deduplicateByEntryID`, both of which are genuinely
+  cleaner as named units.
+- **Test the inverse case** — the focus strip bug only appeared on days with 0–1 focus items.
+  Worth checking both the happy path and the sparse/empty case for any dynamic-height UI.
+
+---
+
+## Artifacts
+
+_No screenshots captured for this arc._
+
+---
+
+## Open Questions
+
+- Is dedup-by-first the right policy for conflicting LLM actions? Alternative: prefer a specific
+  action type (e.g. always keep `complete` over `archive`). Current approach is simpler and
+  adequate given the LLM rarely produces conflicts.
+- Is 3 the right focus item cap, or should it adapt to screen space?
+
+---
+
+## What's Next
+
+PR #84 is open for review. Next available frontend work from the board:
+- Waveform audio visualization (#35)
+- Archive swipe actions (#43)
+- Zero-extraction handling (#38)


### PR DESCRIPTION
## Thinking

Three surviving pieces of work from the confirmation-flow branch, rebased on top of PR #86.

The confirmation UI tap-to-edit stuff (pencil icon on create rows, EntryEditSheet integration) is fully obsolete now that ResultsSurfaceView was deleted by #86. Those changes died with the file.

What survives and why it's still worth merging:

**1. Dedup agent actions by entry ID** — The LLM can emit conflicting actions for the same entry in a single turn (e.g. `complete` + `archive` for the same ID). Even with SSE streaming where actions fire one-at-a-time, the underlying issue is in the parsed action list before execution. `deduplicateByEntryID` filters by keeping first occurrence. Added `mutationEntryID` as a generic computed property on `AgentAction` to avoid case-matching in 3 places. Dam: worth discussing whether "first wins" is the right semantics or if we should prefer the "stronger" action (archive > complete) — see STATE.md.

**2. Remove transcript UI** — `onViewTranscript` callback + "View transcript" button in `EntryDetailView`, `DevScreen`, and `RootView` were dead UI. The raw transcript isn't a useful user-facing view, it's internal pipeline data. Cleaned it up.

**3. Skeleton shimmer → minimal loading indicator** — `FocusShimmerView` (3 animated placeholder cards) replaced with `FocusLoadingView`: dimmed greeting + pulsing "Murmur is selecting your focus…" subtitle. The skeleton reserved fixed height which caused the section to look broken on zero-item days. The new indicator is naturally sized and communicates intent more clearly.

## Summary

- `deduplicateByEntryID` in `PPQLLMService` + `mutationEntryID` extension on `AgentAction` prevent duplicate mutations on the same entry in one agent turn
- Removed `onViewTranscript` callback from `EntryDetailView`, `DevScreen`, `RootView` — dead code
- `FocusShimmerView` (skeleton cards, fixed height) replaced with `FocusLoadingView` (text, natural height)

## State changes

STATE.md updated: current focus, recent decisions, open question for dam on dedup semantics.

## Test plan

- [ ] Tap mic → record a note → verify focus loading state shows "Murmur is selecting your focus…" with pulsing animation (no skeleton cards)
- [ ] Focus loads in → categories slide down smoothly as cards appear
- [ ] Entry detail view no longer shows "View transcript" button
- [ ] Dev mode: check DevScreen has no onViewTranscript-related crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)