### PR TITLE
fix: TestFlight build errors + three post-launch bugs

### DIFF
--- a/Murmur/DevMode/DevModeView.swift
+++ b/Murmur/DevMode/DevModeView.swift
@@ -125,8 +125,10 @@ struct DevModeView: View {
                         // Drain Credits
                         Button {
                             Task { @MainActor in
+                                #if DEBUG
                                 await appState.creditGate?.setBalance(0)
                                 await appState.refreshCreditBalance()
+                                #endif
                             }
                         } label: {
                             HStack(spacing: 8) {

--- a/Murmur/Info.plist
+++ b/Murmur/Info.plist
@@ -39,6 +39,8 @@
 	<string>$(STUDIO_ANALYTICS_ENDPOINT)</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Murmur/Views/Home/ZonedFocusHomeView.swift
+++ b/Murmur/Views/Home/ZonedFocusHomeView.swift
@@ -210,12 +210,19 @@ private struct ZonedFocusTabView: View {
                     FocusLoadingView()
                         .transition(.opacity)
                 } else if let composition {
+                    let zones = zoneItems(composition: composition)
+                    let hasFocusItems = zones.hero != nil || !zones.standard.isEmpty || !zones.habits.isEmpty
+
                     // Greeting + briefing
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Greeting.current + ".")
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(Theme.Colors.textPrimary)
-                        if let briefing = composition.briefing {
+                        if hasFocusItems {
+                            Text("Here's what needs your attention today.")
+                                .font(.subheadline)
+                                .foregroundStyle(Theme.Colors.textSecondary)
+                        } else if let briefing = composition.briefing {
                             Text(briefing)
                                 .font(.subheadline)
                                 .foregroundStyle(Theme.Colors.textSecondary)
@@ -225,8 +232,6 @@ private struct ZonedFocusTabView: View {
                     .opacity(messageVisible ? 1 : 0)
                     .offset(y: messageVisible ? 0 : 6)
                     .padding(.bottom, 20)
-
-                    let zones = zoneItems(composition: composition)
 
                     // Zone 1 — Hero card
                     if let hero = zones.hero, 0 < visibleCardCount {
@@ -562,13 +567,17 @@ private struct HabitRowView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            Image(systemName: habit.isCompletedToday ? "checkmark.circle.fill" : "circle")
-                .font(.system(size: 22))
-                .foregroundStyle(accent)
-                .animation(.spring(response: 0.3, dampingFraction: 0.65), value: habit.isCompletedToday)
-                .frame(width: 44)
-                .contentShape(Rectangle())
-                .onTapGesture { onAction(habit, .checkOffHabit) }
+            Button {
+                onAction(habit, .checkOffHabit)
+            } label: {
+                Image(systemName: habit.isCompletedToday ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 22))
+                    .foregroundStyle(accent)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.65), value: habit.isCompletedToday)
+                    .frame(width: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(habit.summary)

--- a/Murmur/Views/RootView.swift
+++ b/Murmur/Views/RootView.swift
@@ -340,8 +340,12 @@ struct RootView: View {
                 SettingsFullView(
                     onBack: { showSettings = false },
                     onTopUp: {
+                        showSettings = false
                         openTopUp()
-                        showTopUp = true
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .seconds(0.45))
+                            showTopUp = true
+                        }
                     }
                 )
             }

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,23 +6,23 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Real-device tap fixes: resolved two regressions introduced by the UIKit tap overlay fix — list cards navigating to detail instead of expanding, and habit circle opening detail instead of toggling.
+Post-TestFlight bug fixes: three bugs found on first TestFlight install — stale greeting subtitle, credits button not opening, habit card taps not working.
 
 ## Recent decisions
 
-- **UIKit overlay intercepts all taps** — The `UITapGestureRecognizer` added to `SwipeableCard` to fix real-device tapping was too aggressive: it captures all taps including those meant for interactive subviews (list expand chevron, habit circle). SwiftUI sub-buttons are unreachable behind the UIKit overlay.
-- **Category-aware tap routing in SwipeableCard.onTap** — Rather than trying to detect which sub-element was tapped (no coordinate inspection), changed callers to route by category: lists toggle expansion, habits call `checkOffHabit`, others navigate. This keeps `SwipeableCard` API simple.
-- **Expansion state hoisted out of ListCardView** — Added `externalExpanded: Binding<Bool>?` to `ListCardView`. Falls back to internal `@State` when nil (for previews/standalone use). Parent views (AllEntriesView, ZonedFocusHomeView, DamHomeView) each hold `@State private var expandedListIDs: Set<UUID>` and pass per-entry bindings.
-- **Habit tap no longer navigates** — Tapping a habit card toggles it (if `appliesToday`). Navigation to habit detail is still available via swipe actions.
+- **Briefing computed from actual zones, not LLM cache** — `composition.briefing` is set once by the LLM and cached for the day. Layout refreshes update sections but not the briefing, so "All clear" persisted even after new entries arrived. Fix: derive the subtitle dynamically from computed zones — if any hero/standard/habits exist, show "Here's what needs your attention today." Only fall back to LLM briefing when zones are genuinely empty.
+- **Credits button: dismiss settings before opening top-up** — Both settings and top-up are `.sheet` modifiers on the same root view. iOS can't present two sheets simultaneously; the second one is silently swallowed. Fix: set `showSettings = false`, call `openTopUp()`, then delay 0.45s before `showTopUp = true`.
+- **Habit circle: Button instead of nested onTapGesture** — `HabitRowView` had a nested `onTapGesture` on the circle inside an outer `onTapGesture` on the whole row. On real devices, inner `onTapGesture` can eat all taps in its frame, making both the circle check-off AND row navigation unreliable. Replacing the circle with a `Button(.plain)` gives SwiftUI proper gesture priority semantics.
+- **UIKit overlay intercepts all taps** — (from previous PR) The `UITapGestureRecognizer` in `SwipeableCard` was too aggressive. Fixed with category-aware routing.
+- **Expansion state hoisted out of ListCardView** — (from previous PR) `externalExpanded: Binding<Bool>?` on `ListCardView`.
 
 ## Open questions
 
 - Should swipe-to-switch-tabs ever come back? Only viable path is UIViewRepresentable. High complexity, low priority.
-- API key distribution for testers unresolved — dam needs to confirm which PPQ key to bake into the archive build.
-- Is the three-zone layout (ZonedFocusHomeView) still on the roadmap, or do we consolidate on SacHomeView?
+- `project.yml` now has `UIRequiresFullScreen: true` — should we revisit iPad support later?
+- Is the three-zone layout (ZonedFocusHomeView) still on the roadmap, or do we consolidate on one home view?
 
 ## What I need from dam
 
-- Confirm API key plan for TestFlight archive build — document or add a Makefile target.
 - PPQ error signal for wiring error views (#9) — need a clear error type from PPQ auth/quota failures.
-- Review the TestFlight checklist and adjust any dam-owned items or priorities.
+- Confirm whether habit navigation to detail should be re-enabled (current: row tap navigates, circle tap toggles).

--- a/mockups/privacy.html
+++ b/mockups/privacy.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Murmur — Privacy Policy</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      max-width: 680px;
+      margin: 60px auto;
+      padding: 0 24px 80px;
+      color: #1a1a1a;
+      line-height: 1.7;
+    }
+    h1 { font-size: 2rem; margin-bottom: 4px; }
+    h2 { font-size: 1.1rem; margin-top: 36px; margin-bottom: 8px; }
+    p, li { font-size: 0.97rem; color: #333; }
+    ul { padding-left: 20px; }
+    .updated { color: #888; font-size: 0.88rem; margin-bottom: 40px; }
+    a { color: #007aff; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p class="updated">Last updated: March 28, 2026</p>
+
+  <p>Murmur ("we", "our", or "the app") is a voice-to-structured-data iOS application. This policy explains what data we collect, how we use it, and your rights.</p>
+
+  <h2>Data We Collect</h2>
+  <ul>
+    <li><strong>Voice recordings:</strong> When you use the microphone, audio is captured and transcribed on-device using Apple's Speech Recognition framework. We do not store raw audio recordings.</li>
+    <li><strong>Transcribed text and entries:</strong> The text produced from your voice input is stored locally on your device and used to generate structured entries via a third-party language model (PPQ.ai / Anthropic Claude).</li>
+    <li><strong>Usage data:</strong> We collect anonymous token usage counts to support the credit system. No personally identifiable information is attached to this data.</li>
+  </ul>
+
+  <h2>Data We Do Not Collect</h2>
+  <ul>
+    <li>We do not collect your name, email address, or any account information.</li>
+    <li>We do not sell or share your data with advertisers.</li>
+    <li>We do not track you across other apps or websites.</li>
+  </ul>
+
+  <h2>Third-Party Services</h2>
+  <p>Murmur sends transcribed text to <a href="https://ppq.ai">PPQ.ai</a> to process language model requests. This text may be processed by Anthropic's Claude models. Please review <a href="https://www.anthropic.com/privacy">Anthropic's Privacy Policy</a> for details on how they handle API data.</p>
+
+  <h2>Data Storage</h2>
+  <p>All entries and app data are stored locally on your device. We do not operate servers that store your personal data.</p>
+
+  <h2>Permissions</h2>
+  <ul>
+    <li><strong>Microphone:</strong> Required to capture voice input. Only active when you initiate a recording.</li>
+    <li><strong>Speech Recognition:</strong> Used to transcribe your voice locally via Apple's framework.</li>
+    <li><strong>Notifications:</strong> Optional. Used only to deliver reminders you set within the app.</li>
+  </ul>
+
+  <h2>Children's Privacy</h2>
+  <p>Murmur is not directed at children under 13. We do not knowingly collect data from children.</p>
+
+  <h2>Changes to This Policy</h2>
+  <p>We may update this policy as the app evolves. Continued use of the app after changes constitutes acceptance of the updated policy.</p>
+
+  <h2>Contact</h2>
+  <p>Questions? Reach us at <a href="mailto:hello@damsac.com">hello@damsac.com</a>.</p>
+</body>
+</html>

--- a/project.yml
+++ b/project.yml
@@ -73,6 +73,7 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
+        UIRequiresFullScreen: true
     entitlements:
       path: Murmur/Murmur.entitlements
       properties:


### PR DESCRIPTION
## Thinking

Three bugs surfaced on the first TestFlight install. Each had a distinct root cause:

**1. Greeting says "All clear" when tasks exist**
The `composition.briefing` field is set by the LLM once per day and cached. When new entries arrive later, `requestLayoutRefresh` updates `sections` but never touches `briefing`. So the stale "All clear" text from an earlier empty state persists all day. I considered patching `requestLayoutRefresh` to recompute briefing, but that's an LLM call. Better: compute it live in the view from the actual zones that are about to be rendered. If there are items, say so; otherwise fall back to whatever the LLM said. Now briefing always matches what's on screen.

**2. \"Get More Credits\" button in Settings does nothing**
Both the settings sheet and the top-up sheet are `.sheet` modifiers on the same root view. iOS silently drops the second sheet presentation when one is already open. The fix is: dismiss settings first, then delay ~450ms for the dismiss animation to finish before setting `showTopUp = true`. Confirmed this is the same pattern already used in the `OutOfCreditsView` → top-up flow.

**3. Habit circle tap unreliable on real device**
`HabitRowView` had a nested `onTapGesture` on the circle inside an outer `onTapGesture` on the whole row. On real devices SwiftUI's gesture arbiter sometimes lets the inner gesture eat all taps in its frame (including the surrounding row), making both the circle check-off and row navigation unreliable. Replacing the inner `onTapGesture` with a `Button(.plain)` gives SwiftUI proper exclusive gesture semantics — `Button` wins inside its frame, outer `onTapGesture` wins everywhere else.

Also included in this commit: the `UIRequiresFullScreen` + `#if DEBUG` fixes that were needed to produce a valid archive for the TestFlight upload (these were made locally but hadn't been committed to main).

## Summary

- Greeting subtitle now reflects live composition state instead of stale LLM cache
- Settings "Get More Credits" dismisses settings before presenting top-up (prevents silent sheet drop)
- Habit circle check-off uses `Button` instead of nested `onTapGesture` for reliable real-device tap handling
- `DevModeView.setBalance` guarded with `#if DEBUG` so Release builds compile
- `UIRequiresFullScreen: true` added to satisfy Apple's portrait-only validation requirement

## State changes

Moved off tap-fix focus onto post-launch triage. New open question: should habit row navigation (tap anywhere outside circle → open detail) stay, or should we remove it in favor of swipe-only access to detail?

## Test plan

- [ ] Greeting says "Here's what needs your attention today." when focus items exist
- [ ] Greeting falls back to LLM briefing (e.g. "All clear") only when focus zone is empty
- [ ] Settings → "Get More Credits" → top-up sheet opens (settings closes first)
- [ ] Habit circle tap → checks off habit
- [ ] Habit row tap (outside circle) → opens entry detail
- [ ] Release build compiles without error (archive via Xcode)
- [ ] App Store validation accepts the build (UIRequiresFullScreen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)