### PR TITLE
fix(ci): remove conflicting CODE_SIGN_IDENTITY from project.yml

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -14,7 +14,9 @@ settings:
   base:
     SWIFT_VERSION: "5.9"
     CODE_SIGN_STYLE: Automatic
-    CODE_SIGN_IDENTITY: "Apple Development"
+    # CODE_SIGN_IDENTITY intentionally unset: with automatic signing, Xcode
+    # picks "Apple Development" for Debug and "Apple Distribution" for archive
+    # builds. Setting it explicitly conflicts with CI's distribution override.
     STUDIO_ANALYTICS_ENDPOINT: ""
     STUDIO_ANALYTICS_API_KEY: ""
 


### PR DESCRIPTION
## Summary

The first attempted release archive failed at signing:

> Murmur is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified.

`project.yml` had `CODE_SIGN_IDENTITY: \"Apple Development\"` hardcoded in base settings. CI overrides with `Apple Distribution` for archive builds, and Xcode refuses the conflict.

Fix: remove the explicit identity. With `CODE_SIGN_STYLE: Automatic`, Xcode auto-picks the right identity per configuration (Apple Development for Debug, Apple Distribution for archive). The explicit setting was redundant for local dev and actively harmful for CI.

## Thinking

Automatic signing is supposed to be hands-off about identity selection — that's the whole point. The hardcoded identity was probably copy-pasted from an older Xcode template that pre-dated this behavior. Removing it makes both local Debug builds and CI archive builds work without further changes.

## Test plan

- [ ] Merge → next push to main triggers Release workflow → archive step succeeds → build appears in TestFlight
- [ ] Confirm local Debug builds still work (`make run`) — they should since automatic signing handles Debug → Apple Development on its own