### PR TITLE
fix: list item taps + date/time sheet glitch

### DIFF
--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -669,7 +669,16 @@ private struct DueDateEditSheet: View {
     let onRemove: () -> Void
     let onDismiss: () -> Void
 
-    @State private var hasTime: Bool = false
+    @State private var hasTime: Bool
+
+    init(date: Binding<Date>, isRemovable: Bool, onSave: @escaping () -> Void, onRemove: @escaping () -> Void, onDismiss: @escaping () -> Void) {
+        self._date = date
+        self.isRemovable = isRemovable
+        self.onSave = onSave
+        self.onRemove = onRemove
+        self.onDismiss = onDismiss
+        self._hasTime = State(initialValue: date.wrappedValue.hasTimeComponent)
+    }
 
     var body: some View {
         NavigationStack {
@@ -726,9 +735,6 @@ private struct DueDateEditSheet: View {
             }
         }
         .background(Theme.Colors.bgDeep)
-        .onAppear {
-            hasTime = date.hasTimeComponent
-        }
     }
 }
 

--- a/Murmur/Views/Home/AllEntriesView.swift
+++ b/Murmur/Views/Home/AllEntriesView.swift
@@ -73,23 +73,34 @@ struct AllEntriesView: View {
                     } else {
                         LazyVStack(spacing: 12) {
                             ForEach(filteredEntries) { entry in
-                                SwipeableCard(
-                                    actions: swipeActionsProvider(entry),
-                                    activeSwipeID: $activeSwipeEntryID,
-                                    entryID: entry.id,
-                                    onTap: searchTapAction(entry)
-                                ) {
+                                if entry.category == .list {
                                     GlowingEntryRow(
                                         entry: entry,
                                         isArrived: arrivedEntryIDs.contains(entry.id),
                                         category: entry.category,
                                         onAction: onAction,
-                                        listExpanded: entry.category == .list ? Binding(
+                                        onTap: { onEntryTap(entry) },
+                                        listExpanded: Binding(
                                             get: { expandedListIDs.contains(entry.id) },
                                             set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
-                                        ) : nil,
+                                        ),
                                         onGlowComplete: { onGlowComplete(entry.id) }
                                     )
+                                } else {
+                                    SwipeableCard(
+                                        actions: swipeActionsProvider(entry),
+                                        activeSwipeID: $activeSwipeEntryID,
+                                        entryID: entry.id,
+                                        onTap: searchTapAction(entry)
+                                    ) {
+                                        GlowingEntryRow(
+                                            entry: entry,
+                                            isArrived: arrivedEntryIDs.contains(entry.id),
+                                            category: entry.category,
+                                            onAction: onAction,
+                                            onGlowComplete: { onGlowComplete(entry.id) }
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -338,6 +349,26 @@ struct CategorySectionView: View {
                                 insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
                                 removal: .opacity.combined(with: .scale(scale: 0.95))
                             ))
+                        } else if entry.category == .list {
+                            // Lists skip SwipeableCard — UIKit overlay blocks item check-off Buttons.
+                            // ListCardView handles header nav (onTap), expand/collapse (chevron),
+                            // and item check-off (row Buttons) internally — no outer tap needed.
+                            GlowingEntryRow(
+                                entry: entry,
+                                isArrived: arrivedEntryIDs.contains(entry.id),
+                                category: category,
+                                onAction: onAction,
+                                onTap: { onEntryTap(entry) },
+                                listExpanded: Binding(
+                                    get: { expandedListIDs.contains(entry.id) },
+                                    set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
+                                ),
+                                onGlowComplete: { onGlowComplete(entry.id) }
+                            )
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
+                                removal: .opacity.combined(with: .scale(scale: 0.95))
+                            ))
                         } else {
                             SwipeableCard(
                                 actions: swipeActionsProvider(entry),
@@ -350,11 +381,8 @@ struct CategorySectionView: View {
                                     isArrived: arrivedEntryIDs.contains(entry.id),
                                     category: category,
                                     onAction: onAction,
-                                    onTap: entry.category == .list ? nil : { onEntryTap(entry) },
-                                    listExpanded: entry.category == .list ? Binding(
-                                        get: { expandedListIDs.contains(entry.id) },
-                                        set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
-                                    ) : nil,
+                                    onTap: { onEntryTap(entry) },
+                                    listExpanded: nil,
                                     onGlowComplete: { onGlowComplete(entry.id) }
                                 )
                             }

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,25 +6,22 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Post-TestFlight bug fixes (round 2): habit card taps in All tab, personalized focus briefing.
+Post-TestFlight bug fixes (round 3): list item taps, date/time sheet glitch.
 
 ## Recent decisions
 
-- **Habits skip SwipeableCard in All tab** — `SwipeableCard` uses a UIKit `UITapGestureRecognizer` overlay when swipe actions are present. This overlay wins the hit-test on real devices and steals all taps before the SwiftUI Button can receive them. Habits in the All section were wrapped in `SwipeableCard`, so neither circle check-off nor row navigation worked. Fix: habits skip `SwipeableCard` entirely, rendered as plain rows with `onTapGesture` for navigation. Circle `Button(.plain)` handles check-off. Matches Focus tab behavior exactly.
-- **Briefing regenerated per app session, not per day** — Removed the daily disk cache check in `requestHomeComposition`. Composition (including briefing) is now regenerated via LLM on every app launch (when `homeComposition == nil`). Within a session, layout refreshes handle incremental updates. This ensures the greeting subtitle is always personalized to the current state of entries.
-- **Stale "all clear" safety net** — If the LLM runs early with no entries (briefing = "All clear") and entries arrive mid-session via layout refresh, the view detects the stale all-clear text and falls back to a generic "Here's what needs your attention today." This covers the edge case without requiring mid-session LLM re-composition.
-- **Briefing computed from actual zones, not LLM cache** — (from previous PR) `composition.briefing` is set once by the LLM and cached. Fix: derive the subtitle dynamically — show LLM briefing when it's not stale, fall back to hardcoded string otherwise.
-- **Credits button: dismiss settings before opening top-up** — (from previous PR) iOS can't present two sheets simultaneously. Fix: set `showSettings = false`, delay 0.45s, then `showTopUp = true`.
-- **Habit circle: Button instead of nested onTapGesture** — (from previous PR) Replacing the circle with a `Button(.plain)` gives SwiftUI proper gesture priority semantics.
+- **Lists skip SwipeableCard in All tab** — Same UIKit overlay root cause as habits (#134). When `SwipeableCard` wraps a `ListCardView`, the `UITapGestureRecognizer` overlay fires `sectionTapAction` (toggle expand/collapse) on every tap, including taps on item check-off Buttons. Fix: list entries skip `SwipeableCard` entirely in both the category section and search results. `ListCardView` handles navigation (header Button → `onTap`), expand/collapse (chevron Button), and item check-off (row Buttons) internally — no outer gesture wrapper needed.
+- **DueDateEditSheet hasTime initialized from binding, not onAppear** — Previously `hasTime = false` at init, then `onAppear` set it to `true` if the date had a time component. This caused a visible layout jump (date picker alone → time picker appears). Fix: custom `init` initializes `@State private var hasTime` from `date.wrappedValue.hasTimeComponent` so the correct layout renders on first frame.
+- **Top-up packs empty in TestFlight** — Not a code bug. `Product.products(for:)` returns empty because the IAP products don't exist in App Store Connect yet. The `.storekit` file is Simulator-only. Needs dam to create the three consumable products in ASC with product IDs: `com.damsac.murmur.credits.1000`, `com.damsac.murmur.credits.5000`, `com.damsac.murmur.credits.10000`.
+- **Habits skip SwipeableCard in All tab** — (from PR #134) UIKit overlay steals all taps. Habits rendered as plain rows with `onTapGesture` for navigation. Circle `Button(.plain)` handles check-off.
+- **Briefing regenerated per app session** — (from PR #134) Removed daily disk cache. LLM regenerates on every app launch.
 
 ## Open questions
 
-- Should habit cards in All tab also have swipe actions (Done/Snooze)? Currently removed to fix taps — could re-add with a UIKit hit-test override that lets the circle through.
-- Should swipe-to-switch-tabs ever come back? Only viable path is UIViewRepresentable. High complexity, low priority.
-- `project.yml` now has `UIRequiresFullScreen: true` — should we revisit iPad support later?
-- Is the three-zone layout (ZonedFocusHomeView) still on the roadmap, or do we consolidate on one home view?
+- Should habit/list cards in All tab get swipe actions back? Currently removed to fix taps — could re-add with a UIKit hit-test override.
+- Is the three-zone layout (ZonedFocusHomeView) still on the roadmap?
 
 ## What I need from dam
 
+- Create the three IAP products in App Store Connect (product IDs above) so top-up works in TestFlight.
 - PPQ error signal for wiring error views (#9) — need a clear error type from PPQ auth/quota failures.
-- Confirm whether habit navigation to detail should be re-enabled (current: row tap navigates, circle tap toggles — both in Focus and All tabs now).


### PR DESCRIPTION
## Thinking

Two TestFlight bugs, same kind of root cause investigation.

**List item taps closing the list instead of checking off:**
The same UIKit overlay problem that broke habit taps in #134. `SwipeableCard` installs a `UITapGestureRecognizer` via `HorizontalPanGestureInstaller` that wins UIKit's hit-test on real devices. Every tap — including taps on the check-off `Button`s inside `ListCardView.expandedBody` — gets routed to `sectionTapAction` (toggle expand/collapse) before SwiftUI sees it. This explains exactly the reported behavior: tapping a dot collapses the expanded list.

The right fix is the same pattern as habits: skip `SwipeableCard` entirely for list entries. `ListCardView` already has all the button routing it needs — header `Button` for navigation (via `onTap`), chevron `Button` for expand/collapse, row `Button`s for item check-off. Without the UIKit overlay in the way, all three work correctly. No outer `onTapGesture` needed.

Applied this fix in both the category section and search results.

**Date/time sheet layout jump:**
`DueDateEditSheet` had `@State private var hasTime: Bool = false` with an `onAppear` that set it to `true` if the date had a time. This meant the sheet always rendered with just the date picker first, then the time picker appeared after a frame — a visible jump. Fixed by adding a custom `init` that seeds `hasTime` from `date.wrappedValue.hasTimeComponent` so the correct layout appears on the first frame.

**Top-up packs (not in this PR):**
Not a code bug — `Product.products(for:)` returns empty because the IAP products don't exist in App Store Connect. The `.storekit` file only works in Simulator. Dam needs to create the three consumable products in ASC.

## Summary

- List entries now skip `SwipeableCard` in All tab (category section + search results) — same fix as habits in #134
- `DueDateEditSheet` initializes `hasTime` correctly from the date binding, eliminating the layout jump on open

## State changes

Updated current focus to round 3 bug fixes. Added top-up root cause as a decision (ASC config issue, not code). Dropped stale open questions. Added ASC product creation request for dam.

## Test plan
- [ ] Open All tab, expand a list, tap a dot — item should check off (not collapse the list)
- [ ] Search for a list entry, expand it, tap a dot — item should check off
- [ ] Open entry detail for a todo/reminder with a time-component due date → tap due date row → sheet should open with time picker already visible (no jump)
- [ ] Open entry detail for a todo with date-only due date → sheet opens with just date picker (no time section)
- [ ] Open entry detail for a todo with no due date → sheet opens with just date picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)