### PR TITLE
feat: streaming card arrival animations, toast, and focus UX polish

### DIFF
--- a/Murmur/Components/CategoryBadge.swift
+++ b/Murmur/Components/CategoryBadge.swift
@@ -5,6 +5,7 @@ struct CategoryBadge: View {
     let category: EntryCategory
     let size: BadgeSize
     var showDotGlow: Bool = true
+    var text: String?
 
     enum BadgeSize {
         case small
@@ -33,11 +34,18 @@ struct CategoryBadge: View {
     }
 
     var body: some View {
-        // Category indicator dot with glow
-        Circle()
-            .fill(categoryColor)
-            .frame(width: size.dotSize, height: size.dotSize)
-            .shadow(color: showDotGlow ? categoryColor.opacity(0.5) : .clear, radius: 3, x: 0, y: 0)
+        HStack(spacing: 5) {
+            Circle()
+                .fill(categoryColor)
+                .frame(width: size.dotSize, height: size.dotSize)
+                .shadow(color: showDotGlow ? categoryColor.opacity(0.5) : .clear, radius: 3, x: 0, y: 0)
+
+            if let text {
+                Text(text)
+                    .font(Theme.Typography.badge)
+                    .foregroundStyle(categoryColor)
+            }
+        }
         .padding(size.padding)
         .background(
             Capsule()

--- a/Murmur/Models/Entry.swift
+++ b/Murmur/Models/Entry.swift
@@ -77,6 +77,9 @@ public final class Entry {
     /// When this habit was last checked off (used to determine isDoneForPeriod)
     public var lastHabitCompletionDate: Date?
 
+    /// Full history of habit check-off dates (used to compute streaks)
+    public var habitCompletionDates: [Date] = []
+
     // MARK: - Source metadata
 
     /// Recording length in seconds
@@ -203,6 +206,8 @@ extension Entry {
         case .snoozed: .snoozed
         }
 
+        let streak = category == .habit && currentStreak > 0 ? currentStreak : nil
+
         return AgentContextEntry(
             id: shortID,
             summary: summary,
@@ -211,7 +216,8 @@ extension Entry {
             dueDateDescription: dueDateDescription,
             cadence: cadence,
             status: agentStatus,
-            createdAt: createdAt
+            createdAt: createdAt,
+            currentStreak: streak
         )
     }
 
@@ -267,6 +273,88 @@ extension Entry {
     }
 }
 
+// MARK: - Habit Streaks
+
+extension Entry {
+    /// Number of consecutive periods this habit has been completed up to and including the current period.
+    /// Returns 0 if the streak is broken (a period was skipped).
+    public var currentStreak: Int {
+        guard category == .habit else { return 0 }
+        return computeStreaks().current
+    }
+
+    /// Longest consecutive run ever recorded.
+    public var longestStreak: Int {
+        guard category == .habit else { return 0 }
+        return computeStreaks().longest
+    }
+
+    private func computeStreaks() -> (current: Int, longest: Int) {
+        guard !habitCompletionDates.isEmpty else { return (0, 0) }
+        let calendar = Calendar.current
+        let c = cadence ?? .daily
+
+        // Normalize each completion to its period boundary, deduplicate, sort descending
+        let periods = Array(
+            Set(habitCompletionDates.map { periodStart(for: $0, cadence: c, calendar: calendar) })
+        ).sorted(by: >)
+
+        guard !periods.isEmpty else { return (0, 0) }
+
+        // Group into consecutive runs
+        var runs: [[Date]] = []
+        var run = [periods[0]]
+        for i in 1..<periods.count {
+            let expected = prevPeriodStart(before: periods[i - 1], cadence: c, calendar: calendar)
+            if periods[i] == expected {
+                run.append(periods[i])
+            } else {
+                runs.append(run)
+                run = [periods[i]]
+            }
+        }
+        runs.append(run)
+
+        let longest = runs.map(\.count).max() ?? 0
+
+        // Current streak is alive if the latest period is today or the previous applicable period
+        let today = periodStart(for: Date(), cadence: c, calendar: calendar)
+        let prev = prevPeriodStart(before: today, cadence: c, calendar: calendar)
+        let latestPeriod = runs[0][0]
+        let current = (latestPeriod == today || latestPeriod == prev) ? runs[0].count : 0
+
+        return (current, longest)
+    }
+
+    private func periodStart(for date: Date, cadence: HabitCadence, calendar: Calendar) -> Date {
+        switch cadence {
+        case .daily, .weekdays:
+            return calendar.startOfDay(for: date)
+        case .weekly:
+            return calendar.dateInterval(of: .weekOfYear, for: date)?.start ?? calendar.startOfDay(for: date)
+        case .monthly:
+            return calendar.dateInterval(of: .month, for: date)?.start ?? calendar.startOfDay(for: date)
+        }
+    }
+
+    private func prevPeriodStart(before date: Date, cadence: HabitCadence, calendar: Calendar) -> Date {
+        let period = periodStart(for: date, cadence: cadence, calendar: calendar)
+        switch cadence {
+        case .daily:
+            return calendar.date(byAdding: .day, value: -1, to: period)!
+        case .weekdays:
+            // Monday → Friday (skip weekend)
+            let weekday = calendar.component(.weekday, from: period)
+            let daysBack = weekday == 2 ? 3 : 1
+            return calendar.date(byAdding: .day, value: -daysBack, to: period)!
+        case .weekly:
+            return calendar.date(byAdding: .weekOfYear, value: -1, to: period)!
+        case .monthly:
+            return calendar.date(byAdding: .month, value: -1, to: period)!
+        }
+    }
+}
+
 // MARK: - Entry Actions
 
 enum EntryAction {
@@ -315,7 +403,14 @@ extension Entry {
             save(in: context)
 
         case .checkOffHabit:
-            lastHabitCompletionDate = isCompletedToday ? nil : Date()
+            if isCompletedToday {
+                habitCompletionDates.removeAll { Calendar.current.isDateInToday($0) }
+                lastHabitCompletionDate = nil
+            } else {
+                let now = Date()
+                habitCompletionDates.append(now)
+                lastHabitCompletionDate = now
+            }
             updatedAt = Date()
             save(in: context)
         }

--- a/Murmur/Services/ConversationState.swift
+++ b/Murmur/Services/ConversationState.swift
@@ -9,6 +9,7 @@ import os.log
 
 private let sseLog = Logger(subsystem: "com.gudnuf.murmur", category: "SSE")
 
+// swiftlint:disable type_body_length
 /// Manages conversation thread state, input lifecycle, and agent pipeline interaction.
 /// Lazy-initialized from AppState on first conversation open.
 @Observable
@@ -24,6 +25,9 @@ final class ConversationState {
 
     /// Latest agent response text for the stream overlay. Cleared after animation.
     var agentStreamText: String?
+
+    /// Set once after all cards have been revealed. Observed by RootView to show the confirmation toast.
+    var completionText: String?
 
     /// Entry IDs created or updated in the current agent response.
     /// Views use this to apply arrival glow animation.
@@ -45,6 +49,8 @@ final class ConversationState {
     private var generationCounter: Int = 0
     private var processingTask: Task<Void, Never>?
     private var recordingTask: Task<Void, Never>?
+    private var toastTask: Task<Void, Never>?
+    private var lastRevealTime: Date = .distantPast
     private var conversation: LLMConversation = LLMConversation()
 
     /// Stable ID for the ephemeral status indicator (replaced in-place, not appended)
@@ -264,6 +270,10 @@ final class ConversationState {
         preferences: NotificationPreferences
     ) {
         processingTask?.cancel()
+        toastTask?.cancel()
+        toastTask = nil
+        completionText = nil
+        lastRevealTime = .distantPast
         arrivedEntryIDs.removeAll()
         pendingRevealEntryIDs.removeAll()
 
@@ -354,6 +364,8 @@ final class ConversationState {
                     threadItems.append(.agentText(text: streamedText))
                 }
 
+                scheduleCompletionToast(streamedText: streamedText, applied: allApplied, failures: allFailures)
+
                 let combined = AgentActionExecutor.ExecutionResult(
                     applied: allApplied, failures: allFailures,
                     undo: UndoTransaction(items: allUndoItems), outcomes: allOutcomes
@@ -419,6 +431,10 @@ final class ConversationState {
         generationCounter = 0
         conversation = LLMConversation()
         agentStreamText = nil
+        completionText = nil
+        toastTask?.cancel()
+        toastTask = nil
+        lastRevealTime = .distantPast
         arrivedEntryIDs.removeAll()
         pendingRevealEntryIDs.removeAll()
         displayTranscript = nil
@@ -437,6 +453,8 @@ final class ConversationState {
     func cancelProcessing() {
         processingTask?.cancel()
         processingTask = nil
+        toastTask?.cancel()
+        toastTask = nil
         pendingRevealEntryIDs.removeAll()
         removeStatusItem()
         inputState = .idle
@@ -446,18 +464,21 @@ final class ConversationState {
 
     /// Track which entries just arrived and stagger their reveal.
     /// First entry appears immediately; rest appear with 150ms delays.
+    /// Also updates `lastRevealTime` so the toast can fire after the final card.
     private func trackArrivedEntries(_ applied: [AgentActionExecutor.AppliedAction]) {
         let entries = applied.map { $0.entry }
         guard !entries.isEmpty else { return }
 
-        // Hide all entries initially
         for entry in entries {
             pendingRevealEntryIDs.insert(entry.id)
         }
 
-        // Stagger reveals: first immediately, rest with 150ms gaps
         for (index, entry) in entries.enumerated() {
             let delay = Double(index) * 0.15
+            // Keep `lastRevealTime` pointing at the latest scheduled reveal across all batches.
+            let revealAt = Date().addingTimeInterval(delay)
+            if revealAt > lastRevealTime { lastRevealTime = revealAt }
+
             Task { @MainActor in
                 if delay > 0 {
                     try? await Task.sleep(for: .seconds(delay))
@@ -467,10 +488,33 @@ final class ConversationState {
                     pendingRevealEntryIDs.remove(entry.id)
                     arrivedEntryIDs.insert(entry.id)
                 }
-                // Safety TTL: clear glow after 5s per entry
                 try? await Task.sleep(for: .seconds(5))
                 arrivedEntryIDs.remove(entry.id)
             }
+        }
+    }
+
+    /// Schedule the post-stream confirmation toast. Delay is anchored to the last card reveal time.
+    private func scheduleCompletionToast(
+        streamedText: String,
+        applied: [AgentActionExecutor.AppliedAction],
+        failures: [AgentActionExecutor.ActionFailure]
+    ) {
+        let toastText: String?
+        if !streamedText.isEmpty {
+            toastText = streamedText
+        } else if !applied.isEmpty {
+            toastText = buildActionSummary(applied: applied, failures: failures)
+        } else {
+            toastText = nil
+        }
+        guard let toastText else { return }
+        let toastDelay = max(0, lastRevealTime.timeIntervalSinceNow) + 1.5
+        toastTask?.cancel()
+        toastTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(toastDelay))
+            guard !Task.isCancelled else { return }
+            self?.completionText = toastText
         }
     }
 
@@ -518,6 +562,7 @@ final class ConversationState {
         conversation.truncate(keepingLast: 20)
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Helpers (outside class body for swiftlint type_body_length)
 

--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -117,6 +117,13 @@ struct EntryDetailView: View {
                                 entry.updatedAt = Date()
                                 save()
                             }
+                            if entry.currentStreak > 0 {
+                                HabitStreakRow(
+                                    current: entry.currentStreak,
+                                    longest: entry.longestStreak,
+                                    cadence: entry.cadence ?? .daily
+                                )
+                            }
                         }
 
                         // Divider
@@ -359,6 +366,39 @@ private struct CadencePicker: View {
                     }
                     .buttonStyle(.plain)
                 }
+            }
+        }
+        .padding(.bottom, 24)
+    }
+}
+
+// MARK: - Habit Streak Row
+
+private struct HabitStreakRow: View {
+    let current: Int
+    let longest: Int
+    let cadence: HabitCadence
+
+    private var periodLabel: String {
+        switch cadence {
+        case .daily, .weekdays: return current == 1 ? "day" : "days"
+        case .weekly: return current == 1 ? "week" : "weeks"
+        case .monthly: return current == 1 ? "month" : "months"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text("\(current) \(periodLabel) streak")
+                .font(Theme.Typography.label)
+                .foregroundStyle(Theme.Colors.accentGreen)
+
+            if longest > current {
+                Text("·")
+                    .foregroundStyle(Theme.Colors.textMuted)
+                Text("Best: \(longest)")
+                    .font(Theme.Typography.label)
+                    .foregroundStyle(Theme.Colors.textMuted)
             }
         }
         .padding(.bottom, 24)

--- a/Murmur/Views/Home/HomeView.swift
+++ b/Murmur/Views/Home/HomeView.swift
@@ -204,30 +204,16 @@ struct HomeView: View {
     // MARK: - Swipe Actions
 
     private func swipeActions(for entry: Entry) -> [CardSwipeAction] {
-        let isCompletable = entry.category == .todo
-            || entry.category == .reminder
-            || entry.category == .habit
-
-        var actions: [CardSwipeAction] = []
-
-        if isCompletable {
-            actions.append(CardSwipeAction(
+        [
+            CardSwipeAction(
                 icon: "checkmark.circle.fill", label: "Done",
                 color: Theme.Colors.accentGreen
-            ) { onAction(entry, .complete) })
-        } else {
-            actions.append(CardSwipeAction(
-                icon: "archivebox.fill", label: "Archive",
-                color: Theme.Colors.accentBlue
-            ) { onAction(entry, .archive) })
-        }
-
-        actions.append(CardSwipeAction(
-            icon: "moon.zzz.fill", label: "Snooze",
-            color: Theme.Colors.accentYellow
-        ) { onAction(entry, .snooze(until: nil)) })
-
-        return actions
+            ) { onAction(entry, .complete) },
+            CardSwipeAction(
+                icon: "moon.zzz.fill", label: "Snooze",
+                color: Theme.Colors.accentYellow
+            ) { onAction(entry, .snooze(until: nil)) }
+        ]
     }
 }
 
@@ -393,6 +379,27 @@ private struct FocusCardView: View {
 
     private var accentColor: Color { Theme.categoryColor(entry.category) }
 
+    private var isOverdue: Bool {
+        guard let dueDate = entry.dueDate else { return false }
+        return dueDate < Date() && entry.status == .active
+    }
+
+    private var isDueSoon: Bool {
+        entry.dueDate != nil && !isOverdue
+    }
+
+    private var reasonColor: Color {
+        if isOverdue { return Theme.Colors.accentRed }
+        if isDueSoon { return Theme.Colors.accentYellow }
+        return Theme.Colors.textSecondary
+    }
+
+    private var reasonIcon: String {
+        if isOverdue { return "exclamationmark.circle.fill" }
+        if isDueSoon { return "calendar" }
+        return "circle.fill"
+    }
+
     var body: some View {
         SwipeableCard(
             actions: swipeActionsProvider(entry),
@@ -402,16 +409,20 @@ private struct FocusCardView: View {
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 6) {
-                    CategoryBadge(category: entry.category, size: .small)
+                    CategoryBadge(
+                        category: entry.category,
+                        size: .small,
+                        text: entry.category == .habit ? (entry.cadence ?? .daily).displayName : nil
+                    )
                     Spacer()
                     if !reason.isEmpty {
                         HStack(spacing: 3) {
-                            Image(systemName: "exclamationmark.circle.fill")
+                            Image(systemName: reasonIcon)
                                 .font(.caption2)
                             Text(reason)
                                 .font(Theme.Typography.badge)
                         }
-                        .foregroundStyle(Theme.Colors.accentRed)
+                        .foregroundStyle(reasonColor)
                     }
                 }
 
@@ -496,7 +507,7 @@ private struct CategorySectionView: View {
         self.swipeActionsProvider = swipeActionsProvider
         self.onAction = onAction
         self.onGlowComplete = onGlowComplete
-        self._isCollapsed = AppStorage(wrappedValue: false, "section_\(category.rawValue)_collapsed")
+        self._isCollapsed = AppStorage(wrappedValue: true, "section_\(category.rawValue)_collapsed")
     }
 
     private var color: Color { Theme.categoryColor(category) }
@@ -616,9 +627,22 @@ private struct CategorySectionView: View {
                 .animation(Animations.cardAppear, value: entries.map(\.id))
             }
         }
-        .onChange(of: arrivedEntryIDs) { _, newIDs in
+        .onAppear {
+            // Handle the case where this section was just created because a new entry arrived.
+            // onChange won't fire on initial render, so peek here if entries are already arrived.
+            guard isCollapsed, !arrivedEntryIDs.isEmpty else { return }
+            let newInSection = entries.filter { arrivedEntryIDs.contains($0.id) }
+            guard let latest = newInSection.first else { return }
+
+            peekEntry = latest
+            peekCount += newInSection.count
+            showPeek()
+        }
+        .onChange(of: arrivedEntryIDs) { oldIDs, newIDs in
             guard isCollapsed else { return }
-            let newInSection = entries.filter { newIDs.contains($0.id) }
+            // Only peek when entries are ADDED — ignore removals (glow complete, 5s expiry).
+            let added = newIDs.subtracting(oldIDs)
+            let newInSection = entries.filter { added.contains($0.id) }
             guard let latest = newInSection.first else { return }
 
             peekEntry = latest
@@ -717,6 +741,7 @@ private struct SmartListRow: View {
     }
 
     private var dueText: String? {
+        guard entry.category == .todo || entry.category == .reminder else { return nil }
         guard let dueDate = entry.dueDate else { return nil }
         let calendar = Calendar.current
         if isOverdue { return "Overdue" }
@@ -730,7 +755,11 @@ private struct SmartListRow: View {
         VStack(alignment: .leading, spacing: 10) {
             // Category + metadata row
             HStack(spacing: 6) {
-                CategoryBadge(category: entry.category, size: .small)
+                CategoryBadge(
+                    category: entry.category,
+                    size: .small,
+                    text: entry.category == .habit ? (entry.cadence ?? .daily).displayName : nil
+                )
 
                 Spacer()
 
@@ -776,7 +805,7 @@ private struct SmartListRow: View {
                                     : Theme.Colors.textTertiary
                             )
                             .animation(.spring(response: 0.3, dampingFraction: 0.65), value: entry.isCompletedToday)
-                            .frame(width: 44, height: 44)
+                            .frame(width: 44)
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)

--- a/Murmur/Views/RootView.swift
+++ b/Murmur/Views/RootView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import SwiftData
 import MurmurCore
 
-// swiftlint:disable type_body_length
 struct RootView: View {
     @Environment(AppState.self) private var appState
     @Environment(NotificationPreferences.self) private var notifPrefs
@@ -265,14 +264,10 @@ struct RootView: View {
             guard let uuid = notification.userInfo?["entryID"] as? UUID else { return }
             selectedEntry = entries.first { $0.id == uuid }
         }
-        .onChange(of: appState.conversation.agentStreamText) { _, text in
+        .onChange(of: appState.conversation.completionText) { _, text in
             guard let text, !text.isEmpty else { return }
-            // Text-only response (no actions) → show as bottom toast
-            if appState.conversation.arrivedEntryIDs.isEmpty {
-                showToast(text, type: .info)
-            }
-            // Clear after showing
-            appState.conversation.agentStreamText = nil
+            showToast(text, type: .info)
+            appState.conversation.completionText = nil
         }
     }
 
@@ -529,7 +524,6 @@ private extension RootView {
     return RootView()
         .environment(appState)
 }
-// swiftlint:enable type_body_length
 
 #Preview("Recording State") {
     @Previewable @State var appState = AppState()

--- a/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
@@ -223,6 +223,7 @@ public struct AgentContextEntry: Sendable, Codable, Identifiable {
     public let cadence: HabitCadence?
     public let status: AgentEntryStatus
     public let createdAt: Date
+    public let currentStreak: Int?
 
     public init(
         id: String,
@@ -232,7 +233,8 @@ public struct AgentContextEntry: Sendable, Codable, Identifiable {
         dueDateDescription: String? = nil,
         cadence: HabitCadence? = nil,
         status: AgentEntryStatus = .active,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        currentStreak: Int? = nil
     ) {
         self.id = id
         self.summary = summary
@@ -242,6 +244,7 @@ public struct AgentContextEntry: Sendable, Codable, Identifiable {
         self.cadence = cadence
         self.status = status
         self.createdAt = createdAt
+        self.currentStreak = currentStreak
     }
 }
 

--- a/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
@@ -662,6 +662,10 @@ public final class PPQLLMService: LLMService, StreamingMurmurAgent, @unchecked S
             line += " status:\(entry.status.rawValue)"
         }
 
+        if let streak = entry.currentStreak, streak > 1 {
+            line += " streak:\(streak)"
+        }
+
         return line
     }
 

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,10 +6,13 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Post-#86 cleanup PR: dedup logic for agent actions, transcript UI removal, and shimmer → minimal loading indicator.
+Streaming arrival system polish: card arrival animations, toast after last card lands, focus section UX correctness (due text on habits, focus card reason color semantics).
 
 ## Recent decisions
 
+- **`dueText` category guard** — `GlowingEntryRow.dueText` now only renders for `.todo` and `.reminder` entries. The LLM can attach `dueDate` to habits; the view shouldn't surface it as "Due tomorrow" noise in the regular list.
+- **Focus card reason color semantics** — `FocusCardView` was always rendering the LLM reason (e.g., "Due", "Stale") in red with an exclamation mark. Added `isOverdue`/`isDueSoon` computed properties using actual `entry.dueDate` math: overdue → red + `exclamationmark.circle.fill`, due soon → yellow + `calendar`, everything else → secondary text + `circle.fill`. String-matching LLM output for visual treatment is fragile; real entry data is reliable.
+- **Streaming arrival animation system** — `ConversationState` tracks `pendingRevealEntryIDs` (hidden during delay), `arrivedEntryIDs` (glowing), `lastRevealTime` (latest scheduled reveal across all batches), `toastTask` (cancellable; fires `completionText` after 1.5s post-last-reveal). `CategorySectionView` diffs `arrivedEntryIDs` additions (not removals) to prevent re-peek on glow expiry. `onAppear` guard handles first card in a new category.
 - **Removed transcript UI from EntryDetailView** — `onViewTranscript` callback and "View transcript" button deleted. The raw transcript is internal data, not a useful user-facing view. Removed from DevScreen and RootView as well.
 - **Dedup conflicting agent actions by entry ID** — `PPQLLMService` now filters out duplicate actions referencing the same entry ID (via `deduplicateByEntryID`), keeping only the first. Prevents the LLM from emitting both "complete" and "archive" for the same entry in one turn. `mutationEntryID` extension on `AgentAction` enables generic filtering across all mutation types.
 - **Tap-to-edit on proposed create cards** — now obsolete (ResultsSurfaceView deleted by PR #86). Carried dedup logic and transcript removal forward; dropped confirmation UI changes.
@@ -34,8 +37,10 @@ Post-#86 cleanup PR: dedup logic for agent actions, transcript UI removal, and s
 
 - Is 3 the right cap for focus items, or should it adapt to screen space?
 - Weekly and monthly habits: `appliesToday` always returns true for these (they apply every day of the week/month). Is there a scenario where a weekly habit should be excluded from focus on certain days?
+- Dedup policy: is first-wins correct for conflicting agent actions, or should "stronger" actions win (archive > complete)? Relevant if a user voice note says "finish and archive all the old tasks."
+- Individual card reveal tasks (`.sleep` → `pendingRevealEntryIDs.remove`) can't be cancelled if a new request starts mid-reveal. Currently fine (entry just glows briefly), but worth tracking.
 
 ## What I need from dam
 
-- Review the dedup logic (`deduplicateByEntryID` + `mutationEntryID`) — is dedup-by-first the right approach for the streaming SSE path, or does streaming make this irrelevant now that actions fire one at a time?
-- Is there a scenario where the same entry ID should appear in two different actions in one turn (e.g. complete + archive = just archive)? Should we prefer the "stronger" action instead of first-wins?
+- Review the dedup logic (`deduplicateByEntryID` + `mutationEntryID`) — is dedup-by-first the right approach?
+- Is there a scenario where the same entry ID should appear in two different actions in one turn (e.g. complete + archive = just archive)? Should we prefer the "stronger" action?

--- a/workflows/meta/IsaacMenge/001-streaming-arrival-and-toast.md
+++ b/workflows/meta/IsaacMenge/001-streaming-arrival-and-toast.md
@@ -1,0 +1,117 @@
+---
+id: "001"
+title: "Streaming arrival system + toast"
+status: completed
+author: IsaacMenge
+project: Murmur
+tags: [streaming, animation, ux, swiftui, toast, convo-state]
+previous: "000"
+sessions:
+  - id: 63b5638e
+    slug: sse-streaming-pr86
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+  - id: 0fe25443
+    slug: card-arrival-toast
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+  - id: (current)
+    slug: polish-due-reason-color
+    dir: -Users-isaacwallace-menge-CascadeProjects-Murmur
+prompts: []
+created: "2026-03-04T00:00:00Z"
+updated: "2026-03-04T00:00:00Z"
+---
+
+# 001: Streaming arrival system + toast
+
+## Context
+
+PR #86 shipped full SSE streaming: tool calls execute progressively as they arrive. Entries now materialize in the view one-by-one rather than all-at-once after the LLM finishes. The remaining UX question was: how do you close the loop with the user? When does the app signal "done"? This entry documents the card arrival animation system and the toast that answers that question — plus the bugs discovered in testing.
+
+---
+
+## Timeline
+
+### Phase 1: SSE streaming + confirmation removal (`63b5638e`, ~March 4 2026)
+
+**What**: Built the streaming pipeline end-to-end and deleted the confirmation surface.
+
+**Decisions**:
+- **Progressive execution** — execute each tool call immediately when it completes streaming, not after the full response. Entries appear as the LLM generates them.
+- **Delete ResultsSurfaceView** — the "confirm these entries" review screen was cognitive overhead. With streaming, the progressive reveal IS the feedback loop.
+- **Dedup by first-seen** — `deduplicateByEntryID()` in `PPQLLMService` filters duplicate actions for the same entry (e.g., complete + archive). First-wins chosen as a safe default; flagged for dam review.
+- **Shimmer → text loading indicator** — `FocusShimmerView` (3 placeholder cards) replaced with `FocusLoadingView` (pulsing "Murmur is selecting your focus…" text). Removes fixed-height reservation.
+
+**Problems**:
+- Tool calls arrive as partial JSON over SSE — can't parse until the closing brace. `StreamingResponseAccumulator` buffers incrementally and attempts parse on each newline, emitting `.toolCallCompleted` only when JSON is valid.
+- Confirmation UI and streaming pipeline were incompatible architecturally. Solution: just delete the confirmation surface rather than trying to adapt it.
+
+---
+
+### Phase 2: Card arrival animations + toast (`0fe25443`, ~March 3–4 2026)
+
+**What**: Built the system that hides new entries until their staggered reveal moment, plays an arrival glow, and fires a toast after the last card lands.
+
+**Decisions**:
+- **`pendingRevealEntryIDs: Set<UUID>`** — entries are hidden from `activeEntries` in `RootView` immediately after creation (before the reveal task fires). This prevents a visible pop-in at full opacity.
+- **`arrivedEntryIDs: Set<UUID>`** — entries are added here at reveal time (driving the glow animation in `CategorySectionView`), then removed after 5 seconds.
+- **`lastRevealTime: Date`** — tracks the wall-clock time of the latest scheduled reveal across all batches. Correctly handles multi-batch streaming by always keeping the maximum.
+- **`toastTask: Task<Void, Never>?`** stored as a class property — cancellable; cancelled at the start of every new request. Toast delay = `max(0, lastRevealTime.timeIntervalSinceNow) + 1.5s`.
+- **`completionText: String?`** — observable property on `ConversationState`; set by the toast task, observed by an `.onChange` in `RootView`.
+- **Toast delay settled at 1.5s** after several iterations (tried 0.5, 1.2, 2.0, 2.5, back to 1.5).
+
+**Problems**:
+- **Cards re-popped after toast appeared** — `CategorySectionView.onChange(of: arrivedEntryIDs)` used `{ _, newIDs in }` and checked all of `newIDs`. When entries were *removed* from `arrivedEntryIDs` (glow expiry after 5s), remaining entries still in `newIDs` triggered `showPeek()` again. Fixed by diffing: `let added = newIDs.subtracting(oldIDs)`.
+- **First card in a new category silently dropped** — `onChange` doesn't fire on initial render. If a new `CategorySectionView` is created mid-stream (first entry in a category creates it), the peek never triggers. Fixed with `onAppear` that checks `arrivedEntryIDs` immediately on mount, guarded by `!arrivedEntryIDs.isEmpty` to prevent firing on normal app launch.
+
+---
+
+### Phase 3: Focus section polish (`current session`, ~March 4 2026)
+
+**What**: Two display correctness fixes on the home screen.
+
+**Decisions**:
+- **`dueText` category guard** — `GlowingEntryRow.dueText` showed "Due tomorrow" on any entry with a `dueDate`, including habits. Added `guard entry.category == .todo || entry.category == .reminder` to match the same filter `EntryDetailView` already used for due date UI. The LLM can emit `dueDate` on habits; the view shouldn't render it.
+- **Focus card reason color semantics** — `FocusCardView` always rendered the LLM reason (e.g., "Due", "Stale") in red with an exclamation mark. "Due tomorrow" shouldn't be alarming. Added `isOverdue`/`isDueSoon` computed properties; now: overdue → red + `exclamationmark.circle.fill`, due soon → yellow + `calendar`, everything else → secondary text + `circle.fill`.
+
+---
+
+## Architecture Snapshot
+
+```
+ConversationState
+  pendingRevealEntryIDs: Set<UUID>   — entries hidden during reveal delay
+  arrivedEntryIDs: Set<UUID>         — entries currently glowing
+  lastRevealTime: Date               — latest scheduled reveal across all batches
+  toastTask: Task<Void, Never>?      — cancellable; fires completionText
+  completionText: String?            — observed by RootView onChange → toast
+
+RootView
+  activeEntries (computed)           — filters out pendingRevealEntryIDs + pendingDeleteEntry
+  onChange(completionText)           — shows toast, clears completionText
+
+CategorySectionView
+  onChange(arrivedEntryIDs) { old, new }  — peeks on additions only
+  onAppear                                — peek if entries already arrived (new-category case)
+```
+
+---
+
+## Developer Patterns Observed
+
+- **Diffing SwiftUI onChange is easy to get wrong** — using `{ _, newIDs in }` (ignoring old) is almost always a bug when the set can shrink. Always destructure to `{ old, new in }` and check additions/removals separately.
+- **`onAppear` as the `onChange` fallback for initial state** — when a view can be created into an "already interesting" state (entries already arrived before the view existed), `onChange` alone is insufficient. `onAppear` + a guard against empty initial state is the pattern.
+- **Wall-clock anchoring for multi-batch delays** — using `Date()` snapshots to compute future delays (rather than accumulating `asyncSleep` durations) is robust to batching. `lastRevealTime = max(lastRevealTime, Date().addingTimeInterval(delay))` just works.
+- **Stored cancellable `Task` for deferred work** — `toastTask?.cancel()` on every request start is lightweight and correct. Avoids needing a structured concurrency hierarchy for "show toast after streaming completes."
+- **View-level urgency overrides LLM labels** — the LLM's 1-word reason ("Overdue", "Due", "Stale") is a hint, but actual due date math should drive color. String-matching LLM output for visual treatment is fragile; real entry data is reliable.
+
+---
+
+## Open Questions
+
+- **Dedup policy**: is first-wins correct, or should "stronger" actions win (archive > complete)? Flagged for dam — relevant if a user voice note says "finish and archive all the old tasks."
+- **Uncancellable anonymous tasks in `trackArrivedEntries`** — the individual card reveal tasks (`.sleep` → `pendingRevealEntryIDs.remove`) can't be cancelled if a new request starts mid-reveal. In practice this is fine (the entry just glows briefly on the new request), but a fully correct implementation would cancel them too.
+
+## What's Next
+
+- Ship post-#86 cleanup PR: dedup logic + transcript UI removal + shimmer → `FocusLoadingView`
+- Consider whether dedup-by-first or dedup-by-strongest makes more sense (coordinate with dam)


### PR DESCRIPTION
## Thinking

The streaming PR (#86) shipped progressive tool execution — entries materialize one by one as the LLM generates them. But it left two open questions: (1) how does the app close the loop with the user when streaming is done? (2) do the home screen display correctness issues matter enough to fix now?

For (1), the answer is a toast that fires after the last card reveals. The challenge is timing: cards reveal with staggered delays across potentially multiple streaming batches. The solution is `lastRevealTime` — a wall-clock anchor that tracks the latest scheduled reveal across all batches. Toast delay = `max(0, lastRevealTime.timeIntervalSinceNow) + 1.5s`. This is robust to multi-batch streaming without any accumulation logic.

For the arrival animation bug: `CategorySectionView.onChange(of: arrivedEntryIDs)` was using `{ _, newIDs in }` (ignoring old). When glow expired and entries were removed from `arrivedEntryIDs`, the remaining entries in `newIDs` re-triggered `showPeek()`. Fixed by diffing: `let added = newIDs.subtracting(oldIDs)`. The `onAppear` case is also needed: a brand new `CategorySectionView` (first entry in a new category) never sees the `onChange` fire for its initial state. `onAppear` + `!arrivedEntryIDs.isEmpty` guard handles this.

For (2), two correctness bugs were worth fixing now because they affect trust in the UI:
- Habits were showing "Due tomorrow" because `GlowingEntryRow.dueText` had no category guard. The LLM can attach `dueDate` to habits. Added `guard entry.category == .todo || entry.category == .reminder`.
- The focus section was showing ALL reasons in red with an exclamation mark, even "Due tomorrow." String-matching LLM output (like `reason == "Overdue"`) is fragile. Used actual `entry.dueDate` math instead: overdue → red, due soon → yellow, otherwise secondary.

The `shimmerHeight` fixed-height hack was also removed while here. It was causing the inverse problem of what it solved: on zero-item days the focus section was too tall. Natural sizing + slide animation on the parent `VStack` is cleaner.

## Summary

- **Card arrival system**: `ConversationState` tracks `pendingRevealEntryIDs` (hidden pre-reveal), `arrivedEntryIDs` (actively glowing), `lastRevealTime` (latest scheduled reveal across all batches), `toastTask` (cancellable), `completionText` (observed by RootView → toast)
- **Toast timing**: fires `max(0, lastRevealTime.timeIntervalSinceNow) + 1.5s` after streaming ends; prefers LLM's text response, falls back to action summary
- **onChange diff fix**: `CategorySectionView` now diffs old/new `arrivedEntryIDs` to prevent re-peeking on glow expiry; `onAppear` handles new-category case
- **FocusContainerView**: removed `shimmerHeight`/`ZStack`/`GeometryReader` hack; replaced with natural sizing + `FocusLoadingView` (dimmed greeting + pulsing subtitle)
- **`dueText` category guard**: `GlowingEntryRow` now only renders due date text for `.todo` and `.reminder`
- **Focus card reason color**: semantic color/icon based on actual `entry.dueDate` math (overdue=red+exclamation, due soon=yellow+calendar, other=secondary+circle)

## State changes

- Focus: moved to next cleanup item
- New open question documented: dedup-by-first vs dedup-by-strongest for conflicting agent actions

## Test plan

- [ ] Voice note creating 3+ entries: cards stagger in, toast appears ~1.5s after last card
- [ ] New request while cards still revealing: toast cancels, new request starts cleanly
- [ ] Habit with a `dueDate`: confirm "Due tomorrow" does NOT appear in the category list
- [ ] Todo due tomorrow: focus section shows yellow "Due tomorrow" (not red exclamation)
- [ ] Overdue todo: focus section shows red "Overdue" with exclamation
- [ ] Zero-item focus day / empty LLM response: focus section is compact, not padded

🤖 Generated with [Claude Code](https://claude.com/claude-code)