### PR TITLE
fix: point analytics endpoint at https://damsac.studio

### DIFF
--- a/project.local.yml.template
+++ b/project.local.yml.template
@@ -17,10 +17,12 @@ settings:
     PPQ_API_KEY: ""
 
   # OPTIONAL: Studio Analytics — per-config endpoints (leave empty to disable)
+  # Production endpoint uses HTTPS + domain name — hitting the bare IP will fail
+  # TLS validation (cert CN=damsac.studio). Port 80 auto-redirects to 443.
   configs:
     Debug:
-      STUDIO_ANALYTICS_ENDPOINT: "http://localhost:8080"
+      STUDIO_ANALYTICS_ENDPOINT: "https://damsac.studio"
       STUDIO_ANALYTICS_API_KEY: "sk_test"
     Release:
-      STUDIO_ANALYTICS_ENDPOINT: "YOUR_RELEASE_ANALYTICS_ENDPOINT"
+      STUDIO_ANALYTICS_ENDPOINT: "https://damsac.studio"
       STUDIO_ANALYTICS_API_KEY: "YOUR_RELEASE_ANALYTICS_API_KEY"


### PR DESCRIPTION
## Thinking

TestFlight builds stopped reporting to damsac.studio right around our last merge. Traced it to a server-side change, not a client regression.

**Timeline:**
- `2026-03-21` — damsac-studio `145c994` (pinned Swift SDK revision)
- `2026-03-22` — damsac-studio `caa5ba8` enabled Caddy auto-TLS for the `damsac.studio` vhost
- `2026-03-24` — last Murmur merge (#129, unified analytics event schema)
- Dashboard goes quiet shortly after

**Root cause:**
My local `project.local.yml` (and presumably sac's) pointed `STUDIO_ANALYTICS_ENDPOINT` at `http://178.156.161.158`. After the Caddy change:

1. `POST http://178.156.161.158/v1/events` → `308 Permanent Redirect` → `https://178.156.161.158/v1/events`
2. TLS handshake fails: server cert is `CN=damsac.studio`, not the bare IP → `tlsv1 alert internal error`
3. `StudioAnalytics.NetworkClient.sendSync` records `.networkError` → exponential backoff → circuit breaker opens after 5 failures → events dropped silently, nothing in logs unless you're watching `saLog.warning`

Verified both paths with `curl`:
- `POST https://damsac.studio/v1/events` + `X-API-Key: sk_murmur` → **HTTP 202 `{"accepted":1}`** ✅
- `POST http://178.156.161.158/v1/events` → 308 → TLS error ❌

The SDK and event schema are fine. Only the endpoint is wrong.

## Summary

- Update `project.local.yml.template` so new clones default to `https://damsac.studio` for both Debug and Release
- Add comment explaining why bare-IP HTTP no longer works (prevent future re-introduction)

## What this PR does NOT fix

- `project.local.yml` is gitignored, so each developer needs to flip their own endpoint. I've updated mine locally; sac needs to do the same (or copy from the new template) before their builds will report.
- The silent failure mode itself. Worth a follow-up: surface network/TLS errors through `os_log` at default level, or expose a `lastSendError` property so we notice faster next time.

## Test plan

- [ ] sac: flip `STUDIO_ANALYTICS_ENDPOINT` in local `project.local.yml` to `https://damsac.studio`
- [ ] dam: ship a new TestFlight build, confirm events land on the dashboard within a few minutes
- [ ] Confirm `debug.connectivity_test` event (already sent via curl during diagnosis) is visible on the dashboard