### PR TITLE
fix: due date sheet opens at full height

### DIFF
--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -669,7 +669,16 @@ private struct DueDateEditSheet: View {
     let onRemove: () -> Void
     let onDismiss: () -> Void
 
-    @State private var hasTime: Bool = false
+    @State private var hasTime: Bool
+
+    init(date: Binding<Date>, isRemovable: Bool, onSave: @escaping () -> Void, onRemove: @escaping () -> Void, onDismiss: @escaping () -> Void) {
+        self._date = date
+        self.isRemovable = isRemovable
+        self.onSave = onSave
+        self.onRemove = onRemove
+        self.onDismiss = onDismiss
+        self._hasTime = State(initialValue: date.wrappedValue.hasTimeComponent)
+    }
 
     var body: some View {
         NavigationStack {
@@ -726,9 +735,6 @@ private struct DueDateEditSheet: View {
             }
         }
         .background(Theme.Colors.bgDeep)
-        .onAppear {
-            hasTime = date.hasTimeComponent
-        }
     }
 }
 

--- a/Murmur/Views/Detail/EntryDetailView.swift
+++ b/Murmur/Views/Detail/EntryDetailView.swift
@@ -367,7 +367,7 @@ struct EntryDetailView: View {
                 },
                 onDismiss: { showDueDateSheet = false }
             )
