### PR TITLE
docs: add privacy policy for TestFlight external testing

### DIFF
--- a/mockups/privacy.html
+++ b/mockups/privacy.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Murmur — Privacy Policy</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      max-width: 680px;
+      margin: 60px auto;
+      padding: 0 24px 80px;
+      color: #1a1a1a;
+      line-height: 1.7;
+    }
+    h1 { font-size: 2rem; margin-bottom: 4px; }
+    h2 { font-size: 1.1rem; margin-top: 36px; margin-bottom: 8px; }
+    p, li { font-size: 0.97rem; color: #333; }
+    ul { padding-left: 20px; }
+    .updated { color: #888; font-size: 0.88rem; margin-bottom: 40px; }
+    a { color: #007aff; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p class="updated">Last updated: March 28, 2026</p>
+
+  <p>Murmur ("we", "our", or "the app") is a voice-to-structured-data iOS application. This policy explains what data we collect, how we use it, and your rights.</p>
+
+  <h2>Data We Collect</h2>
+  <ul>
+    <li><strong>Voice recordings:</strong> When you use the microphone, audio is captured and transcribed on-device using Apple's Speech Recognition framework. We do not store raw audio recordings.</li>
+    <li><strong>Transcribed text and entries:</strong> The text produced from your voice input is stored locally on your device and used to generate structured entries via a third-party language model (PPQ.ai / Anthropic Claude).</li>
+    <li><strong>Usage data:</strong> We collect anonymous token usage counts to support the credit system. No personally identifiable information is attached to this data.</li>
+  </ul>
+
+  <h2>Data We Do Not Collect</h2>
+  <ul>
+    <li>We do not collect your name, email address, or any account information.</li>
+    <li>We do not sell or share your data with advertisers.</li>
+    <li>We do not track you across other apps or websites.</li>
+  </ul>
+
+  <h2>Third-Party Services</h2>
+  <p>Murmur sends transcribed text to <a href="https://ppq.ai">PPQ.ai</a> to process language model requests. This text may be processed by Anthropic's Claude models. Please review <a href="https://www.anthropic.com/privacy">Anthropic's Privacy Policy</a> for details on how they handle API data.</p>
+
+  <h2>Data Storage</h2>
+  <p>All entries and app data are stored locally on your device. We do not operate servers that store your personal data.</p>
+
+  <h2>Permissions</h2>
+  <ul>
+    <li><strong>Microphone:</strong> Required to capture voice input. Only active when you initiate a recording.</li>
+    <li><strong>Speech Recognition:</strong> Used to transcribe your voice locally via Apple's framework.</li>
+    <li><strong>Notifications:</strong> Optional. Used only to deliver reminders you set within the app.</li>
+  </ul>
+
+  <h2>Children's Privacy</h2>
+  <p>Murmur is not directed at children under 13. We do not knowingly collect data from children.</p>
+
+  <h2>Changes to This Policy</h2>
+  <p>We may update this policy as the app evolves. Continued use of the app after changes constitutes acceptance of the updated policy.</p>
+
+  <h2>Contact</h2>
+  <p>Questions? Reach us at <a href="mailto:hello@damsac.com">hello@damsac.com</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Thinking

Needed for external TestFlight — Apple requires a live public URL. Used the existing GitHub Pages setup (deploys from `mockups/`) so no new infrastructure needed.

## Summary

- Adds `mockups/privacy.html` — a simple, accurate privacy policy
- Covers: microphone/speech permissions, local storage, PPQ.ai/Anthropic as third-party processor, no account data collected
- Will be live at `https://damsac.github.io/Murmur/privacy.html` after merge

## Test plan

- [ ] Merge → verify GitHub Pages deploys and URL is publicly accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)