### PR TITLE
feat: TestFlight polish — archive delete, LLM fixes, onboarding UX

### DIFF
--- a/Murmur/Views/Home/SacHomeView.swift
+++ b/Murmur/Views/Home/SacHomeView.swift
@@ -41,7 +41,7 @@ struct SacHomeView: View {
         HStack {
             Button(action: onCalendarTap) {
                 Image(systemName: "calendar")
-                    .font(.system(size: 20, weight: .medium))
+                    .font(.system(size: 24, weight: .medium))
                     .foregroundStyle(Theme.Colors.textSecondary)
                     .frame(width: 44, height: 44)
             }
@@ -53,7 +53,7 @@ struct SacHomeView: View {
 
             Button(action: onSettingsTap) {
                 Image(systemName: "gearshape")
-                    .font(.system(size: 20, weight: .medium))
+                    .font(.system(size: 24, weight: .medium))
                     .foregroundStyle(Theme.Colors.textSecondary)
                     .frame(width: 44, height: 44)
             }

--- a/Murmur/Views/Onboarding/OnboardingFlowView.swift
+++ b/Murmur/Views/Onboarding/OnboardingFlowView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import SwiftData
 import MurmurCore
 
 // MARK: - Onboarding Content
@@ -54,7 +53,6 @@ struct OnboardingFlowView: View {
     let onComplete: () -> Void
 
     @Environment(AppState.self) private var appState
-    @Environment(\.modelContext) private var modelContext
 
     @State private var currentStep: OnboardingStep = .welcome
     @State private var displayEntries: [Entry] = OnboardingContent.makeDisplayEntries()
@@ -101,7 +99,7 @@ struct OnboardingFlowView: View {
                         removal: .opacity
                     ))
                     .task {
-                        try? await Task.sleep(for: .seconds(1.5))
+                        try? await Task.sleep(for: .seconds(2.5))
                         withAnimation(.spring(response: 0.5, dampingFraction: 0.75)) {
                             currentStep = .result
                         }
@@ -121,15 +119,6 @@ struct OnboardingFlowView: View {
     }
 
     private func saveAndComplete() {
-        for entry in displayEntries {
-            modelContext.insert(entry)
-        }
-        do {
-            try modelContext.save()
-        } catch {
-            print("Failed to save onboarding entries: \(error.localizedDescription)")
-        }
-
         appState.hasCompletedOnboarding = true
         onComplete()
     }

--- a/Murmur/Views/Onboarding/OnboardingResultView.swift
+++ b/Murmur/Views/Onboarding/OnboardingResultView.swift
@@ -9,9 +9,6 @@ struct OnboardingResultView: View {
     @State private var cardsVisible = false
     @State private var ctaVisible = false
     @State private var habitChecked = false
-    @State private var swipeCalloutVisible = false
-    @State private var habitCalloutVisible = false
-    @State private var calendarCalloutVisible = false
 
     private var todoEntry: Entry? { entries.first(where: { $0.category == .todo }) }
     private var reminderEntry: Entry? { entries.first(where: { $0.category == .reminder }) }
@@ -77,12 +74,6 @@ struct OnboardingResultView: View {
                         .offset(y: cardsVisible ? 0 : 8)
                         .padding(.bottom, 16)
                     }
-
-                    // Notification tip
-                    NotificationTipRow()
-                        .opacity(ctaVisible ? 1 : 0)
-                        .offset(y: ctaVisible ? 0 : 6)
-                        .padding(.bottom, 16)
 
                     Spacer().frame(height: 120)
                 }
@@ -277,34 +268,6 @@ private struct OnboardingHabitRow: View {
         )
         .opacity(checked ? 0.5 : 1.0)
         .animation(.easeInOut(duration: 0.2), value: checked)
-    }
-}
-
-// MARK: - Notification Tip
-
-private struct NotificationTipRow: View {
-    var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "bell.badge.fill")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(Theme.Colors.accentPurple)
-
-            Text("Customize when you get notified in **Settings → Notifications**")
-                .font(.caption)
-                .foregroundStyle(Theme.Colors.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: Theme.Spacing.cardRadius)
-                .fill(Theme.Colors.accentPurple.opacity(0.07))
-                .overlay(
-                    RoundedRectangle(cornerRadius: Theme.Spacing.cardRadius)
-                        .stroke(Theme.Colors.accentPurple.opacity(0.15), lineWidth: 1)
-                )
-        )
     }
 }
 

