### PR TITLE
ci: fix bundle ID to match TestFlight registration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,9 @@ jobs:
           settings:
             base:
               DEVELOPMENT_TEAM: $APPLE_TEAM_ID
-              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.damsac.murmur
-              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.damsac.murmur.tests
-              APP_GROUP_IDENTIFIER: group.com.damsac.murmur.shared
+              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm.murmur
+              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.isaacwm.murmur.tests
+              APP_GROUP_IDENTIFIER: group.com.isaacwm.murmur.shared
               PPQ_API_KEY: "$PPQ_API_KEY"
             configs:
               Release:

--- a/meta/TESTFLIGHT_CI_SETUP.md
+++ b/meta/TESTFLIGHT_CI_SETUP.md
@@ -4,16 +4,22 @@ One-time prerequisites for the `Release` workflow (`.github/workflows/release.ym
 Once these are done, pushing to `main` ships an internal TestFlight build and
 pushing a `v*` tag ships a build that's ready for external beta review.
 
+> **Note on bundle ID:** the bundle ID is `com.isaacwm.murmur` (registered
+> under the damsac Apple Developer team). The `damsac` namespace is the
+> GitHub org and the team in App Store Connect; the bundle ID prefix
+> happens to be Isaac-namespaced because that's what was registered first.
+> All instructions below use that bundle ID.
+
 ## 1. Register App Group capability on the App ID
 
-The app uses the App Group `group.com.damsac.murmur.shared` for sharing data
+The app uses the App Group `group.com.isaacwm.murmur.shared` for sharing data
 between the app and any future extensions. Automatic provisioning will fail
 unless this is registered as a capability on the App ID itself.
 
 1. Open [Apple Developer → Identifiers](https://developer.apple.com/account/resources/identifiers/list).
-2. Find the App ID `com.damsac.murmur` (create it if missing).
+2. Find the App ID `com.isaacwm.murmur` (create it if missing).
 3. Edit → check **App Groups** under Capabilities → Configure → add
-   `group.com.damsac.murmur.shared`.
+   `group.com.isaacwm.murmur.shared`.
 4. Save.
 
 ## 2. Generate an App Store Connect API key


### PR DESCRIPTION
## Summary

Quick follow-up to #126 — the merged version generates `project.local.yml` with `com.damsac.murmur`, but the actual TestFlight app is registered under `com.isaacwm.murmur` on the damsac team. Without this fix the CI job will fail at signing because the App ID doesn't exist in the team.

- Workflow generates `PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm.murmur` (and matching `.tests` + app group)
- Setup doc updated with an explanatory note about the namespace mismatch (damsac team, isaacwm bundle prefix)

## Thinking

The damsac team owns the bundle ID — Isaac just happened to register it under his personal-style prefix when he first set up the App ID. Updating the workflow to match what's actually in TestFlight is faster than re-registering a new App ID and migrating the existing TestFlight history/testers/external invites.

## Test plan

- [ ] Merge
- [ ] Verify the next push to main produces a build that lands in TestFlight (after secrets are configured per `meta/TESTFLIGHT_CI_SETUP.md`)