### PR TITLE
fix(ci): set CODE_SIGN_IDENTITY per config to override XcodeGen default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,6 @@ jobs:
         run: |
           BUILD_SETTINGS=(
             "CODE_SIGN_STYLE=Automatic"
-            "CODE_SIGN_IDENTITY=Apple Distribution"
             "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
             "CURRENT_PROJECT_VERSION=${{ github.run_number }}"
           )

--- a/project.yml
+++ b/project.yml
@@ -58,6 +58,14 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Murmur/Murmur.entitlements
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_EMIT_LOC_STRINGS: true
+      configs:
+        # XcodeGen defaults CODE_SIGN_IDENTITY to "iPhone Developer" at the
+        # target level. Override per-config: Debug stays development, Release
+        # uses distribution so archive builds (CI + local) sign correctly.
+        Debug:
+          CODE_SIGN_IDENTITY: "Apple Development"
+        Release:
+          CODE_SIGN_IDENTITY: "Apple Distribution"
     info:
       path: Murmur/Info.plist
       properties:

--- a/project.yml
+++ b/project.yml
@@ -14,7 +14,9 @@ settings:
   base:
     SWIFT_VERSION: "5.9"
     CODE_SIGN_STYLE: Automatic
-    CODE_SIGN_IDENTITY: "Apple Development"
+    # CODE_SIGN_IDENTITY intentionally unset: with automatic signing, Xcode
+    # picks "Apple Development" for Debug and "Apple Distribution" for archive
+    # builds. Setting it explicitly conflicts with CI's distribution override.
     STUDIO_ANALYTICS_ENDPOINT: ""
     STUDIO_ANALYTICS_API_KEY: ""
 


### PR DESCRIPTION
## Summary

Second attempt at unblocking the release archive. PR #141 removed `CODE_SIGN_IDENTITY` from `project.yml`'s base settings, but the build still failed with the same error:

> Murmur is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified.

## Root cause

XcodeGen inserts `CODE_SIGN_IDENTITY = \"iPhone Developer\"` at the **target level** by default for iOS app targets. Target-level settings override project-base settings — so removing it from project-base in PR #141 did nothing. The xcodegen default still won, which is why the build kept thinking it should sign for development.

Confirmed by inspecting the generated `Murmur.xcodeproj/project.pbxproj` after `make generate`:

```
CODE_SIGN_IDENTITY = \"iPhone Developer\";
```

…in both Debug and Release config sections of the Murmur target.

## Fix

Override XcodeGen's default explicitly per config in `project.yml`:

```yaml
configs:
  Debug:
    CODE_SIGN_IDENTITY: \"Apple Development\"
  Release:
    CODE_SIGN_IDENTITY: \"Apple Distribution\"
```

After regen, the project now has the right identity for each configuration. Verified locally:

```
Debug:   CODE_SIGN_IDENTITY = \"Apple Development\";
Release: CODE_SIGN_IDENTITY = \"Apple Distribution\";
```

CI no longer needs to pass `CODE_SIGN_IDENTITY=Apple Distribution` as an override since the project file is correct on its own. Removed it from `BUILD_SETTINGS` in the workflow.

## Test plan

- [ ] Merge → push to main triggers Release workflow → archive succeeds → build appears in TestFlight
- [ ] Local Debug builds still work (`make run`) — Debug config now explicitly uses Apple Development which is the same identity it had before (\"iPhone Developer\" is just the legacy alias)
- [ ] Local archive (Product → Archive in Xcode) signs with Apple Distribution — useful if dam ever needs to manually upload from his laptop