--- a/Murmur/Views/Onboarding/OnboardingTranscriptView.swift
+++ b/Murmur/Views/Onboarding/OnboardingTranscriptView.swift
@@ -77,20 +77,20 @@ struct OnboardingTranscriptView: View {
                 // Natural pacing: longer pause after punctuation
                 let charIndex = transcript.index(transcript.startIndex, offsetBy: i - 1)
                 let char = transcript[charIndex]
-                let baseDelay: UInt64 = 35_000_000 // 35ms
-                let jitter = UInt64.random(in: 0...10_000_000) // 0-10ms jitter
+                let baseDelay: UInt64 = 18_000_000 // 18ms
+                let jitter = UInt64.random(in: 0...5_000_000) // 0-5ms jitter
 
                 if char == "." || char == "," || char == "—" {
-                    try? await Task.sleep(nanoseconds: baseDelay * 4 + jitter)
+                    try? await Task.sleep(nanoseconds: baseDelay * 3 + jitter)
                 } else if char == " " {
-                    try? await Task.sleep(nanoseconds: baseDelay + jitter * 2)
+                    try? await Task.sleep(nanoseconds: baseDelay + jitter)
                 } else {
                     try? await Task.sleep(nanoseconds: baseDelay + jitter)
                 }
             }
 
             // Brief hold after streaming completes
-            try? await Task.sleep(nanoseconds: 800_000_000) // 0.8s
+            try? await Task.sleep(nanoseconds: 1_800_000_000) // 1.8s
 
             if !Task.isCancelled {
                 onComplete()

--- a/Murmur/Views/RootView.swift
+++ b/Murmur/Views/RootView.swift
@@ -26,6 +26,7 @@ struct RootView: View {
     @State private var topUpProductIDByCredits: [Int64: String] = [:]
     @AppStorage("homeVariant") private var homeVariant: String = "sac"
     @State private var hintStep: Int = -1
+    @State private var hintTimerTask: Task<Void, Never>?
     @State private var pendingDeleteEntry: Entry?
     @State private var pendingDeleteTask: Task<Void, Never>?
     @State private var snoozeEntry: Entry?
@@ -82,6 +83,7 @@ struct RootView: View {
                             withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
                                 hintStep = 0
                             }
+                            scheduleHintTimer()
                         }
                     }
                 )
@@ -114,33 +116,7 @@ struct RootView: View {
             }
 
             // Post-onboarding sequential hints
-            if hintStep >= 0 && hintStep < onboardingHints.count {
-                let hint = onboardingHints[hintStep]
-                VStack {
-                    Spacer()
-                    Label(hint.text, systemImage: hint.icon)
-                        .font(.subheadline)
-                        .foregroundStyle(Theme.Colors.textSecondary)
-                        .padding(.horizontal, 24)
-                        .padding(.vertical, 14)
-                        .background(
-                            Capsule()
-                                .fill(Theme.Colors.bgCard)
-                                .overlay(Capsule().stroke(Theme.Colors.borderSubtle, lineWidth: 1))
-                        )
-                        .padding(.bottom, Theme.Spacing.micButtonSize + 20)
-                        .shadow(color: Theme.Colors.accentPurple.opacity(0.45), radius: 16, x: 0, y: 0)
-                        .id(hintStep)
-                        .transition(.opacity.animation(.easeOut(duration: 0.25)))
-                        .onTapGesture { advanceHint() }
-                        .task(id: hintStep) {
-                            try? await Task.sleep(for: .seconds(3.5))
-                            advanceHint()
-                        }
-                }
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-                .zIndex(55)
-            }
+            hintOverlay
 
             // Tap-to-dismiss overlay when text input is open
             if showTextInputBar {
@@ -438,12 +414,86 @@ private extension RootView {
             HintItem(icon: "arrow.left", text: "Swipe left to snooze or complete"),
             HintItem(icon: "circle", text: "Tap the circle on habits to check them off"),
             HintItem(icon: "calendar", text: "Tap calendar to see your schedule"),
+            HintItem(icon: "bell", text: "Customize notification preferences in Settings"),
         ]
     }
 
     func advanceHint() {
-        withAnimation(.easeOut(duration: 0.3)) {
+        hintTimerTask?.cancel()
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
             hintStep += 1
+        }
+        scheduleHintTimer()
+    }
+
+    func scheduleHintTimer() {
+        hintTimerTask?.cancel()
+        guard hintStep < onboardingHints.count else { return }
+        hintTimerTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(4.5))
+            guard !Task.isCancelled else { return }
+            advanceHint()
+        }
+    }
+
+    @ViewBuilder var hintOverlay: some View {
+        if hintStep >= 0 && hintStep < onboardingHints.count {
+            let hint = onboardingHints[hintStep]
+            VStack {
+                Spacer()
+                VStack(spacing: 12) {
+                    HStack(spacing: 12) {
+                        Image(systemName: hint.icon)
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(Theme.Colors.accentPurple)
+                            .frame(width: 32, height: 32)
+                            .background(Theme.Colors.accentPurple.opacity(0.12), in: Circle())
+                            .id("icon_\(hintStep)")
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .offset(y: 6)),
+                                removal: .opacity.combined(with: .offset(y: -6))
+                            ))
+                        Text(hint.text)
+                            .font(Theme.Typography.body)
+                            .foregroundStyle(Theme.Colors.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id("text_\(hintStep)")
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .offset(y: 6)),
+                                removal: .opacity.combined(with: .offset(y: -6))
+                            ))
+                    }
+                    HStack(spacing: 6) {
+                        ForEach(0..<onboardingHints.count, id: \.self) { i in
+                            Capsule()
+                                .fill(i == hintStep ? Theme.Colors.accentPurple : Theme.Colors.borderSubtle)
+                                .frame(width: i == hintStep ? 16 : 6, height: 4)
+                                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: hintStep)
+                        }
+                        Spacer()
+                        let isLast = hintStep == onboardingHints.count - 1
+                        Text(isLast ? "Got it" : "Tap to continue")
+                            .font(Theme.Typography.caption)
+                            .foregroundStyle(isLast ? Theme.Colors.accentPurple : Theme.Colors.textTertiary)
+                    }
+                }
+                .padding(.horizontal, 18)
+                .padding(.vertical, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Spacing.cardRadius)
+                        .fill(Theme.Colors.bgCard)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.Spacing.cardRadius)
+                                .stroke(Theme.Colors.accentPurple.opacity(0.2), lineWidth: 1)
+                        )
+                )
+                .shadow(color: .black.opacity(0.3), radius: 20, y: 8)
+                .padding(.horizontal, Theme.Spacing.screenPadding)
+                .padding(.bottom, Theme.Spacing.micButtonSize + 28)
+                .onTapGesture { advanceHint() }
+            }
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .zIndex(55)
         }
     }
 

