### PR TITLE
fix(ci): use com.isaacwm23.mumur bundle ID to match existing App Store profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,9 @@ jobs:
           settings:
             base:
               DEVELOPMENT_TEAM: $APPLE_TEAM_ID
-              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm.murmur
-              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.isaacwm.murmur.tests
-              APP_GROUP_IDENTIFIER: group.com.isaacwm.murmur.shared
+              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm23.mumur
+              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.isaacwm23.mumur.tests
+              APP_GROUP_IDENTIFIER: group.com.isaacwm23.mumur.shared
               PPQ_API_KEY: "$PPQ_API_KEY"
             configs:
               Release:

--- a/meta/TESTFLIGHT_CI_SETUP.md
+++ b/meta/TESTFLIGHT_CI_SETUP.md
@@ -4,7 +4,7 @@ One-time prerequisites for the `Release` workflow (`.github/workflows/release.ym
 Once these are done, pushing to `main` ships an internal TestFlight build and
 pushing a `v*` tag ships a build that's ready for external beta review.
 
-> **Note on bundle ID:** the bundle ID is `com.isaacwm.murmur` (registered
+> **Note on bundle ID:** the bundle ID is `com.isaacwm23.mumur` (registered
 > under the damsac Apple Developer team). The `damsac` namespace is the
 > GitHub org and the team in App Store Connect; the bundle ID prefix
 > happens to be Isaac-namespaced because that's what was registered first.
@@ -12,14 +12,14 @@ pushing a `v*` tag ships a build that's ready for external beta review.
 
 ## 1. Register App Group capability on the App ID
 
-The app uses the App Group `group.com.isaacwm.murmur.shared` for sharing data
+The app uses the App Group `group.com.isaacwm23.mumur.shared` for sharing data
 between the app and any future extensions. Automatic provisioning will fail
 unless this is registered as a capability on the App ID itself.
 
 1. Open [Apple Developer → Identifiers](https://developer.apple.com/account/resources/identifiers/list).
-2. Find the App ID `com.isaacwm.murmur` (create it if missing).
+2. Find the App ID `com.isaacwm23.mumur` (create it if missing).
 3. Edit → check **App Groups** under Capabilities → Configure → add
-   `group.com.isaacwm.murmur.shared`.
+   `group.com.isaacwm23.mumur.shared`.
 4. Save.
 
 ## 2. Generate an App Store Connect API key


### PR DESCRIPTION
## Summary

Root cause of all four failed Release runs: CI was signing for `com.isaacwm.murmur`, but the only App Store provisioning profile in the damsac team is bound to `com.isaacwm23.mumur` (different App ID — note the `23` suffix and the typo `mumur` without the second `r`).

Automatic signing couldn't find a matching App Store profile for `com.isaacwm.murmur`, so it fell back to a Development profile, and that conflicted with the Apple Distribution identity in the Release config — hence the recurring "automatically signed for development" error.

## Fix

Update the CI-generated `project.local.yml` to use the identifiers that match the existing profile:

| | Before | After |
|---|---|---|
| Bundle ID | `com.isaacwm.murmur` | `com.isaacwm23.mumur` |
| Tests bundle ID | `com.isaacwm.murmur.tests` | `com.isaacwm23.mumur.tests` |
| App Group | `group.com.isaacwm.murmur.shared` | `group.com.isaacwm23.mumur.shared` |

## Thinking

The bundle ID has a typo (`mumur` not `murmur`) — that's how it's registered with Apple. Renaming would require a new App ID, a new TestFlight app record, and losing any existing TestFlight history and tester invites. Not worth it.

The `23` suffix exists because Isaac registered the App ID before the `damsac` team had its preferred namespace; it just stayed.

## Test plan

- [ ] Merge → push to main triggers Release workflow → archive succeeds (automatic signing now finds the "Mumur Distribution" App Store profile) → upload to TestFlight succeeds → build appears in App Store Connect
- [ ] If the upload step fails with "no app record for this bundle ID", the TestFlight app in App Store Connect needs to be re-pointed at `com.isaacwm23.mumur` or a new app record created