### PR TITLE
feat: list UI with expand/collapse and checkable items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
           key: brew-${{ runner.os }}-xcodegen-xcbeautify
 
       - name: Install tools
-        run: brew install xcodegen xcbeautify
+        run: |
+          brew install xcodegen xcbeautify || true
+          brew link --overwrite xcodegen xcbeautify || true
 
       - name: Configure CI environment
         run: |

--- a/Murmur/Components/ListCardView.swift
+++ b/Murmur/Components/ListCardView.swift
@@ -4,6 +4,7 @@ import MurmurCore
 struct ListCardView: View {
     let entry: Entry
     let onAction: (Entry, EntryAction) -> Void
+    var onTap: (() -> Void)?
     var glowAccent: Color?
     var glowIntensity: Double = 0
 
@@ -37,11 +38,11 @@ struct ListCardView: View {
             // Header — always visible
             headerView
 
-            // Expanded items
-            if isExpanded {
-                expandedBody
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-            }
+            // Expanded items — always in hierarchy, height controlled
+            expandedBody
+                .frame(maxHeight: isExpanded ? nil : 0)
+                .opacity(isExpanded ? 1 : 0)
+                .clipped()
         }
         .cardStyle(accent: glowAccent, intensity: glowIntensity)
         .opacity(entry.isDone ? 0.5 : 1.0)
@@ -53,31 +54,39 @@ struct ListCardView: View {
     // MARK: - Header (collapsed / always visible)
 
     private var headerView: some View {
-        Button {
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                isExpanded.toggle()
-            }
-        } label: {
-            HStack(alignment: .center, spacing: 12) {
-                Circle()
-                    .fill(accent)
-                    .frame(width: 8, height: 8)
-                    .shadow(color: accent.opacity(0.6), radius: 4)
-                    .padding(.leading, 2)
+        HStack(alignment: .center, spacing: 12) {
+            // Tappable card body — opens detail
+            Button {
+                onTap?()
+            } label: {
+                HStack(alignment: .center, spacing: 12) {
+                    Circle()
+                        .fill(accent)
+                        .frame(width: 8, height: 8)
+                        .shadow(color: accent.opacity(0.6), radius: 4)
+                        .padding(.leading, 2)
 
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(entry.summary)
-                        .font(.subheadline)
-                        .foregroundStyle(entry.isDone ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
-                        .lineLimit(2)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(entry.summary)
+                            .font(.subheadline)
+                            .foregroundStyle(entry.isDone ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
+                            .lineLimit(2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                    if !isExpanded {
                         collapsedPreview
                     }
+                    .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
                 }
-                .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
 
+            // Expand/collapse button — right side only
+            Button {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                    isExpanded.toggle()
+                }
+            } label: {
                 HStack(spacing: 8) {
                     // Item count badge
                     Text("\(listItems.count)")
@@ -98,9 +107,12 @@ struct ListCardView: View {
                         .rotationEffect(.degrees(isExpanded ? 0 : -90))
                         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isExpanded)
                 }
+                .padding(.vertical, 8)
+                .padding(.leading, 4)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Collapsed Preview

--- a/Murmur/Components/ListCardView.swift
+++ b/Murmur/Components/ListCardView.swift
@@ -1,0 +1,230 @@
+import SwiftUI
+import MurmurCore
+
+struct ListCardView: View {
+    let entry: Entry
+    let onAction: (Entry, EntryAction) -> Void
+    var glowAccent: Color?
+    var glowIntensity: Double = 0
+
+    @State private var isExpanded: Bool = false
+
+    private var accent: Color { Theme.categoryColor(entry.category) }
+
+    // MARK: - Parsing
+
+    private var listItems: [(text: String, checked: Bool)] {
+        entry.content.components(separatedBy: "\n")
+            .compactMap { line -> (String, Bool)? in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("- [x] ") {
+                    return (String(trimmed.dropFirst(6)), true)
+                } else if trimmed.hasPrefix("- [ ] ") {
+                    return (String(trimmed.dropFirst(6)), false)
+                } else if trimmed.hasPrefix("- ") {
+                    return (String(trimmed.dropFirst(2)), false)
+                }
+                return nil
+            }
+    }
+
+    private var checkedCount: Int {
+        listItems.filter { $0.checked }.count
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header — always visible
+            headerView
+
+            // Expanded items
+            if isExpanded {
+                expandedBody
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .cardStyle(accent: glowAccent, intensity: glowIntensity)
+        .opacity(entry.isDone ? 0.5 : 1.0)
+        .animation(.easeInOut(duration: 0.2), value: entry.isCompletedToday)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(entry.category.displayName): \(entry.summary), \(checkedCount) of \(listItems.count) checked")
+    }
+
+    // MARK: - Header (collapsed / always visible)
+
+    private var headerView: some View {
+        Button {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack(alignment: .center, spacing: 12) {
+                Circle()
+                    .fill(accent)
+                    .frame(width: 8, height: 8)
+                    .shadow(color: accent.opacity(0.6), radius: 4)
+                    .padding(.leading, 2)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(entry.summary)
+                        .font(.subheadline)
+                        .foregroundStyle(entry.isDone ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if !isExpanded {
+                        collapsedPreview
+                    }
+                }
+                .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
+
+                HStack(spacing: 8) {
+                    // Item count badge
+                    Text("\(listItems.count)")
+                        .font(Theme.Typography.badge)
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(Theme.Colors.bgCard)
+                                .overlay(Capsule().stroke(Theme.Colors.borderSubtle, lineWidth: 1))
+                        )
+
+                    // Expand chevron
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                        .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isExpanded)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Collapsed Preview
+
+    private var collapsedPreview: some View {
+        let items = listItems
+        let previewItems = Array(items.prefix(3))
+        let previewText = previewItems.map { $0.text }.joined(separator: " · ")
+        return Text(previewText)
+            .font(.caption2)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            .lineLimit(1)
+    }
+
+    // MARK: - Expanded Body
+
+    private var expandedBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Divider
+            Rectangle()
+                .fill(Theme.Colors.borderSubtle)
+                .frame(height: 0.5)
+                .padding(.top, 10)
+                .padding(.bottom, 8)
+
+            // List items with checkboxes
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(listItems.enumerated()), id: \.offset) { index, item in
+                    listItemRow(index: index, text: item.text, checked: item.checked)
+                }
+            }
+
+            // Progress footer
+            if !listItems.isEmpty {
+                HStack(spacing: 4) {
+                    // Progress bar
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            Capsule()
+                                .fill(Theme.Colors.borderSubtle)
+                                .frame(height: 3)
+                            Capsule()
+                                .fill(accent)
+                                .frame(
+                                    width: listItems.isEmpty
+                                        ? 0
+                                        : geo.size.width * CGFloat(checkedCount) / CGFloat(listItems.count),
+                                    height: 3
+                                )
+                                .animation(.spring(response: 0.3, dampingFraction: 0.7), value: checkedCount)
+                        }
+                    }
+                    .frame(height: 3)
+                    .frame(maxWidth: 60)
+
+                    Text("\(checkedCount)/\(listItems.count)")
+                        .font(Theme.Typography.badge)
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                }
+                .padding(.top, 10)
+            }
+        }
+    }
+
+    // MARK: - List Item Row
+
+    private func listItemRow(index: Int, text: String, checked: Bool) -> some View {
+        Button {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.65)) {
+                onAction(entry, .toggleListItem(index: index))
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: checked ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18))
+                    .foregroundStyle(checked ? accent : Theme.Colors.textTertiary)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.65), value: checked)
+
+                Text(text)
+                    .font(.subheadline)
+                    .foregroundStyle(checked ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
+                    .strikethrough(checked, color: Theme.Colors.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(3)
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("List Card — Collapsed") {
+    VStack(spacing: 16) {
+        ListCardView(
+            entry: Entry(
+                transcript: "",
+                content: "- [ ] Eggs\n- [x] Milk\n- [ ] Bread\n- [ ] Butter\n- [x] Cheese\n- [ ] Tomatoes\n- [ ] Onions",
+                category: .list,
+                sourceText: "",
+                summary: "Grocery shopping list"
+            ),
+            onAction: { _, action in print("Action:", action) }
+        )
+    }
+    .padding(Theme.Spacing.screenPadding)
+    .background(Theme.Colors.bgDeep)
+}
+
+#Preview("List Card — Plain Bullets") {
+    VStack(spacing: 16) {
+        ListCardView(
+            entry: Entry(
+                transcript: "",
+                content: "- Pack clothes\n- Book hotel\n- Cancel mail delivery\n- Water plants",
+                category: .list,
+                sourceText: "",
+                summary: "Trip preparation checklist"
+            ),
+            onAction: { _, action in print("Action:", action) }
+        )
+    }
+    .padding(Theme.Spacing.screenPadding)
+    .background(Theme.Colors.bgDeep)
+}

--- a/Murmur/Models/Entry.swift
+++ b/Murmur/Models/Entry.swift
@@ -469,36 +469,36 @@ extension Entry {
             save(in: context)
 
         case .toggleListItem(let index):
-            var lines = content.components(separatedBy: "\n")
-            var itemIndex = 0
-            for i in lines.indices {
-                let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
-                let isListItem = trimmed.hasPrefix("- [x] ")
-                    || trimmed.hasPrefix("- [ ] ")
-                    || trimmed.hasPrefix("- ")
-                guard isListItem else { continue }
-                if itemIndex == index {
-                    // Find the prefix in the original line (preserving leading whitespace)
-                    let leading = String(lines[i].prefix(while: { $0 == " " || $0 == "\t" }))
-                    if trimmed.hasPrefix("- [x] ") {
-                        let rest = String(trimmed.dropFirst(6))
-                        lines[i] = leading + "- [ ] " + rest
-                    } else if trimmed.hasPrefix("- [ ] ") {
-                        let rest = String(trimmed.dropFirst(6))
-                        lines[i] = leading + "- [x] " + rest
-                    } else if trimmed.hasPrefix("- ") {
-                        // Plain bullet — promote to checkbox syntax
-                        let rest = String(trimmed.dropFirst(2))
-                        lines[i] = leading + "- [x] " + rest
-                    }
-                    break
-                }
-                itemIndex += 1
-            }
-            content = lines.joined(separator: "\n")
-            updatedAt = Date()
+            toggleListItem(at: index)
             save(in: context)
         }
+    }
+
+    /// Toggle a checkbox item in list content by its index among list items.
+    private func toggleListItem(at index: Int) {
+        var lines = content.components(separatedBy: "\n")
+        var itemIndex = 0
+        for i in lines.indices {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+            let isListItem = trimmed.hasPrefix("- [x] ")
+                || trimmed.hasPrefix("- [ ] ")
+                || trimmed.hasPrefix("- ")
+            guard isListItem else { continue }
+            if itemIndex == index {
+                let leading = String(lines[i].prefix(while: { $0 == " " || $0 == "\t" }))
+                if trimmed.hasPrefix("- [x] ") {
+                    lines[i] = leading + "- [ ] " + String(trimmed.dropFirst(6))
+                } else if trimmed.hasPrefix("- [ ] ") {
+                    lines[i] = leading + "- [x] " + String(trimmed.dropFirst(6))
+                } else if trimmed.hasPrefix("- ") {
+                    lines[i] = leading + "- [x] " + String(trimmed.dropFirst(2))
+                }
+                break
+            }
+            itemIndex += 1
+        }
+        content = lines.joined(separator: "\n")
+        updatedAt = Date()
     }
 
     private func save(in context: ModelContext) {

--- a/Murmur/Models/Entry.swift
+++ b/Murmur/Models/Entry.swift
@@ -417,6 +417,7 @@ enum EntryAction {
     case unarchive
     case delete
     case checkOffHabit         // toggle done-for-period on habit entries
+    case toggleListItem(index: Int) // toggle checkbox on a list item
 }
 
 extension Entry {
@@ -464,6 +465,37 @@ extension Entry {
                 habitCompletionDates.append(now)
                 lastHabitCompletionDate = now
             }
+            updatedAt = Date()
+            save(in: context)
+
+        case .toggleListItem(let index):
+            var lines = content.components(separatedBy: "\n")
+            var itemIndex = 0
+            for i in lines.indices {
+                let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+                let isListItem = trimmed.hasPrefix("- [x] ")
+                    || trimmed.hasPrefix("- [ ] ")
+                    || trimmed.hasPrefix("- ")
+                guard isListItem else { continue }
+                if itemIndex == index {
+                    // Find the prefix in the original line (preserving leading whitespace)
+                    let leading = String(lines[i].prefix(while: { $0 == " " || $0 == "\t" }))
+                    if trimmed.hasPrefix("- [x] ") {
+                        let rest = String(trimmed.dropFirst(6))
+                        lines[i] = leading + "- [ ] " + rest
+                    } else if trimmed.hasPrefix("- [ ] ") {
+                        let rest = String(trimmed.dropFirst(6))
+                        lines[i] = leading + "- [x] " + rest
+                    } else if trimmed.hasPrefix("- ") {
+                        // Plain bullet — promote to checkbox syntax
+                        let rest = String(trimmed.dropFirst(2))
+                        lines[i] = leading + "- [x] " + rest
+                    }
+                    break
+                }
+                itemIndex += 1
+            }
+            content = lines.joined(separator: "\n")
             updatedAt = Date()
             save(in: context)
         }

--- a/Murmur/Models/ThreadItem.swift
+++ b/Murmur/Models/ThreadItem.swift
@@ -62,6 +62,7 @@ struct AppliedActionInfo: Identifiable {
             switch action {
             case .create: return .created
             case .update: return .updated
+            case .updateListItems: return .updated
             case .complete: return .completed
             case .archive: return .archived
             case .updateMemory: return .updated

--- a/Murmur/Services/AgentActionExecutor.swift
+++ b/Murmur/Services/AgentActionExecutor.swift
@@ -126,6 +126,17 @@ struct AgentActionExecutor {
                 applyStatusUpdate(a.fields, to: entry, context: ctx)
                 return .updated(entryID: entry.id, previousFields: snapshot)
             }
+        case .updateListItems(let a):
+            if completedIDs.contains(a.id) { return .skipped }
+            return executeMutation(id: a.id, entries: ctx.entries) { entry in
+                let previousContent = entry.content
+                entry.content = UpdateListItemsAction.serializeToMarkdown(a.items)
+                entry.updatedAt = Date()
+                return .updated(
+                    entryID: entry.id,
+                    previousFields: FieldSnapshot.contentOnly(previousContent)
+                )
+            }
         case .complete(let a):
             let result = executeMutation(id: a.id, entries: ctx.entries) { entry in
                 guard entry.status != .completed else { return nil }
@@ -355,6 +366,34 @@ struct FieldSnapshot {
     let lastHabitCompletionDate: Date?
     let habitCompletionDates: [Date]?
 
+    private init(
+        content: String?,
+        summary: String?,
+        category: EntryCategory?,
+        priority: Int?,
+        dueDateDescription: String?,
+        dueDate: Date?,
+        cadence: HabitCadence?,
+        status: EntryStatus?,
+        snoozeUntil: Date?,
+        notes: String?,
+        lastHabitCompletionDate: Date?,
+        habitCompletionDates: [Date]?
+    ) {
+        self.content = content
+        self.summary = summary
+        self.category = category
+        self.priority = priority
+        self.dueDateDescription = dueDateDescription
+        self.dueDate = dueDate
+        self.cadence = cadence
+        self.status = status
+        self.snoozeUntil = snoozeUntil
+        self.notes = notes
+        self.lastHabitCompletionDate = lastHabitCompletionDate
+        self.habitCompletionDates = habitCompletionDates
+    }
+
     init(entry: Entry, fields: UpdateFields) {
         self.content = fields.content != nil ? entry.content : nil
         self.summary = fields.summary != nil ? entry.summary : nil
@@ -368,6 +407,24 @@ struct FieldSnapshot {
         self.notes = fields.notes != nil ? entry.notes : nil
         self.lastHabitCompletionDate = fields.checkOffHabit == true ? entry.lastHabitCompletionDate : nil
         self.habitCompletionDates = fields.checkOffHabit == true ? entry.habitCompletionDates : nil
+    }
+
+    /// Snapshot capturing only the previous content value (for list item updates).
+    static func contentOnly(_ previousContent: String) -> FieldSnapshot {
+        FieldSnapshot(
+            content: previousContent,
+            summary: nil,
+            category: nil,
+            priority: nil,
+            dueDateDescription: nil,
+            dueDate: nil,
+            cadence: nil,
+            status: nil,
+            snoozeUntil: nil,
+            notes: nil,
+            lastHabitCompletionDate: nil,
+            habitCompletionDates: nil
+        )
     }
 
     func restore(to entry: Entry) {

--- a/Murmur/Services/ConversationState.swift
+++ b/Murmur/Services/ConversationState.swift
@@ -684,7 +684,11 @@ private func buildActionSummary(
 ) -> String {
     let labels: [(String, (AgentAction) -> Bool)] = [
         ("Created", { if case .create = $0 { return true }; return false }),
-        ("Updated", { if case .update = $0 { return true }; return false }),
+        ("Updated", {
+            if case .update = $0 { return true }
+            if case .updateListItems = $0 { return true }
+            return false
+        }),
         ("Completed", { if case .complete = $0 { return true }; return false }),
         ("Archived", { if case .archive = $0 { return true }; return false }),
     ]

--- a/Murmur/Services/ToolResultBuilder.swift
+++ b/Murmur/Services/ToolResultBuilder.swift
@@ -84,6 +84,8 @@ enum ToolResultBuilder {
             return "Created [\(shortID)] '\(summary)'"
         case "update_entries":
             return "Updated [\(shortID)]"
+        case "update_list_items":
+            return "Updated list items [\(shortID)]"
         case "complete_entries":
             return "Completed [\(shortID)]"
         case "archive_entries":

--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -134,54 +134,65 @@ struct EntryDetailView: View {
                             }
                             .padding(.bottom, 24)
 
-                        // MARK: Notes (inline TextEditor, always visible)
-                        Text("Notes")
-                            .font(Theme.Typography.label)
-                            .foregroundStyle(Theme.Colors.textSecondary)
-                            .padding(.bottom, 6)
-
-                        ZStack(alignment: .topLeading) {
-                            if draftNotes.isEmpty && !notesFocused {
-                                Text("Add a note…")
-                                    .font(Theme.Typography.body)
-                                    .foregroundStyle(Theme.Colors.textMuted)
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 16)
-                                    .allowsHitTesting(false)
-                            }
-                            TextEditor(text: $draftNotes)
-                                .font(Theme.Typography.body)
-                                .foregroundStyle(Theme.Colors.textPrimary)
-                                .scrollContentBackground(.hidden)
-                                .frame(minHeight: 80)
-                                .focused($notesFocused)
-                                .padding(12)
-                                .onChange(of: draftNotes) { _, newValue in
-                                    if entry.category == .list {
+                        // MARK: Notes / List items
+                        if draftCategory == .list {
+                            ListItemsEditor(
+                                content: Binding(
+                                    get: { draftNotes },
+                                    set: { newValue in
+                                        draftNotes = newValue
                                         entry.content = newValue
-                                    } else {
-                                        entry.notes = newValue
+                                        entry.updatedAt = Date()
+                                        save()
                                     }
-                                    entry.updatedAt = Date()
-                                    save()
-                                }
-                        }
-                        .background(
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(notesFocused
-                                    ? Theme.Colors.bgCard
-                                    : Theme.Colors.bgCard.opacity(0.5))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .stroke(
-                                            notesFocused
-                                                ? Theme.Colors.accentPurple.opacity(0.3)
-                                                : Theme.Colors.borderFaint,
-                                            lineWidth: 1
-                                        )
                                 )
-                        )
-                        .padding(.bottom, 24)
+                            )
+                            .padding(.bottom, 24)
+                        } else {
+                            Text("Notes")
+                                .font(Theme.Typography.label)
+                                .foregroundStyle(Theme.Colors.textSecondary)
+                                .padding(.bottom, 6)
+
+                            ZStack(alignment: .topLeading) {
+                                if draftNotes.isEmpty && !notesFocused {
+                                    Text("Add a note…")
+                                        .font(Theme.Typography.body)
+                                        .foregroundStyle(Theme.Colors.textMuted)
+                                        .padding(.horizontal, 16)
+                                        .padding(.vertical, 16)
+                                        .allowsHitTesting(false)
+                                }
+                                TextEditor(text: $draftNotes)
+                                    .font(Theme.Typography.body)
+                                    .foregroundStyle(Theme.Colors.textPrimary)
+                                    .scrollContentBackground(.hidden)
+                                    .frame(minHeight: 80)
+                                    .focused($notesFocused)
+                                    .padding(12)
+                                    .onChange(of: draftNotes) { _, newValue in
+                                        entry.notes = newValue
+                                        entry.updatedAt = Date()
+                                        save()
+                                    }
+                            }
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(notesFocused
+                                        ? Theme.Colors.bgCard
+                                        : Theme.Colors.bgCard.opacity(0.5))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(
+                                                notesFocused
+                                                    ? Theme.Colors.accentPurple.opacity(0.3)
+                                                    : Theme.Colors.borderFaint,
+                                                lineWidth: 1
+                                            )
+                                    )
+                            )
+                            .padding(.bottom, 24)
+                        }
 
                         // MARK: Priority picker (inline, always visible)
                         VStack(alignment: .leading, spacing: 8) {
@@ -686,6 +697,126 @@ private struct CustomSnoozeSheet: View {
             }
         }
         .background(Theme.Colors.bgDeep)
+    }
+}
+
+// MARK: - List Items Editor
+
+private struct ListItemsEditor: View {
+    @Binding var content: String
+
+    private var items: [(index: Int, text: String, checked: Bool)] {
+        content.components(separatedBy: "\n").enumerated().compactMap { lineIndex, line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("- [x] ") {
+                return (lineIndex, String(trimmed.dropFirst(6)), true)
+            } else if trimmed.hasPrefix("- [ ] ") {
+                return (lineIndex, String(trimmed.dropFirst(6)), false)
+            } else if trimmed.hasPrefix("- ") {
+                return (lineIndex, String(trimmed.dropFirst(2)), false)
+            }
+            return nil
+        }
+    }
+
+    private var checkedCount: Int { items.filter { $0.checked }.count }
+    private var accent: Color { Theme.categoryColor(.list) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("Items")
+                    .font(Theme.Typography.label)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                Spacer()
+                if !items.isEmpty {
+                    Text("\(checkedCount)/\(items.count)")
+                        .font(Theme.Typography.badge)
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                }
+            }
+            .padding(.bottom, 10)
+
+            // Item rows
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(items, id: \.index) { item in
+                    Button {
+                        toggleItem(at: item.index, currentlyChecked: item.checked)
+                    } label: {
+                        HStack(alignment: .center, spacing: 12) {
+                            Image(systemName: item.checked ? "checkmark.circle.fill" : "circle")
+                                .font(.system(size: 22))
+                                .foregroundStyle(item.checked ? accent : Theme.Colors.textTertiary)
+
+                            Text(item.text)
+                                .font(Theme.Typography.body)
+                                .foregroundStyle(item.checked ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
+                                .strikethrough(item.checked, color: Theme.Colors.textTertiary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .lineLimit(3)
+                        }
+                        .padding(.vertical, 10)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+
+                    if item.index != items.last?.index {
+                        Rectangle()
+                            .fill(Theme.Colors.borderFaint)
+                            .frame(height: 0.5)
+                            .padding(.leading, 34)
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Theme.Colors.bgCard.opacity(0.5))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Theme.Colors.borderFaint, lineWidth: 1)
+                    )
+            )
+
+            // Progress bar
+            if !items.isEmpty {
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(Theme.Colors.borderSubtle)
+                            .frame(height: 3)
+                        Capsule()
+                            .fill(accent)
+                            .frame(
+                                width: geo.size.width * CGFloat(checkedCount) / CGFloat(items.count),
+                                height: 3
+                            )
+                            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: checkedCount)
+                    }
+                }
+                .frame(height: 3)
+                .padding(.top, 10)
+            }
+        }
+    }
+
+    private func toggleItem(at lineIndex: Int, currentlyChecked: Bool) {
+        var lines = content.components(separatedBy: "\n")
+        guard lineIndex < lines.count else { return }
+        let line = lines[lineIndex]
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if currentlyChecked {
+            lines[lineIndex] = line.replacingOccurrences(of: "- [x] ", with: "- [ ] ")
+        } else if trimmed.hasPrefix("- [ ] ") {
+            lines[lineIndex] = line.replacingOccurrences(of: "- [ ] ", with: "- [x] ")
+        } else if trimmed.hasPrefix("- ") {
+            lines[lineIndex] = line.replacingOccurrences(of: "- ", with: "- [x] ")
+        }
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.65)) {
+            content = lines.joined(separator: "\n")
+        }
     }
 }
 

--- a/Murmur/Views/Home/AllEntriesView.swift
+++ b/Murmur/Views/Home/AllEntriesView.swift
@@ -269,6 +269,7 @@ struct CategorySectionView: View {
                         ListCardView(
                             entry: peekEntry,
                             onAction: onAction,
+                            onTap: { onEntryTap(peekEntry) },
                             glowAccent: color,
                             glowIntensity: 1.0
                         )
@@ -310,6 +311,7 @@ struct CategorySectionView: View {
                                 isArrived: arrivedEntryIDs.contains(entry.id),
                                 category: category,
                                 onAction: onAction,
+                                onTap: { onEntryTap(entry) },
                                 onGlowComplete: { onGlowComplete(entry.id) }
                             )
                         }
@@ -381,6 +383,7 @@ private struct GlowingEntryRow: View {
     let isArrived: Bool
     let category: EntryCategory
     let onAction: (Entry, EntryAction) -> Void
+    var onTap: (() -> Void)?
     let onGlowComplete: () -> Void
 
     @State private var glowIntensity: Double = 0
@@ -392,6 +395,7 @@ private struct GlowingEntryRow: View {
                 ListCardView(
                     entry: entry,
                     onAction: onAction,
+                    onTap: onTap,
                     glowAccent: glowIntensity > 0 ? Theme.categoryColor(category) : nil,
                     glowIntensity: glowIntensity
                 )

--- a/Murmur/Views/Home/AllEntriesView.swift
+++ b/Murmur/Views/Home/AllEntriesView.swift
@@ -264,12 +264,23 @@ struct CategorySectionView: View {
 
             // Peek slot (collapsed section arrival preview)
             if isCollapsed && peekVisible, let peekEntry {
-                SmartListRow(
-                    entry: peekEntry,
-                    onAction: onAction,
-                    glowAccent: color,
-                    glowIntensity: 1.0
-                )
+                Group {
+                    if peekEntry.category == .list {
+                        ListCardView(
+                            entry: peekEntry,
+                            onAction: onAction,
+                            glowAccent: color,
+                            glowIntensity: 1.0
+                        )
+                    } else {
+                        SmartListRow(
+                            entry: peekEntry,
+                            onAction: onAction,
+                            glowAccent: color,
+                            glowIntensity: 1.0
+                        )
+                    }
+                }
                 .padding(.horizontal, 12)
                 .transition(.opacity.combined(with: .move(edge: .top)))
                 .onTapGesture {
@@ -376,12 +387,23 @@ private struct GlowingEntryRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        SmartListRow(
-            entry: entry,
-            onAction: onAction,
-            glowAccent: glowIntensity > 0 ? Theme.categoryColor(category) : nil,
-            glowIntensity: glowIntensity
-        )
+        Group {
+            if entry.category == .list {
+                ListCardView(
+                    entry: entry,
+                    onAction: onAction,
+                    glowAccent: glowIntensity > 0 ? Theme.categoryColor(category) : nil,
+                    glowIntensity: glowIntensity
+                )
+            } else {
+                SmartListRow(
+                    entry: entry,
+                    onAction: onAction,
+                    glowAccent: glowIntensity > 0 ? Theme.categoryColor(category) : nil,
+                    glowIntensity: glowIntensity
+                )
+            }
+        }
         .onChange(of: isArrived) { _, newValue in
             if newValue { triggerGlow() }
         }

--- a/Murmur/Views/Home/DamHomeView.swift
+++ b/Murmur/Views/Home/DamHomeView.swift
@@ -293,19 +293,38 @@ private struct ComposedSectionView: View {
                         ForEach(Array(items.enumerated()), id: \.element.id) { _, item in
                             switch item {
                             case .entry(let entry, let composed):
-                                ComposedEntryView(
-                                    entry: entry,
-                                    emphasis: composed.emphasis,
-                                    badge: composed.badge,
-                                    activeSwipeEntryID: $activeSwipeEntryID,
-                                    swipeActionsProvider: swipeActionsProvider,
-                                    onTap: { onEntryTap(entry) },
-                                    onAction: { onAction(entry, $0) }
-                                )
-                                .matchedGeometryEffect(id: "entry-\(composed.id)", in: layoutNamespace)
-                                .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                                .opacity(isEntryRevealed(composed.id) ? 1 : 0)
-                                .scaleEffect(isEntryRevealed(composed.id) ? 1 : 0.95)
+                                if entry.category == .list {
+                                    SwipeableCard(
+                                        actions: swipeActionsProvider(entry),
+                                        activeSwipeID: $activeSwipeEntryID,
+                                        entryID: entry.id,
+                                        onTap: { onEntryTap(entry) }
+                                    ) {
+                                        ListCardView(
+                                            entry: entry,
+                                            onAction: onAction
+                                        )
+                                    }
+                                    .padding(.horizontal, Theme.Spacing.screenPadding)
+                                    .matchedGeometryEffect(id: "entry-\(composed.id)", in: layoutNamespace)
+                                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                                    .opacity(isEntryRevealed(composed.id) ? 1 : 0)
+                                    .scaleEffect(isEntryRevealed(composed.id) ? 1 : 0.95)
+                                } else {
+                                    ComposedEntryView(
+                                        entry: entry,
+                                        emphasis: composed.emphasis,
+                                        badge: composed.badge,
+                                        activeSwipeEntryID: $activeSwipeEntryID,
+                                        swipeActionsProvider: swipeActionsProvider,
+                                        onTap: { onEntryTap(entry) },
+                                        onAction: { onAction(entry, $0) }
+                                    )
+                                    .matchedGeometryEffect(id: "entry-\(composed.id)", in: layoutNamespace)
+                                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                                    .opacity(isEntryRevealed(composed.id) ? 1 : 0)
+                                    .scaleEffect(isEntryRevealed(composed.id) ? 1 : 0.95)
+                                }
                             case .message(let text):
                                 ComposedMessageView(text: text)
                             }

--- a/Murmur/Views/Home/DamHomeView.swift
+++ b/Murmur/Views/Home/DamHomeView.swift
@@ -302,7 +302,8 @@ private struct ComposedSectionView: View {
                                     ) {
                                         ListCardView(
                                             entry: entry,
-                                            onAction: onAction
+                                            onAction: onAction,
+                                            onTap: { onEntryTap(entry) }
                                         )
                                     }
                                     .padding(.horizontal, Theme.Spacing.screenPadding)

--- a/Murmur/Views/Home/ZonedFocusHomeView.swift
+++ b/Murmur/Views/Home/ZonedFocusHomeView.swift
@@ -253,7 +253,8 @@ private struct ZonedFocusTabView: View {
                                         ) {
                                             ListCardView(
                                                 entry: item.entry,
-                                                onAction: onAction
+                                                onAction: onAction,
+                                                onTap: { onEntryTap(item.entry) }
                                             )
                                         }
                                         .transition(cardTransition)

--- a/Murmur/Views/Home/ZonedFocusHomeView.swift
+++ b/Murmur/Views/Home/ZonedFocusHomeView.swift
@@ -244,15 +244,30 @@ private struct ZonedFocusTabView: View {
                         VStack(spacing: 8) {
                             ForEach(zones.standard, id: \.entry.id) { item in
                                 if item.globalIndex < visibleCardCount {
-                                    StandardFocusCard(
-                                        entry: item.entry,
-                                        reason: item.reason,
-                                        activeSwipeEntryID: $activeSwipeEntryID,
-                                        swipeActionsProvider: swipeActionsProvider,
-                                        onAction: onAction,
-                                        onTap: { onEntryTap(item.entry) }
-                                    )
-                                    .transition(cardTransition)
+                                    if item.entry.category == .list {
+                                        SwipeableCard(
+                                            actions: swipeActionsProvider(item.entry),
+                                            activeSwipeID: $activeSwipeEntryID,
+                                            entryID: item.entry.id,
+                                            onTap: { onEntryTap(item.entry) }
+                                        ) {
+                                            ListCardView(
+                                                entry: item.entry,
+                                                onAction: onAction
+                                            )
+                                        }
+                                        .transition(cardTransition)
+                                    } else {
+                                        StandardFocusCard(
+                                            entry: item.entry,
+                                            reason: item.reason,
+                                            activeSwipeEntryID: $activeSwipeEntryID,
+                                            swipeActionsProvider: swipeActionsProvider,
+                                            onAction: onAction,
+                                            onTap: { onEntryTap(item.entry) }
+                                        )
+                                        .transition(cardTransition)
+                                    }
                                 }
                             }
                         }

--- a/Murmur/Views/RootView.swift
+++ b/Murmur/Views/RootView.swift
@@ -579,6 +579,10 @@ private extension RootView {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             entry.perform(.checkOffHabit, in: modelContext, preferences: notifPrefs)
 
+        case .toggleListItem(let index):
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            entry.perform(.toggleListItem(index: index), in: modelContext, preferences: notifPrefs)
+
         case .snooze(nil):
             snoozeEntry = entry
             showSnoozeDialog = true

--- a/Packages/MurmurCore/Sources/MurmurCore/AgentTypes.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/AgentTypes.swift
@@ -154,6 +154,24 @@ public struct UpdateMemoryAction: Sendable {
     }
 }
 
+/// Action to update list items on an existing list entry.
+public struct UpdateListItemsAction: Sendable {
+    public let id: String
+    public let items: [(text: String, checked: Bool)]
+
+    public init(id: String, items: [(text: String, checked: Bool)]) {
+        self.id = id
+        self.items = items
+    }
+
+    /// Serialize list items to markdown checkbox format.
+    public static func serializeToMarkdown(_ items: [(text: String, checked: Bool)]) -> String {
+        items.map { item in
+            "- [\(item.checked ? "x" : " ")] \(item.text)"
+        }.joined(separator: "\n")
+    }
+}
+
 /// Proposed actions awaiting user confirmation.
 public struct ConfirmationRequest: Sendable {
     public let message: String
@@ -169,6 +187,7 @@ public struct ConfirmationRequest: Sendable {
 public enum AgentAction: Sendable {
     case create(CreateAction)
     case update(UpdateAction)
+    case updateListItems(UpdateListItemsAction)
     case complete(CompleteAction)
     case archive(ArchiveAction)
     case updateMemory(UpdateMemoryAction)
@@ -183,10 +202,11 @@ public extension AgentAction {
         return false
     }
 
-    /// The entry ID targeted by a mutation action (update/complete/archive), or nil for creates/other.
+    /// The entry ID targeted by a mutation action (update/updateListItems/complete/archive), or nil for creates/other.
     var mutationEntryID: String? {
         switch self {
         case .update(let a): return a.id
+        case .updateListItems(let a): return a.id
         case .complete(let a): return a.id
         case .archive(let a): return a.id
         default: return nil

--- a/Packages/MurmurCore/Sources/MurmurCore/LLMPrompt.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/LLMPrompt.swift
@@ -25,6 +25,7 @@ public struct LLMPrompt: @unchecked Sendable {
             Your job is to decide which actions to take using tools:
             - create_entries: add genuinely new entries
             - update_entries: modify existing entry fields (including snooze via status + snooze_until)
+            - update_list_items: manage checklist items on list entries
             - complete_entries: mark entries done
             - archive_entries: remove no-longer-relevant entries
 
@@ -47,6 +48,11 @@ public struct LLMPrompt: @unchecked Sendable {
             - For habits, set cadence to daily/weekdays/weekly/monthly when clear.
             - Priority 1-5 (1=highest). Default 3 unless words signal urgency ("urgent", "ASAP", "critical" → 1-2) or low importance ("whenever", "someday" → 4-5).
             - Do not include urgency words in content when priority captures urgency.
+            - For list entries, format content as markdown checkboxes: "- [ ] item" or "- [x] item".
+
+            List entry rules:
+            - For list entries, use update_list_items to manage checklist items. Format each item with text and checked status.
+            - Use update_list_items instead of update_entries when modifying list items.
 
             Mutation rules:
             - Every update/complete/archive item must include a short reason.
@@ -78,6 +84,7 @@ public struct LLMPrompt: @unchecked Sendable {
         tools: [
             createEntriesToolSchema(),
             updateEntriesToolSchema(),
+            updateListItemsToolSchema(),
             completeEntriesToolSchema(),
             archiveEntriesToolSchema(),
             updateMemoryToolSchema(),
@@ -270,6 +277,37 @@ private extension LLMPrompt {
                         ] as [String: Any],
                     ],
                     "required": ["updates"],
+                ] as [String: Any],
+            ] as [String: Any],
+        ]
+    }
+
+    static func updateListItemsToolSchema() -> [String: Any] {
+        [
+            "type": "function",
+            "function": [
+                "name": "update_list_items",
+                "description": "Update the items in a list entry. Use this instead of update_entries when modifying list items.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "entry_id": [
+                            "type": "string",
+                            "description": "ID of the list entry to update",
+                        ],
+                        "items": [
+                            "type": "array",
+                            "items": [
+                                "type": "object",
+                                "properties": [
+                                    "text": ["type": "string"],
+                                    "checked": ["type": "boolean"],
+                                ] as [String: Any],
+                                "required": ["text", "checked"],
+                            ] as [String: Any],
+                        ] as [String: Any],
+                    ],
+                    "required": ["entry_id", "items"],
                 ] as [String: Any],
             ] as [String: Any],
         ]
@@ -483,7 +521,8 @@ private extension LLMPrompt {
                                 "properties": [
                                     "tool": [
                                         "type": "string",
-                                        "enum": ["create_entries", "update_entries", "complete_entries", "archive_entries"],
+                                        "enum": ["create_entries", "update_entries", "update_list_items",
+                                                 "complete_entries", "archive_entries"],
                                         "description": "Which tool to call if confirmed",
                                     ],
                                     "arguments": [

--- a/Packages/MurmurCore/Sources/MurmurCore/PPQTypes.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/PPQTypes.swift
@@ -264,6 +264,21 @@ struct UpdateMemoryArguments: Decodable {
     let content: String
 }
 
+struct UpdateListItemsArguments: Decodable {
+    let entryId: String
+    let items: [ListItemArgument]
+
+    struct ListItemArgument: Decodable {
+        let text: String
+        let checked: Bool
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case entryId = "entry_id"
+        case items
+    }
+}
+
 struct RawEntryMutation: Decodable {
     let id: String
     let reason: String?

--- a/Packages/MurmurCore/Sources/MurmurCore/ToolCallParser.swift
+++ b/Packages/MurmurCore/Sources/MurmurCore/ToolCallParser.swift
@@ -44,6 +44,14 @@ public enum ToolCallParser {
                 let wrapper = try JSONDecoder().decode(UpdateEntriesArguments.self, from: argumentsData)
                 actions = wrapper.updates.map { .update($0.asAction) }
 
+            case "update_list_items":
+                let wrapper = try JSONDecoder().decode(UpdateListItemsArguments.self, from: argumentsData)
+                let items = wrapper.items.map { (text: $0.text, checked: $0.checked) }
+                actions = [.updateListItems(UpdateListItemsAction(
+                    id: wrapper.entryId,
+                    items: items
+                ))]
+
             case "complete_entries":
                 let wrapper = try JSONDecoder().decode(EntryMutationArguments.self, from: argumentsData)
                 actions = wrapper.entries.map {
@@ -158,6 +166,13 @@ public enum ToolCallParser {
                 case "update_entries":
                     let wrapper = try JSONDecoder().decode(UpdateEntriesArguments.self, from: data)
                     result.append(contentsOf: wrapper.updates.map { .update($0.asAction) })
+                case "update_list_items":
+                    let wrapper = try JSONDecoder().decode(UpdateListItemsArguments.self, from: data)
+                    let items = wrapper.items.map { (text: $0.text, checked: $0.checked) }
+                    result.append(.updateListItems(UpdateListItemsAction(
+                        id: wrapper.entryId,
+                        items: items
+                    )))
                 case "complete_entries":
                     let wrapper = try JSONDecoder().decode(EntryMutationArguments.self, from: data)
                     result.append(contentsOf: wrapper.entries.map {
@@ -186,7 +201,11 @@ public enum ToolCallParser {
 
         let labels: [(String, Int)] = [
             ("created", actions.filter { if case .create = $0 { return true }; return false }.count),
-            ("updated", actions.filter { if case .update = $0 { return true }; return false }.count),
+            ("updated", actions.filter {
+                if case .update = $0 { return true }
+                if case .updateListItems = $0 { return true }
+                return false
+            }.count),
             ("completed", actions.filter { if case .complete = $0 { return true }; return false }.count),
             ("archived", actions.filter { if case .archive = $0 { return true }; return false }.count),
         ]


### PR DESCRIPTION
## Summary
- New `update_list_items` LLM tool that takes structured JSON items and serializes to markdown checkboxes in the entry's `content` field
- New `ListCardView` component with expand/collapse and checkable items
- Collapsed: shows title + compact preview + item count + chevron
- Expanded: shows all items as tappable checkbox rows with progress bar
- Wired into ZonedFocusHomeView, AllEntriesView, and DamHomeView
- New `EntryAction.toggleListItem(index:)` for local checkbox toggling with haptic feedback

## Thinking
Lists are one of Murmur's core categories but had no custom UI — they rendered the same as every other entry type. Habits already have custom rendering (checkable circles), so lists deserved the same treatment.

The key design decision was the **middle ground approach**: the LLM sends structured data via a typed tool (`update_list_items`), but we serialize to markdown checkboxes in the `content` field. This gives us structured tool interface (LLM can't corrupt formatting) with simple storage (no model migration, no new SwiftData fields). Easy to upgrade to a proper sub-model later if needed.

## Test plan
- [ ] Create a list entry via voice ("make a grocery list: eggs, bread, butter, milk")
- [ ] Verify list renders collapsed in Zones view with preview text and count
- [ ] Tap to expand — verify all items show as checkable rows
- [ ] Tap checkboxes — verify items toggle with haptic feedback and strikethrough
- [ ] Verify progress bar updates correctly
- [ ] Collapse the list — verify it returns to compact view
- [ ] Voice command to check off items ("check off eggs from my grocery list")
- [ ] Verify list appears correctly in AllEntriesView and DamHomeView

🤖 Generated with [Claude Code](https://claude.com/claude-code)