### PR TITLE
ci: TestFlight release pipeline (main → internal, tags → external)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,189 @@
+# TestFlight release pipeline.
+#
+# Two release lanes:
+#   - Push to main         → internal TestFlight (continuous; team dogfoods)
+#   - Push tag (v1.2.3)    → external TestFlight (requires manual ASC submission)
+#
+# Both lanes upload to the same TestFlight via the same job. Internal vs external
+# is configured ONCE in App Store Connect (auto-distribute new builds to internal
+# group; external assignment + beta review stays manual after a tag build lands).
+#
+# Setup steps (one-time, outside CI) are documented in meta/TESTFLIGHT_CI_SETUP.md.
+#
+# Required GitHub secrets:
+#   APPLE_TEAM_ID                       Apple Developer Team ID (10-char)
+#   ASC_API_KEY_ID                      App Store Connect API key ID
+#   ASC_API_ISSUER_ID                   App Store Connect issuer UUID
+#   ASC_API_KEY_P8                      Full contents of AuthKey_*.p8 (text)
+#   PPQ_API_KEY                         PPQ.ai API key (baked into Info.plist)
+#   STUDIO_ANALYTICS_API_KEY_RELEASE    Studio Analytics key for Release config
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
+
+      - name: Cache Homebrew packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/xcodegen
+            /opt/homebrew/Cellar/xcbeautify
+          key: brew-${{ runner.os }}-xcodegen-xcbeautify
+
+      - name: Install tools
+        run: brew install xcodegen xcbeautify
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Tag '$TAG' does not match v<major>.<minor>.<patch>"
+              exit 1
+            fi
+            VERSION="${TAG#v}"
+            echo "marketing_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "lane=external" >> "$GITHUB_OUTPUT"
+            echo "Release lane: external (tag $TAG → MARKETING_VERSION=$VERSION)"
+          else
+            echo "marketing_version=" >> "$GITHUB_OUTPUT"
+            echo "lane=internal" >> "$GITHUB_OUTPUT"
+            echo "Release lane: internal (using MARKETING_VERSION from project.yml)"
+          fi
+          echo "Build number: ${{ github.run_number }}"
+
+      - name: Configure project.local.yml
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PPQ_API_KEY: ${{ secrets.PPQ_API_KEY }}
+          STUDIO_ANALYTICS_API_KEY_RELEASE: ${{ secrets.STUDIO_ANALYTICS_API_KEY_RELEASE }}
+        run: |
+          if [ -z "$APPLE_TEAM_ID" ]; then
+            echo "::error::APPLE_TEAM_ID secret not set"
+            exit 1
+          fi
+          cat > project.local.yml << EOF
+          settings:
+            base:
+              DEVELOPMENT_TEAM: $APPLE_TEAM_ID
+              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.damsac.murmur
+              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.damsac.murmur.tests
+              APP_GROUP_IDENTIFIER: group.com.damsac.murmur.shared
+              PPQ_API_KEY: "$PPQ_API_KEY"
+            configs:
+              Release:
+                STUDIO_ANALYTICS_ENDPOINT: "https://damsac.studio"
+                STUDIO_ANALYTICS_API_KEY: "$STUDIO_ANALYTICS_API_KEY_RELEASE"
+          EOF
+
+      - name: Materialize ASC API key
+        env:
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          if [ -z "$ASC_API_KEY_P8" ]; then
+            echo "::error::ASC_API_KEY_P8 secret not set"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          printf '%s' "$ASC_API_KEY_P8" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Generate Xcode project
+        run: make generate
+
+      - name: Write ExportOptions.plist
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store-connect</string>
+            <key>destination</key>
+            <string>upload</string>
+            <key>signingStyle</key>
+            <string>automatic</string>
+            <key>teamID</key>
+            <string>$APPLE_TEAM_ID</string>
+            <key>uploadSymbols</key>
+            <true/>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Archive
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MARKETING_VERSION_OVERRIDE: ${{ steps.version.outputs.marketing_version }}
+        run: |
+          BUILD_SETTINGS=(
+            "CODE_SIGN_STYLE=Automatic"
+            "CODE_SIGN_IDENTITY=Apple Distribution"
+            "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
+            "CURRENT_PROJECT_VERSION=${{ github.run_number }}"
+          )
+          if [ -n "$MARKETING_VERSION_OVERRIDE" ]; then
+            BUILD_SETTINGS+=("MARKETING_VERSION=$MARKETING_VERSION_OVERRIDE")
+          fi
+          set -o pipefail && xcodebuild archive \
+            -project Murmur.xcodeproj \
+            -scheme Murmur \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/Murmur.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "$ASC_API_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_API_ISSUER_ID" \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+            "${BUILD_SETTINGS[@]}" \
+            | xcbeautify
+
+      - name: Export and upload to TestFlight
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: |
+          set -o pipefail && xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Murmur.xcarchive" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "$ASC_API_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_API_ISSUER_ID" \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+            | xcbeautify
+
+      - name: Upload archive artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Murmur-${{ steps.version.outputs.lane }}-${{ github.run_number }}
+          path: ${{ runner.temp }}/Murmur.xcarchive
+          retention-days: 30
+
+      - name: Clean up API key
+        if: ${{ always() }}
+        run: rm -f "$RUNNER_TEMP/private_keys/AuthKey.p8"

