### PR TITLE
fix(ci): revert to com.isaacwm.murmur to match TestFlight record

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,9 @@ jobs:
           settings:
             base:
               DEVELOPMENT_TEAM: $APPLE_TEAM_ID
-              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm23.mumur
-              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.isaacwm23.mumur.tests
-              APP_GROUP_IDENTIFIER: group.com.isaacwm23.mumur.shared
+              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm.murmur
+              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.isaacwm.murmur.tests
+              APP_GROUP_IDENTIFIER: group.com.isaacwm.murmur.shared
               PPQ_API_KEY: "$PPQ_API_KEY"
             configs:
               Release:

--- a/meta/TESTFLIGHT_CI_SETUP.md
+++ b/meta/TESTFLIGHT_CI_SETUP.md
@@ -4,7 +4,7 @@ One-time prerequisites for the `Release` workflow (`.github/workflows/release.ym
 Once these are done, pushing to `main` ships an internal TestFlight build and
 pushing a `v*` tag ships a build that's ready for external beta review.
 
-> **Note on bundle ID:** the bundle ID is `com.isaacwm23.mumur` (registered
+> **Note on bundle ID:** the bundle ID is `com.isaacwm.murmur` (registered
 > under the damsac Apple Developer team). The `damsac` namespace is the
 > GitHub org and the team in App Store Connect; the bundle ID prefix
 > happens to be Isaac-namespaced because that's what was registered first.
@@ -12,14 +12,14 @@ pushing a `v*` tag ships a build that's ready for external beta review.
 
 ## 1. Register App Group capability on the App ID
 
-The app uses the App Group `group.com.isaacwm23.mumur.shared` for sharing data
+The app uses the App Group `group.com.isaacwm.murmur.shared` for sharing data
 between the app and any future extensions. Automatic provisioning will fail
 unless this is registered as a capability on the App ID itself.
 
 1. Open [Apple Developer → Identifiers](https://developer.apple.com/account/resources/identifiers/list).
-2. Find the App ID `com.isaacwm23.mumur` (create it if missing).
+2. Find the App ID `com.isaacwm.murmur` (create it if missing).
 3. Edit → check **App Groups** under Capabilities → Configure → add
-   `group.com.isaacwm23.mumur.shared`.
+   `group.com.isaacwm.murmur.shared`.
 4. Save.
 
 ## 2. Generate an App Store Connect API key


### PR DESCRIPTION
## Summary

PR #143 switched CI to `com.isaacwm23.mumur` because that bundle ID had an existing App Store provisioning profile in the developer portal. But the actual TestFlight app record uses `com.isaacwm.murmur` — confirmed in App Store Connect (only one Murmur app exists, bundle ID `com.isaacwm.murmur`, Apple ID 6761315709).

Uploading a build signed for `com.isaacwm23.mumur` to TestFlight would fail because no app record matches that bundle ID, even if the archive succeeds.

## Real fix (one-time, manual, outside this PR)

Create an App Store provisioning profile for `com.isaacwm.murmur` in the Apple Developer Portal:

1. **Identifiers** → click `com.isaacwm.murmur` → enable **App Groups** capability if not already, configure to include `group.com.isaacwm.murmur.shared`
2. **Profiles** → **+** → **App Store** → select `com.isaacwm.murmur` → pick the team's Distribution cert → name it "Murmur App Store"

Once that profile exists, automatic signing will find it via the API key and the archive step will succeed.

## Test plan

- [ ] Profile is created at `developer.apple.com/account/resources/profiles` for App ID `com.isaacwm.murmur`, type App Store
- [ ] Merge this PR → push to main triggers Release workflow → archive succeeds → upload to TestFlight succeeds → build appears under the Murmur app in App Store Connect