-            .presentationDetents([.medium, .large])
+            .presentationDetents([.large])
             .presentationDragIndicator(.visible)
         }
         .confirmationDialog("Snooze until...", isPresented: $showSnoozeDialog) {

--- a/Murmur/Views/Home/AllEntriesView.swift
+++ b/Murmur/Views/Home/AllEntriesView.swift
@@ -73,23 +73,34 @@ struct AllEntriesView: View {
                     } else {
                         LazyVStack(spacing: 12) {
                             ForEach(filteredEntries) { entry in
-                                SwipeableCard(
-                                    actions: swipeActionsProvider(entry),
-                                    activeSwipeID: $activeSwipeEntryID,
-                                    entryID: entry.id,
-                                    onTap: searchTapAction(entry)
-                                ) {
+                                if entry.category == .list {
                                     GlowingEntryRow(
                                         entry: entry,
                                         isArrived: arrivedEntryIDs.contains(entry.id),
                                         category: entry.category,
                                         onAction: onAction,
-                                        listExpanded: entry.category == .list ? Binding(
+                                        onTap: { onEntryTap(entry) },
+                                        listExpanded: Binding(
                                             get: { expandedListIDs.contains(entry.id) },
                                             set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
-                                        ) : nil,
+                                        ),
                                         onGlowComplete: { onGlowComplete(entry.id) }
                                     )
+                                } else {
+                                    SwipeableCard(
+                                        actions: swipeActionsProvider(entry),
+                                        activeSwipeID: $activeSwipeEntryID,
+                                        entryID: entry.id,
+                                        onTap: searchTapAction(entry)
+                                    ) {
+                                        GlowingEntryRow(
+                                            entry: entry,
+                                            isArrived: arrivedEntryIDs.contains(entry.id),
+                                            category: entry.category,
+                                            onAction: onAction,
+                                            onGlowComplete: { onGlowComplete(entry.id) }
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -338,6 +349,26 @@ struct CategorySectionView: View {
                                 insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
                                 removal: .opacity.combined(with: .scale(scale: 0.95))
                             ))
+                        } else if entry.category == .list {
+                            // Lists skip SwipeableCard — UIKit overlay blocks item check-off Buttons.
+                            // ListCardView handles header nav (onTap), expand/collapse (chevron),
+                            // and item check-off (row Buttons) internally — no outer tap needed.
+                            GlowingEntryRow(
+                                entry: entry,
+                                isArrived: arrivedEntryIDs.contains(entry.id),
+                                category: category,
+                                onAction: onAction,
+                                onTap: { onEntryTap(entry) },
+                                listExpanded: Binding(
+                                    get: { expandedListIDs.contains(entry.id) },
+                                    set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
+                                ),
+                                onGlowComplete: { onGlowComplete(entry.id) }
+                            )
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.97)).combined(with: .offset(y: 8)),
+                                removal: .opacity.combined(with: .scale(scale: 0.95))
+                            ))
                         } else {
                             SwipeableCard(
                                 actions: swipeActionsProvider(entry),
@@ -350,11 +381,8 @@ struct CategorySectionView: View {
                                     isArrived: arrivedEntryIDs.contains(entry.id),
                                     category: category,
                                     onAction: onAction,
-                                    onTap: entry.category == .list ? nil : { onEntryTap(entry) },
-                                    listExpanded: entry.category == .list ? Binding(
-                                        get: { expandedListIDs.contains(entry.id) },
-                                        set: { if $0 { expandedListIDs.insert(entry.id) } else { expandedListIDs.remove(entry.id) } }
-                                    ) : nil,
+                                    onTap: { onEntryTap(entry) },
+                                    listExpanded: nil,
                                     onGlowComplete: { onGlowComplete(entry.id) }
                                 )
                             }

--- a/Murmur/Views/Home/ZonedFocusHomeView.swift
+++ b/Murmur/Views/Home/ZonedFocusHomeView.swift
@@ -256,25 +256,16 @@ private struct ZonedFocusTabView: View {
                             ForEach(zones.standard, id: \.entry.id) { item in
                                 if item.globalIndex < visibleCardCount {
                                     if item.entry.category == .list {
-                                        SwipeableCard(
-                                            actions: swipeActionsProvider(item.entry),
-                                            activeSwipeID: $activeSwipeEntryID,
-                                            entryID: item.entry.id,
-                                            onTap: {
-                                                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                                                    if expandedListIDs.contains(item.entry.id) { expandedListIDs.remove(item.entry.id) } else { expandedListIDs.insert(item.entry.id) }
-                                                }
-                                            }
-                                        ) {
-                                            ListCardView(
-                                                entry: item.entry,
-                                                onAction: onAction,
-                                                externalExpanded: Binding(
-                                                    get: { expandedListIDs.contains(item.entry.id) },
-                                                    set: { if $0 { expandedListIDs.insert(item.entry.id) } else { expandedListIDs.remove(item.entry.id) } }
-                                                )
+                                        // Lists skip SwipeableCard — UIKit overlay blocks item check-off Buttons.
+                                        ListCardView(
+                                            entry: item.entry,
+                                            onAction: onAction,
+                                            onTap: { onEntryTap(item.entry) },
+                                            externalExpanded: Binding(
+                                                get: { expandedListIDs.contains(item.entry.id) },
+                                                set: { if $0 { expandedListIDs.insert(item.entry.id) } else { expandedListIDs.remove(item.entry.id) } }
                                             )
-                                        }
+                                        )
                                         .transition(cardTransition)
                                     } else {
                                         StandardFocusCard(

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,11 +6,12 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Post-TestFlight bug fixes (round 3): list item taps, date/time sheet glitch.
+Post-TestFlight bug fixes (round 4): list item taps on Focus tab.
 
 ## Recent decisions
 
-- **Lists skip SwipeableCard in All tab** — Same UIKit overlay root cause as habits (#134). When `SwipeableCard` wraps a `ListCardView`, the `UITapGestureRecognizer` overlay fires `sectionTapAction` (toggle expand/collapse) on every tap, including taps on item check-off Buttons. Fix: list entries skip `SwipeableCard` entirely in both the category section and search results. `ListCardView` handles navigation (header Button → `onTap`), expand/collapse (chevron Button), and item check-off (row Buttons) internally — no outer gesture wrapper needed.
+- **Lists skip SwipeableCard in Focus tab too** — PR #135 fixed the All tab but missed the Focus tab (`ZonedFocusTabView`). Same UIKit overlay root cause: `SwipeableCard` wrapping `ListCardView` fires expand/collapse on every tap. Fix: render `ListCardView` directly with `onTap: { onEntryTap(item.entry) }` — same pattern as the All tab fix.
+- **Lists skip SwipeableCard in All tab** — (from PR #135) Same UIKit overlay root cause as habits (#134). When `SwipeableCard` wraps a `ListCardView`, the `UITapGestureRecognizer` overlay fires `sectionTapAction` (toggle expand/collapse) on every tap, including taps on item check-off Buttons. Fix: list entries skip `SwipeableCard` entirely in both the category section and search results. `ListCardView` handles navigation (header Button → `onTap`), expand/collapse (chevron Button), and item check-off (row Buttons) internally — no outer gesture wrapper needed.
 - **DueDateEditSheet hasTime initialized from binding, not onAppear** — Previously `hasTime = false` at init, then `onAppear` set it to `true` if the date had a time component. This caused a visible layout jump (date picker alone → time picker appears). Fix: custom `init` initializes `@State private var hasTime` from `date.wrappedValue.hasTimeComponent` so the correct layout renders on first frame.
 - **Top-up packs empty in TestFlight** — Not a code bug. `Product.products(for:)` returns empty because the IAP products don't exist in App Store Connect yet. The `.storekit` file is Simulator-only. Needs dam to create the three consumable products in ASC with product IDs: `com.damsac.murmur.credits.1000`, `com.damsac.murmur.credits.5000`, `com.damsac.murmur.credits.10000`.
 - **Habits skip SwipeableCard in All tab** — (from PR #134) UIKit overlay steals all taps. Habits rendered as plain rows with `onTapGesture` for navigation. Circle `Button(.plain)` handles check-off.

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,11 +6,12 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Post-TestFlight bug fixes (round 4): list item taps on Focus tab.
+Post-TestFlight bug fixes (round 5): due date sheet height.
 
 ## Recent decisions
 
-- **Lists skip SwipeableCard in Focus tab too** — PR #135 fixed the All tab but missed the Focus tab (`ZonedFocusTabView`). Same UIKit overlay root cause: `SwipeableCard` wrapping `ListCardView` fires expand/collapse on every tap. Fix: render `ListCardView` directly with `onTap: { onEntryTap(item.entry) }` — same pattern as the All tab fix.
+- **DueDateEditSheet opens at .large detent** — Sheet was using `[.medium, .large]`, defaulting to medium. The graphical calendar + time wheel + toolbar buttons don't fit at medium height. Fix: use `[.large]` only so the sheet always opens with enough room.
+- **Lists skip SwipeableCard in Focus tab too** — (from PR #136) PR #135 fixed the All tab but missed the Focus tab (`ZonedFocusTabView`). Same UIKit overlay root cause: `SwipeableCard` wrapping `ListCardView` fires expand/collapse on every tap. Fix: render `ListCardView` directly with `onTap: { onEntryTap(item.entry) }` — same pattern as the All tab fix.
 - **Lists skip SwipeableCard in All tab** — (from PR #135) Same UIKit overlay root cause as habits (#134). When `SwipeableCard` wraps a `ListCardView`, the `UITapGestureRecognizer` overlay fires `sectionTapAction` (toggle expand/collapse) on every tap, including taps on item check-off Buttons. Fix: list entries skip `SwipeableCard` entirely in both the category section and search results. `ListCardView` handles navigation (header Button → `onTap`), expand/collapse (chevron Button), and item check-off (row Buttons) internally — no outer gesture wrapper needed.
 - **DueDateEditSheet hasTime initialized from binding, not onAppear** — Previously `hasTime = false` at init, then `onAppear` set it to `true` if the date had a time component. This caused a visible layout jump (date picker alone → time picker appears). Fix: custom `init` initializes `@State private var hasTime` from `date.wrappedValue.hasTimeComponent` so the correct layout renders on first frame.
 - **Top-up packs empty in TestFlight** — Not a code bug. `Product.products(for:)` returns empty because the IAP products don't exist in App Store Connect yet. The `.storekit` file is Simulator-only. Needs dam to create the three consumable products in ASC with product IDs: `com.damsac.murmur.credits.1000`, `com.damsac.murmur.credits.5000`, `com.damsac.murmur.credits.10000`.

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,25 +6,22 @@ What sac is working on right now. Updated with every PR.
 
 ## Current focus
 
-Post-TestFlight bug fixes (round 2): habit card taps in All tab, personalized focus briefing.
+Post-TestFlight bug fixes (round 3): list item taps, date/time sheet glitch.
 
 ## Recent decisions
 
-- **Habits skip SwipeableCard in All tab** — `SwipeableCard` uses a UIKit `UITapGestureRecognizer` overlay when swipe actions are present. This overlay wins the hit-test on real devices and steals all taps before the SwiftUI Button can receive them. Habits in the All section were wrapped in `SwipeableCard`, so neither circle check-off nor row navigation worked. Fix: habits skip `SwipeableCard` entirely, rendered as plain rows with `onTapGesture` for navigation. Circle `Button(.plain)` handles check-off. Matches Focus tab behavior exactly.
-- **Briefing regenerated per app session, not per day** — Removed the daily disk cache check in `requestHomeComposition`. Composition (including briefing) is now regenerated via LLM on every app launch (when `homeComposition == nil`). Within a session, layout refreshes handle incremental updates. This ensures the greeting subtitle is always personalized to the current state of entries.
-- **Stale "all clear" safety net** — If the LLM runs early with no entries (briefing = "All clear") and entries arrive mid-session via layout refresh, the view detects the stale all-clear text and falls back to a generic "Here's what needs your attention today." This covers the edge case without requiring mid-session LLM re-composition.
-- **Briefing computed from actual zones, not LLM cache** — (from previous PR) `composition.briefing` is set once by the LLM and cached. Fix: derive the subtitle dynamically — show LLM briefing when it's not stale, fall back to hardcoded string otherwise.
-- **Credits button: dismiss settings before opening top-up** — (from previous PR) iOS can't present two sheets simultaneously. Fix: set `showSettings = false`, delay 0.45s, then `showTopUp = true`.
-- **Habit circle: Button instead of nested onTapGesture** — (from previous PR) Replacing the circle with a `Button(.plain)` gives SwiftUI proper gesture priority semantics.
+- **Lists skip SwipeableCard in All tab** — Same UIKit overlay root cause as habits (#134). When `SwipeableCard` wraps a `ListCardView`, the `UITapGestureRecognizer` overlay fires `sectionTapAction` (toggle expand/collapse) on every tap, including taps on item check-off Buttons. Fix: list entries skip `SwipeableCard` entirely in both the category section and search results. `ListCardView` handles navigation (header Button → `onTap`), expand/collapse (chevron Button), and item check-off (row Buttons) internally — no outer gesture wrapper needed.
+- **DueDateEditSheet hasTime initialized from binding, not onAppear** — Previously `hasTime = false` at init, then `onAppear` set it to `true` if the date had a time component. This caused a visible layout jump (date picker alone → time picker appears). Fix: custom `init` initializes `@State private var hasTime` from `date.wrappedValue.hasTimeComponent` so the correct layout renders on first frame.
+- **Top-up packs empty in TestFlight** — Not a code bug. `Product.products(for:)` returns empty because the IAP products don't exist in App Store Connect yet. The `.storekit` file is Simulator-only. Needs dam to create the three consumable products in ASC with product IDs: `com.damsac.murmur.credits.1000`, `com.damsac.murmur.credits.5000`, `com.damsac.murmur.credits.10000`.
+- **Habits skip SwipeableCard in All tab** — (from PR #134) UIKit overlay steals all taps. Habits rendered as plain rows with `onTapGesture` for navigation. Circle `Button(.plain)` handles check-off.
+- **Briefing regenerated per app session** — (from PR #134) Removed daily disk cache. LLM regenerates on every app launch.
 
 ## Open questions
 
-- Should habit cards in All tab also have swipe actions (Done/Snooze)? Currently removed to fix taps — could re-add with a UIKit hit-test override that lets the circle through.
-- Should swipe-to-switch-tabs ever come back? Only viable path is UIViewRepresentable. High complexity, low priority.
-- `project.yml` now has `UIRequiresFullScreen: true` — should we revisit iPad support later?
-- Is the three-zone layout (ZonedFocusHomeView) still on the roadmap, or do we consolidate on one home view?
+- Should habit/list cards in All tab get swipe actions back? Currently removed to fix taps — could re-add with a UIKit hit-test override.
+- Is the three-zone layout (ZonedFocusHomeView) still on the roadmap?
 
 ## What I need from dam
 
+- Create the three IAP products in App Store Connect (product IDs above) so top-up works in TestFlight.
 - PPQ error signal for wiring error views (#9) — need a clear error type from PPQ auth/quota failures.
-- Confirm whether habit navigation to detail should be re-enabled (current: row tap navigates, circle tap toggles — both in Focus and All tabs now).


### PR DESCRIPTION
## Thinking

The due date sheet was configured with \`presentationDetents([.medium, .large])\`. SwiftUI defaults to the first detent in the array, so it opened at medium (~50% screen height). At medium, the graphical calendar picker alone nearly fills the available space, leaving no visible room for the time toggle row, the time wheel picker (when enabled), and critically the toolbar buttons (Save/Cancel at top, Remove Date at bottom bar). The user reported the sheet felt cramped and the buttons didn't have enough room.

The fix is simple: drop medium entirely and use \`[.large]\` only. A date/time picker is inherently a full-screen-class interaction — there's no benefit to a half-height sheet here. Everything fits comfortably at large.

## Summary

- Due date sheet now opens at \`.large\` detent instead of \`.medium\`
- All elements (calendar, time toggle, time wheel, Save/Cancel/Remove buttons) have proper breathing room

## State changes

- Updated current focus to round 5
- Added decision entry for the detent change

## Test plan

- [ ] Tap due date on an entry — sheet opens at full height
- [ ] Toggle "Add time" on — time wheel appears with room to spare
- [ ] Save and Cancel buttons visible in nav bar without scrolling
- [ ] "Remove Date" button visible at bottom (when entry has an existing due date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)