--- a/docs/superpowers/specs/2026-04-28-testflight-release-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-28-testflight-release-pipeline-design.md
@@ -1,0 +1,174 @@
+# TestFlight Release Pipeline — Design
+
+**Date:** 2026-04-28
+**Status:** Approved
+**Replaces:** scaffold in PR #126 (`pr/dam/ci-archive`)
+
+## Goal
+
+Push code, get a TestFlight build. No App Store deployment yet.
+
+Two release lanes:
+
+- **Main push** → internal TestFlight (continuous; team dogfoods every commit)
+- **Tag push** (`v*`) → external TestFlight (curated; gets submitted for Apple Beta Review and assigned to external testers)
+
+Both lanes upload to the same TestFlight via the same job. The internal-vs-external split is configured **once in App Store Connect** (auto-distribute new builds to the internal group). External assignment + beta review submission stays a manual click in ASC after a tag build lands.
+
+## Non-goals
+
+- App Store production releases.
+- Automated external beta review submission. (Future improvement once the pipeline is stable.)
+- Manual signing with imported `.p12` cert + `.mobileprovision` profile. (Replaced by ASC API key + automatic signing.)
+- Per-PR build pipeline. (Existing `ci.yml` runs tests on PR; this workflow only fires on `main` and tags.)
+
+## Trigger model
+
+Single workflow file `.github/workflows/release.yml` (renamed from the existing `ci-archive.yml`):
+
+```yaml
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+```
+
+Inside the job, branch on `github.ref`:
+
+- `refs/heads/main` → main path
+- `refs/tags/v*` → tag path
+
+The two paths share all build, sign, and upload steps. The only differences:
+
+- `MARKETING_VERSION` derivation
+- Optional ASC build description / "What to test" notes (out of scope for v1)
+
+## Versioning
+
+### Build number
+
+`CURRENT_PROJECT_VERSION = ${{ github.run_number }}` for both paths.
+
+`github.run_number` is monotonic across every run of this workflow regardless of trigger, so no two builds can collide on `(MARKETING_VERSION, CURRENT_PROJECT_VERSION)`. TestFlight rejects duplicates; this scheme makes that impossible.
+
+### Marketing version
+
+- **Main push** → reads `MARKETING_VERSION` from `project.yml` (currently `1.0.0`). Bump in source when you want main builds to track a new version.
+- **Tag push** (`v1.2.3`) → workflow parses tag, strips leading `v`, exports `MARKETING_VERSION=1.2.3` at xcodebuild invocation time. `project.yml` is **not** edited.
+
+Tags are independent of `project.yml`. You do not need to keep them in sync.
+
+Tag pattern is `v*` for the trigger filter; the parser uses a stricter regex (`^v\d+\.\d+\.\d+$`) and fails the build if the tag doesn't match. (Pre-release tags like `v1.2.3-beta.1` are out of scope; we'll add them only when needed.)
+
+## Signing & upload
+
+### Approach
+
+App Store Connect API key with **automatic signing** via `-allowProvisioningUpdates`. Apple cloud-manages the Distribution cert and the App Store provisioning profile. The same API key handles the TestFlight upload via `altool`.
+
+### Secrets
+
+Stored in GitHub Settings → Secrets and variables → Actions:
+
+| Secret | Purpose |
+|---|---|
+| `APPLE_TEAM_ID` | 10-character team identifier |
+| `ASC_API_KEY_ID` | Key ID from App Store Connect |
+| `ASC_API_ISSUER_ID` | Issuer UUID for the team |
+| `ASC_API_KEY_P8` | Full contents of the `AuthKey_*.p8` file (text, not base64) |
+| `PPQ_API_KEY` | Baked into Info.plist as `PPQAPIKey` |
+| `STUDIO_ANALYTICS_API_KEY_RELEASE` | `sk_murmur`, used by Release config only |
+
+### Build flow
+
+1. **Generate `project.local.yml` from secrets.** Sets `DEVELOPMENT_TEAM`, bundle IDs, app group, `PPQ_API_KEY`, and the `Release` config's `STUDIO_ANALYTICS_ENDPOINT` + `STUDIO_ANALYTICS_API_KEY`. `Debug` config left empty (CI doesn't run Debug builds for release).
+2. **`make generate`** — XcodeGen produces `Murmur.xcodeproj`.
+3. **Materialize the API key** to a temp `.p8` file from `ASC_API_KEY_P8`.
+4. **`xcodebuild archive`** with:
+   - `-project Murmur.xcodeproj -scheme Murmur`
+   - `-destination 'generic/platform=iOS'`
+   - `-archivePath $RUNNER_TEMP/Murmur.xcarchive`
+   - `-allowProvisioningUpdates`
+   - `-authenticationKeyID $ASC_API_KEY_ID`
+   - `-authenticationKeyIssuerID $ASC_API_ISSUER_ID`
+   - `-authenticationKeyPath $RUNNER_TEMP/AuthKey.p8`
+   - `CODE_SIGN_STYLE=Automatic`
+   - `CODE_SIGN_IDENTITY="Apple Distribution"`
+   - `DEVELOPMENT_TEAM=$APPLE_TEAM_ID`
+   - `MARKETING_VERSION=$VERSION` (parsed from tag, or omitted on main path)
+   - `CURRENT_PROJECT_VERSION=${{ github.run_number }}`
+   - Piped through `xcbeautify`
+5. **`xcodebuild -exportArchive`** with an `ExportOptions.plist` containing:
+   ```xml
+   method: app-store-connect
+   destination: upload
+   signingStyle: automatic
+   teamID: $APPLE_TEAM_ID
+   ```
+   Note: with `destination: upload`, `xcodebuild` itself uploads to TestFlight using the supplied API key — no separate `altool` step needed. (Confirmed in implementation; if `destination: upload` proves flaky, fall back to `destination: export` + explicit `xcrun altool --upload-app`.)
+6. **Upload `.xcarchive` as Actions artifact** for 30-day retention. Useful for replay/debugging signing failures.
+
+### Project changes required outside CI
+
+`project.yml` currently has:
+
+```yaml
+CODE_SIGN_STYLE: Automatic
+CODE_SIGN_IDENTITY: "Apple Development"
+```
+
+The `CODE_SIGN_IDENTITY` value is fine for local Debug builds but is overridden in CI by xcodebuild flags. **No edit needed to `project.yml`.**
+
+### What gets removed from PR #126's scaffold
+
+- Conditional "build unsigned if no secrets" branch (the workflow now requires real secrets and hard-fails without them — cleaner than silent fallback)
+- `.p12` certificate import step
+- `.mobileprovision` profile import step
+- Keychain creation, unlock, and cleanup steps
+- `xcrun altool --upload-app` separate step (folded into `xcodebuild -exportArchive` with `destination: upload`)
+
+The workflow gets noticeably shorter.
+
+## Prerequisites (one-time, outside CI)
+
+These must be done before the first CI run will succeed:
+
+1. **Apple Developer Portal** — register `group.com.damsac.murmur.shared` as an App Group capability on the App ID `com.damsac.murmur`. Without this, automatic provisioning fails because the requested entitlements don't match what the App ID allows. (Already flagged in `meta/TESTFLIGHT_CHECKLIST.md` item #14.)
+2. **App Store Connect** — generate an API key with **App Manager** role (Developer role cannot sign for distribution). Save the `.p8` file immediately — Apple does not allow re-downloading it.
+3. **App Store Connect** — configure the internal test group to "auto-distribute new builds" so internal testers get every uploaded build automatically.
+4. **GitHub** — add the six secrets listed above to the repository.
+
+A `meta/TESTFLIGHT_CI_SETUP.md` doc captures these steps so they're not lost.
+
+## Failure modes & responses
+
+| Failure | Likely cause | Response |
+|---|---|---|
+| `xcodebuild archive` fails with provisioning error | App Group not registered on App ID | Register in Developer Portal (prereq #1) |
+| Upload rejected: duplicate build number | Should be impossible with `github.run_number`, but if a re-run somehow collides | Manually re-trigger the workflow with `workflow_dispatch` (not in scope yet) or push a no-op commit |
+| Upload rejected: marketing version regression | Tag pushed with version lower than what's in TestFlight | Push a higher tag; old tags can't be re-released |
+| ASC API key revoked or expired | Apple revokes keys after team-level changes | Generate a new key, update `ASC_API_KEY_P8`/`ASC_API_KEY_ID` |
+| Tag doesn't match `^v\d+\.\d+\.\d+$` | Typo in tag | Workflow fails fast in the version-parse step before any build work; delete tag and re-push |
+
+## Test plan
+
+- Set the six secrets in GitHub.
+- Run prereqs #1–3 (App Group, ASC API key, internal auto-distribute).
+- Push a no-op commit to `main` → verify a build appears in TestFlight, build number = run number, marketing version = `1.0.0` (from `project.yml`).
+- Push a tag `v1.0.1` → verify a second build appears in TestFlight, build number > previous, marketing version = `1.0.1`.
+- In ASC, manually submit the tag build for external beta review and assign to external group → verify the external tester flow.
+
+## Open questions
+
+None — design is complete enough to write the implementation plan.
+
+## Files
+
+- New / modified:
+  - `.github/workflows/release.yml` (rewritten from `ci-archive.yml`)
+  - `meta/TESTFLIGHT_CI_SETUP.md` (new — captures the one-time prereqs)
+- Deleted:
+  - `.github/workflows/ci-archive.yml` (renamed to `release.yml`)
+- Untouched:
+  - `project.yml` — no edits needed; xcodebuild flags override signing for CI
+  - Existing `ci.yml`, `ci-lint.yml`, `pages.yml` — unchanged

--- a/meta/TESTFLIGHT_CI_SETUP.md
+++ b/meta/TESTFLIGHT_CI_SETUP.md
@@ -1,0 +1,84 @@
+# TestFlight CI Setup
+
+One-time prerequisites for the `Release` workflow (`.github/workflows/release.yml`).
+Once these are done, pushing to `main` ships an internal TestFlight build and
+pushing a `v*` tag ships a build that's ready for external beta review.
+
+## 1. Register App Group capability on the App ID
+
+The app uses the App Group `group.com.damsac.murmur.shared` for sharing data
+between the app and any future extensions. Automatic provisioning will fail
+unless this is registered as a capability on the App ID itself.
+
+1. Open [Apple Developer → Identifiers](https://developer.apple.com/account/resources/identifiers/list).
+2. Find the App ID `com.damsac.murmur` (create it if missing).
+3. Edit → check **App Groups** under Capabilities → Configure → add
+   `group.com.damsac.murmur.shared`.
+4. Save.
+
+## 2. Generate an App Store Connect API key
+
+You'll need this for both signing (Apple cloud-generates the Distribution
+cert and provisioning profile on demand) and the TestFlight upload.
+
+1. Open [App Store Connect → Users and Access → Integrations → App Store
+   Connect API](https://appstoreconnect.apple.com/access/integrations/api).
+2. Generate a new key. **Role: App Manager.** (Developer cannot sign for
+   distribution.)
+3. Download the `.p8` file immediately — Apple will not let you download it
+   again. Note the **Key ID** and the **Issuer ID** shown on the page.
+
+## 3. Configure auto-distribution to internal testers
+
+1. Open the Murmur app in App Store Connect.
+2. TestFlight tab → Internal Testing → your group.
+3. Enable **automatic distribution** so internal testers get every uploaded
+   build immediately.
+
+External testers stay manual: after a tag-triggered build lands in TestFlight,
+go to the build, add it to the external group, and submit for Beta App Review.
+
+## 4. Add GitHub repository secrets
+
+[Settings → Secrets and variables → Actions](https://github.com/damsac/Murmur/settings/secrets/actions)
+on the repository. Add each as a "Repository secret":
+
+| Secret | Value |
+|---|---|
+| `APPLE_TEAM_ID` | 10-character team ID (e.g., `ABCD123456`). Find at [Apple Developer → Membership](https://developer.apple.com/account#MembershipDetailsCard). |
+| `ASC_API_KEY_ID` | Key ID from step 2 (e.g., `2X9YPDMS47`). |
+| `ASC_API_ISSUER_ID` | Issuer UUID from step 2. |
+| `ASC_API_KEY_P8` | **Full contents** of the `.p8` file from step 2. Paste the file as text, including the `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines. Do not base64-encode. |
+| `PPQ_API_KEY` | The PPQ.ai key that production builds should use. |
+| `STUDIO_ANALYTICS_API_KEY_RELEASE` | `sk_murmur` (the Release-config Studio Analytics key). |
+
+## 5. Verify
+
+Push a no-op commit to `main`. Watch the Release workflow run in
+[GitHub Actions](https://github.com/damsac/Murmur/actions/workflows/release.yml).
+A new build should appear in App Store Connect → TestFlight within a few
+minutes of the workflow completing. Internal testers get it automatically.
+
+To ship to externals, push a tag:
+
+```bash
+git tag v1.0.1
+git push origin v1.0.1
+```
+
+The build will land in TestFlight with `MARKETING_VERSION=1.0.1`. Open it in
+ASC, add the external group, and submit for Beta App Review.
+
+## Troubleshooting
+
+- **"No profiles for ... were found"** — App Group capability not registered
+  on the App ID (step 1) or the API key role is too low (step 2).
+- **"Invalid version number"** — TestFlight rejects a build whose
+  `MARKETING_VERSION + CURRENT_PROJECT_VERSION` already exists. Build numbers
+  come from `github.run_number` so collisions are impossible from CI; if you
+  see this, you likely uploaded a colliding build manually from a laptop.
+- **"Authentication failed"** on `xcodebuild` — the `.p8` was pasted with
+  trailing whitespace stripped or BEGIN/END lines missing. Re-paste the
+  entire file verbatim.
+- **Workflow fails on tag push with "Tag does not match v<major>.<minor>.<patch>"** —
+  use a strict semver tag (`v1.0.0`, not `v1.0` or `release-1.0.0`).


### PR DESCRIPTION
## Summary

Replaces the unsigned-archive scaffold with a real TestFlight upload workflow.

- **Push to `main`** → internal TestFlight (continuous; team dogfoods every commit)
- **Push tag `v1.2.3`** → external TestFlight (curated; gets submitted for Apple Beta Review manually in ASC)
- Single ASC API key handles both signing (`-allowProvisioningUpdates`) and upload (`xcodebuild -exportArchive` with `destination: upload`)
- Build number from `github.run_number` — monotonic across every trigger so TestFlight collisions are impossible
- Tag parser strips leading `v`, fails fast on non-semver tags
- `meta/TESTFLIGHT_CI_SETUP.md` captures the one-time prereqs

## Thinking

The original PR sketched manual signing (import `.p12` cert + `.mobileprovision`). Since dam hasn't shipped from his laptop yet, there's no reason to drag sac's local cert into a secret-sharing dance. ASC API key + automatic signing means dam is the source of truth for releases, and onboarding future contributors needs no cert plumbing — they just need GitHub access.

The internal/external split is configured **once in App Store Connect** (auto-distribute new builds to internal group; external assignment + beta review stays manual). The CI doesn't enforce the split — it just controls what `MARKETING_VERSION` ships and treats main builds and tag builds identically at the upload layer. External submission stays a manual click in ASC, which is a feature: it's the checkpoint where you confirm release notes and "what to test" copy before flipping it to externals.

Design doc: [`docs/superpowers/specs/2026-04-28-testflight-release-pipeline-design.md`](https://github.com/damsac/Murmur/blob/main/docs/superpowers/specs/2026-04-28-testflight-release-pipeline-design.md)

## Required GitHub secrets

(See `meta/TESTFLIGHT_CI_SETUP.md` for full instructions.)

| Secret | Purpose |
|---|---|
| `APPLE_TEAM_ID` | 10-character team ID |
| `ASC_API_KEY_ID` | App Store Connect API key ID |
| `ASC_API_ISSUER_ID` | App Store Connect issuer UUID |
| `ASC_API_KEY_P8` | Full contents of `AuthKey_*.p8` (text, not base64) |
| `PPQ_API_KEY` | Baked into Info.plist |
| `STUDIO_ANALYTICS_API_KEY_RELEASE` | `sk_murmur` for Release config |

## One-time prereqs (outside CI)

1. Register `group.com.damsac.murmur.shared` as an App Group capability on the App ID `com.damsac.murmur` in the Developer Portal
2. Generate an ASC API key with **App Manager** role; save the `.p8` immediately
3. Configure the internal test group in ASC to auto-distribute new builds
4. Add the six secrets above to repository secrets

## Test plan

- [ ] Set the six secrets in GitHub
- [ ] Complete the one-time prereqs
- [ ] Merge this PR → first push to main triggers the workflow → verify a build lands in TestFlight with `MARKETING_VERSION=1.0.0`, build number = run_number
- [ ] Internal testers receive it automatically (verify in TestFlight on a device)
- [ ] Push tag `v1.0.1` → verify second build lands with `MARKETING_VERSION=1.0.1`, higher build number
- [ ] In ASC, manually submit the tag build for external beta review and assign to external group