--- a/Murmur/Views/Settings/ArchiveView.swift
+++ b/Murmur/Views/Settings/ArchiveView.swift
@@ -63,15 +63,20 @@ struct ArchiveView: View {
                                         entries: group.entries,
                                         onRestore: { entry in
                                             entry.perform(.unarchive, in: modelContext, preferences: notifPrefs)
+                                        },
+                                        onDelete: { entry in
+                                            modelContext.delete(entry)
                                         }
                                     )
                                 }
                             } else {
                                 LazyVStack(spacing: 12) {
                                     ForEach(filteredEntries) { entry in
-                                        ArchiveRow(entry: entry) {
+                                        ArchiveRow(entry: entry, onRestore: {
                                             entry.perform(.unarchive, in: modelContext, preferences: notifPrefs)
-                                        }
+                                        }, onDelete: {
+                                            modelContext.delete(entry)
+                                        })
                                     }
                                 }
                                 .padding(.horizontal, Theme.Spacing.screenPadding)
@@ -153,13 +158,15 @@ private struct ArchiveSectionView: View {
     let category: EntryCategory
     let entries: [Entry]
     let onRestore: (Entry) -> Void
+    let onDelete: (Entry) -> Void
 
     @AppStorage private var isCollapsed: Bool
 
-    init(category: EntryCategory, entries: [Entry], onRestore: @escaping (Entry) -> Void) {
+    init(category: EntryCategory, entries: [Entry], onRestore: @escaping (Entry) -> Void, onDelete: @escaping (Entry) -> Void) {
         self.category = category
         self.entries = entries
         self.onRestore = onRestore
+        self.onDelete = onDelete
         self._isCollapsed = AppStorage(wrappedValue: false, "archive_section_\(category.rawValue)_collapsed")
     }
 
@@ -220,9 +227,11 @@ private struct ArchiveSectionView: View {
             if !isCollapsed {
                 LazyVStack(spacing: 12) {
                     ForEach(entries) { entry in
-                        ArchiveRow(entry: entry) {
+                        ArchiveRow(entry: entry, onRestore: {
                             onRestore(entry)
-                        }
+                        }, onDelete: {
+                            onDelete(entry)
+                        })
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.screenPadding)
@@ -237,6 +246,7 @@ private struct ArchiveSectionView: View {
 private struct ArchiveRow: View {
     let entry: Entry
     let onRestore: () -> Void
+    let onDelete: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
@@ -251,13 +261,23 @@ private struct ArchiveRow: View {
 
             Spacer()
 
-            Button(action: onRestore) {
-                Image(systemName: "arrow.uturn.backward.circle.fill")
-                    .font(.system(size: 24))
-                    .foregroundStyle(Theme.Colors.accentPurple)
+            HStack(spacing: 12) {
+                Button(action: onRestore) {
+                    Image(systemName: "arrow.uturn.backward.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(Theme.Colors.accentPurple)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Restore entry")
+
+                Button(action: onDelete) {
+                    Image(systemName: "trash.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Delete entry")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Restore entry")
         }
         .cardStyle()
     }

--- a/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/LLMService.swift
@@ -99,6 +99,7 @@ public struct LLMPrompt: @unchecked Sendable {
             - Set due_date as an ISO 8601 datetime string resolved from the current time (e.g. "2025-03-17T15:30:00"). Always set it when the user mentions any time reference.
             - Keep snooze_until as the user's natural language phrase.
             - For habits, set cadence to daily/weekdays/weekly/monthly when clear.
+            - Priority 1-5 (1=highest). Default 3 unless words signal urgency ("urgent", "ASAP", "critical" → 1-2) or low importance ("whenever", "someday" → 4-5).
             - Do not include urgency words in content when priority captures urgency.
 
             Mutation rules:
@@ -158,7 +159,8 @@ public struct LLMPrompt: @unchecked Sendable {
             - category
             - source_text: relevant transcript span
             - summary: 10 words or fewer
-            Optional: priority (1-5), due_date (ISO 8601 datetime resolved from the current time provided above, e.g. "2025-03-17T15:30:00"), cadence (for habits)
+            Optional: priority (1-5, default 3 unless urgency/low importance is clear), \
+            due_date (ISO 8601 datetime resolved from current time, e.g. "2025-03-17T15:30:00"), cadence (for habits)
             Always set due_date for reminders and todos when the user mentions any time reference (e.g. "in 30 minutes", "tomorrow", "next Friday").
             """,
         tools: [createEntriesToolSchema()],

--- a/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/PPQLLMService.swift
@@ -447,8 +447,9 @@ public final class PPQLLMService: LLMService, StreamingMurmurAgent, @unchecked S
             ]
         }
 
+        let temporalContext = buildTemporalContext()
         return conversation.messages + [
-            ["role": "user", "content": userContent],
+            ["role": "user", "content": "[\(temporalContext)]\n\n\(userContent)"],
         ]
     }
 

--- a/meta/TESTFLIGHT_CHECKLIST.md
+++ b/meta/TESTFLIGHT_CHECKLIST.md
@@ -145,3 +145,4 @@ IAP products (credit packs) may not exist in App Store Connect for the first bet
 | 20 | Verify StoreKit degradation | **sac** | Soft | Not started |
 
 
+

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,7 +6,7 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Launch screen polish: eliminated the visible seam/box around the launch icon.
+TestFlight polish: onboarding UX improvements, archive delete, LLM quality fixes, Studio Analytics setup.
 
 ## Recent decisions
 
@@ -16,7 +16,6 @@ Launch screen polish: eliminated the visible seam/box around the launch icon.
 - **LLM now always sets due_date for reminders/todos** — Changed "Optional: due_date (verbatim phrase)" to an explicit instruction: always set it when the user mentions a time reference.
 - **Snooze notification defaults to ON** — `snoozeWakeUpEnabled` was defaulting to OFF, making snooze effectively silent. Changed to ON; snooze implies wanting a reminder.
 - **Summary edit re-syncs notification** — EntryDetailView summary onChange now calls `sync()` so the pending notification title stays current.
-- **Notification tip in onboarding result view** — Purple-tinted card pointing to Settings → Notifications after habits strip.
 - **Dropped swipe-to-switch-tabs** — `TabView(.page)` fires simultaneously with card swipe actions. Replaced with HStack pager (tap-only). Applied to both home variants.
 - **Section headers: dot + colored text + hairline** — Replaced pill/bubble with dot + category-colored label + tinted hairline.
 - **Archive + All-entries search** — Both views now have a search bar that filters by summary. Archive: grouped sections when idle, flat list when searching. All entries: same pattern, hides processing dots while searching.
@@ -24,6 +23,11 @@ Launch screen polish: eliminated the visible seam/box around the launch icon.
 - **Smart toast duration** — Duration scales with message length: `max(2.5, min(6.0, chars / 12.0))`. Short confirmations ("Completed") disappear quickly; long LLM responses stay readable.
 - **List category color: teal → blue** — Minor color tweak for better visual distinction.
 - **Launch screen seam fix** — PNG has no alpha (navy background baked in), so color matching was imperfect. Fixed by pinning imageView to all 4 edges (full screen) with `scaleAspectFit` + setting screen background to the exact PNG corner pixel color (#060912). No seam because the imageView IS the background; letterbox areas above/below the icon match the PNG border color.
+- **Archive delete** — Added trash button alongside restore in ArchiveRow. `.swipeActions` doesn't work in `LazyVStack`; went with always-visible side-by-side buttons instead of restructuring to `List`.
+- **LLM priority defaults to 3** — Changed prompt to default priority to middle (3) unless context clearly signals urgency or low importance. Prevents all entries coming in as P1.
+- **Temporal context on every turn** — `buildTemporalContext()` was only injected on first turn; subsequent turns had a stale timestamp causing wrong relative-time calculations for notifications. Fixed by prepending `[temporalContext]` to every user message.
+- **Post-onboarding hint cards** — Replaced tiny capsule pills with a prominent floating card that cycles through 5 tips (added notifications tip). Used explicit task management (`hintTimerTask`) to prevent tap+auto-advance races. Tapping advances to the next card; last card shows "Got it".
+- **Studio Analytics wired** — Added `STUDIO_ANALYTICS_ENDPOINT` + `STUDIO_ANALYTICS_API_KEY` to `project.local.yml` for both Debug and Release configs.
 
 ## Open questions
 


### PR DESCRIPTION
## Thinking

The main goal this session was making the first-run experience feel more polished and trustworthy for TestFlight testers. A few threads:

**Auto-created sample entries removed.** The onboarding result screen shows demo cards (client proposal, dentist reminder, morning run) as a walkthrough, but they were being persisted to SwiftData on "Start capturing." That meant testers launched into an app that already had fake data they didn't create. Decided to drop the `modelContext.insert` entirely — onboarding is now purely illustrative. The `saveAndComplete` function just sets `hasCompletedOnboarding = true`. Removed the now-unused `SwiftData` import and `@Environment(\.modelContext)`.

**Hint card race condition.** The old `.task(id: hintStep)` auto-advance would race with tap. If the timer was ~about to fire and the user tapped, both paths called `advanceHint()` simultaneously, rapidly overshooting past all 5 hints and dismissing the overlay. Fixed with explicit `Task<Void, Never>?` management: `advanceHint()` always cancels the running timer before incrementing, then `scheduleHintTimer()` starts a fresh one.

**Processing screen duration.** 1.5s felt like the spinner barely appeared before the result screen came in. 2.5s gives the user time to read "AI is processing your thoughts" and feel like something real happened.

**LLM temporal context.** Temporal context (current timestamp) was only injected on the first turn of a conversation. Subsequent turns had a stale timestamp, causing wrong relative-time calculations when the user said things like "remind me in 30 minutes." Fixed by prepending `[temporalContext]` to every user message.

**Priority defaulting to 1.** LLM was treating everything as urgent by default. Changed the prompt to default to 3 (middle) unless the user's words clearly signal urgency or low importance.

## Summary

- **Onboarding**: Sample entries (client proposal, dentist, morning run) are no longer saved to SwiftData — the result screen is now display-only
- **Onboarding**: Processing screen lingers 2.5s (was 1.5s) so it feels substantive
- **Hint cards**: 5-tip floating card replaces tiny capsule pills; tap-to-advance; explicit timer management prevents race condition that was collapsing all hints on tap; notifications Settings tip added
- **Archive**: Trash button added alongside restore for permanent delete
- **LLM**: Priority defaults to 3 (middle) instead of 1; temporal context injected every turn

## State changes

Updated `meta/sac/STATE.md` with all decisions above. Added archive delete decision and hint card task management note. No new canon candidates — these are all UI/UX implementation details.

## Test plan

- [ ] Complete onboarding → tap "Start capturing" → verify home screen is empty (no sample entries)
- [ ] Complete onboarding → verify 5 hint cards appear, auto-advance every ~4.5s
- [ ] Tap a hint card mid-cycle → verify it advances to next card (not dismiss)
- [ ] Tap last hint card → verify "Got it" label and dismissal
- [ ] Archive an entry → verify trash icon appears; tap trash → entry is permanently deleted
- [ ] Record "remind me in 30 minutes" → verify due date is ~30min from now (not wrong day)
- [ ] Record "finish the proposal" (no urgency words) → verify priority is 3 not 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)