### PR TITLE
fix: habit taps in All tab + personalized focus briefing

### DIFF
--- a/Murmur/Services/AppState.swift
+++ b/Murmur/Services/AppState.swift
@@ -166,11 +166,8 @@ final class AppState {
         // Set variant on LLM service
         llmService?.compositionVariant = variant
 
-        // Check cache (variant-aware)
-        if let cached = homeCompositionStore?.load(expectedVariant: variant), cached.isFromToday {
-            homeComposition = cached
-            return
-        }
+        // Check in-memory composition — skip LLM if already loaded this session
+        if homeComposition != nil { return }
 
         guard let llmService, let creditGate else {
             homeComposition = buildDeterministicComposition(entries: entries, variant: variant)

--- a/Murmur/Views/Home/AllEntriesView.swift
+++ b/Murmur/Views/Home/AllEntriesView.swift
@@ -319,29 +319,50 @@ struct CategorySectionView: View {
             if !isCollapsed {
                 LazyVStack(spacing: 12) {
                     ForEach(entries) { entry in
-                        SwipeableCard(
-                            actions: swipeActionsProvider(entry),
-                            activeSwipeID: $activeSwipeEntryID,
-                            entryID: entry.id,
-                            onTap: sectionTapAction(entry)
-                        ) {
+                        if entry.category == .habit {
+                            // Habits skip SwipeableCard — its UIKit overlay steals taps
+                            // before the circle Button can receive them. Match Focus tab:
+                            // circle Button = check-off, row tap = navigate to detail.
                             GlowingEntryRow(
                                 entry: entry,
                                 isArrived: arrivedEntryIDs.contains(entry.id),
                                 category: category,
                                 onAction: onAction,
-                                onTap: entry.category == .list ? nil : { onEntryTap(entry) },
-                                listExpanded: entry.category == .list ? Binding(
-                                    get: { expandedListIDs.contains(entry.id) },
-                                    set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
-                                ) : nil,
+                                onTap: nil,
+                                listExpanded: nil,
                                 onGlowComplete: { onGlowComplete(entry.id) }
                             )
+                            .contentShape(Rectangle())
+                            .onTapGesture { onEntryTap(entry) }
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
+                                removal: .opacity.combined(with: .scale(scale: 0.95))
+                            ))
+                        } else {
+                            SwipeableCard(
+                                actions: swipeActionsProvider(entry),
+                                activeSwipeID: $activeSwipeEntryID,
+                                entryID: entry.id,
+                                onTap: sectionTapAction(entry)
+                            ) {
+                                GlowingEntryRow(
+                                    entry: entry,
+                                    isArrived: arrivedEntryIDs.contains(entry.id),
+                                    category: category,
+                                    onAction: onAction,
+                                    onTap: entry.category == .list ? nil : { onEntryTap(entry) },
+                                    listExpanded: entry.category == .list ? Binding(
+                                        get: { expandedListIDs.contains(entry.id) },
+                                        set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
+                                    ) : nil,
+                                    onGlowComplete: { onGlowComplete(entry.id) }
+                                )
+                            }
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
+                                removal: .opacity.combined(with: .scale(scale: 0.95))
+                            ))
                         }
-                        .transition(.asymmetric(
-                            insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
-                            removal: .opacity.combined(with: .scale(scale: 0.95))
-                        ))
                     }
                 }
                 .padding(.horizontal, 12)
@@ -507,16 +528,18 @@ struct SmartListRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             if entry.category == .habit {
-                Image(systemName: entry.isCompletedToday ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 24))
-                    .foregroundStyle(Theme.categoryColor(entry.category))
-                    .animation(.spring(response: 0.3, dampingFraction: 0.65), value: entry.isCompletedToday)
-                    .frame(width: 36)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        guard entry.appliesToday else { return }
-                        onAction(entry, .checkOffHabit)
-                    }
+                Button {
+                    guard entry.appliesToday else { return }
+                    onAction(entry, .checkOffHabit)
+                } label: {
+                    Image(systemName: entry.isCompletedToday ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 24))
+                        .foregroundStyle(Theme.categoryColor(entry.category))
+                        .animation(.spring(response: 0.3, dampingFraction: 0.65), value: entry.isCompletedToday)
+                        .frame(width: 36)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             } else {
                 let dotColor = Theme.categoryColor(entry.category)
                 Circle()

--- a/Murmur/Views/Home/ZonedFocusHomeView.swift
+++ b/Murmur/Views/Home/ZonedFocusHomeView.swift
@@ -212,18 +212,22 @@ private struct ZonedFocusTabView: View {
                 } else if let composition {
                     let zones = zoneItems(composition: composition)
                     let hasFocusItems = zones.hero != nil || !zones.standard.isEmpty || !zones.habits.isEmpty
+                    let isStaleAllClear: Bool = {
+                        guard let b = composition.briefing else { return false }
+                        let l = b.lowercased()
+                        return l.contains("all clear") || l.contains("nothing pressing") || l.contains("nothing urgent")
+                    }()
+                    let subtitle: String? = hasFocusItems
+                        ? (isStaleAllClear ? "Here's what needs your attention today." : composition.briefing)
+                        : composition.briefing
 
                     // Greeting + briefing
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Greeting.current + ".")
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(Theme.Colors.textPrimary)
-                        if hasFocusItems {
-                            Text("Here's what needs your attention today.")
-                                .font(.subheadline)
-                                .foregroundStyle(Theme.Colors.textSecondary)
-                        } else if let briefing = composition.briefing {
-                            Text(briefing)
+                        if let subtitle {
+                            Text(subtitle)
                                 .font(.subheadline)
                                 .foregroundStyle(Theme.Colors.textSecondary)
                         }

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,18 +6,20 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Post-TestFlight bug fixes: three bugs found on first TestFlight install — stale greeting subtitle, credits button not opening, habit card taps not working.
+Post-TestFlight bug fixes (round 2): habit card taps in All tab, personalized focus briefing.
 
 ## Recent decisions
 
-- **Briefing computed from actual zones, not LLM cache** — `composition.briefing` is set once by the LLM and cached for the day. Layout refreshes update sections but not the briefing, so "All clear" persisted even after new entries arrived. Fix: derive the subtitle dynamically from computed zones — if any hero/standard/habits exist, show "Here's what needs your attention today." Only fall back to LLM briefing when zones are genuinely empty.
-- **Credits button: dismiss settings before opening top-up** — Both settings and top-up are `.sheet` modifiers on the same root view. iOS can't present two sheets simultaneously; the second one is silently swallowed. Fix: set `showSettings = false`, call `openTopUp()`, then delay 0.45s before `showTopUp = true`.
-- **Habit circle: Button instead of nested onTapGesture** — `HabitRowView` had a nested `onTapGesture` on the circle inside an outer `onTapGesture` on the whole row. On real devices, inner `onTapGesture` can eat all taps in its frame, making both the circle check-off AND row navigation unreliable. Replacing the circle with a `Button(.plain)` gives SwiftUI proper gesture priority semantics.
-- **UIKit overlay intercepts all taps** — (from previous PR) The `UITapGestureRecognizer` in `SwipeableCard` was too aggressive. Fixed with category-aware routing.
-- **Expansion state hoisted out of ListCardView** — (from previous PR) `externalExpanded: Binding<Bool>?` on `ListCardView`.
+- **Habits skip SwipeableCard in All tab** — `SwipeableCard` uses a UIKit `UITapGestureRecognizer` overlay when swipe actions are present. This overlay wins the hit-test on real devices and steals all taps before the SwiftUI Button can receive them. Habits in the All section were wrapped in `SwipeableCard`, so neither circle check-off nor row navigation worked. Fix: habits skip `SwipeableCard` entirely, rendered as plain rows with `onTapGesture` for navigation. Circle `Button(.plain)` handles check-off. Matches Focus tab behavior exactly.
+- **Briefing regenerated per app session, not per day** — Removed the daily disk cache check in `requestHomeComposition`. Composition (including briefing) is now regenerated via LLM on every app launch (when `homeComposition == nil`). Within a session, layout refreshes handle incremental updates. This ensures the greeting subtitle is always personalized to the current state of entries.
+- **Stale "all clear" safety net** — If the LLM runs early with no entries (briefing = "All clear") and entries arrive mid-session via layout refresh, the view detects the stale all-clear text and falls back to a generic "Here's what needs your attention today." This covers the edge case without requiring mid-session LLM re-composition.
+- **Briefing computed from actual zones, not LLM cache** — (from previous PR) `composition.briefing` is set once by the LLM and cached. Fix: derive the subtitle dynamically — show LLM briefing when it's not stale, fall back to hardcoded string otherwise.
+- **Credits button: dismiss settings before opening top-up** — (from previous PR) iOS can't present two sheets simultaneously. Fix: set `showSettings = false`, delay 0.45s, then `showTopUp = true`.
+- **Habit circle: Button instead of nested onTapGesture** — (from previous PR) Replacing the circle with a `Button(.plain)` gives SwiftUI proper gesture priority semantics.
 
 ## Open questions
 
+- Should habit cards in All tab also have swipe actions (Done/Snooze)? Currently removed to fix taps — could re-add with a UIKit hit-test override that lets the circle through.
 - Should swipe-to-switch-tabs ever come back? Only viable path is UIViewRepresentable. High complexity, low priority.
 - `project.yml` now has `UIRequiresFullScreen: true` — should we revisit iPad support later?
 - Is the three-zone layout (ZonedFocusHomeView) still on the roadmap, or do we consolidate on one home view?
@@ -25,4 +27,4 @@ Post-TestFlight bug fixes: three bugs found on first TestFlight install — stal
 ## What I need from dam
 
 - PPQ error signal for wiring error views (#9) — need a clear error type from PPQ auth/quota failures.
-- Confirm whether habit navigation to detail should be re-enabled (current: row tap navigates, circle tap toggles).
+- Confirm whether habit navigation to detail should be re-enabled (current: row tap navigates, circle tap toggles — both in Focus and All tabs now).


### PR DESCRIPTION
## Thinking

Two issues found after PR #133 shipped to TestFlight:

**Habit taps in All tab**: My original circle fix (replacing `onTapGesture` with `Button(.plain)`) only worked in the Focus tab because the Focus tab renders habits via `HabitsStripView` → `HabitRowView` — no `SwipeableCard` wrapper. In the All tab, every entry (including habits) is wrapped in `SwipeableCard`. When swipe actions are present, `SwipeableCard` installs a `UITapGestureRecognizer` via `UIViewRepresentable` overlay. This overlay wins UIKit's hit-test and steals all taps before SwiftUI's gesture system can dispatch them — meaning the `Button(.plain)` I added was unreachable. The fix: habits skip `SwipeableCard` entirely. They render as plain rows, circle `Button(.plain)` handles check-off, outer `onTapGesture` handles navigation. Consistent with how Focus tab works.

**Personalized briefing**: The previous fix hardcoded "Here's what needs your attention today." when focus items exist — dropping all LLM personalization. The real problem was the daily disk cache: `requestHomeComposition` loaded from the store and returned early if the composition was from today, so the briefing was generated once at first launch and never refreshed. Fix: replace the disk cache check with an in-memory check (`homeComposition != nil`). Now the LLM regenerates composition (including briefing) on every app launch. Layout refreshes still handle mid-session section updates. A stale "all clear" safety net in the view covers the edge case where the LLM ran with no entries but entries arrived mid-session.

## Summary

- Habits in the All tab now skip `SwipeableCard` to avoid UIKit tap interception — circle checks off, row navigates to detail, matching Focus tab behavior
- Focus briefing is now regenerated per app session (not cached per day) so the LLM's personalized message is always fresh
- Stale "all clear" detection in the view catches mid-session staleness as a fallback

## State changes

- Updated open question: should habit cards in All tab get swipe actions back? Would need UIKit hit-test override to let the circle through.
- Canon candidate: **SwipeableCard's UIKit overlay blocks SwiftUI Buttons** — when `actions` are present, don't rely on `Button` inside the card content; route everything through `onTap`. Or skip `SwipeableCard` for rows that need internal button routing.

## Test plan

- [ ] All tab: tap habit circle → habit checks off, circle animates
- [ ] All tab: tap habit row (outside circle) → navigates to habit detail
- [ ] Focus tab: same behavior unchanged
- [ ] Focus tab: greeting subtitle shows personalized LLM briefing (not hardcoded string) after fresh app launch with entries
- [ ] Focus tab: if launched with no entries and entries added mid-session, subtitle doesn't show stale "All clear"

🤖 Generated with [Claude Code](https://claude.com/claude-code)