### PR TITLE
fix(ci): clear CODE_SIGN_IDENTITY for automatic signing + debug step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,12 @@ jobs:
       - name: Generate Xcode project
         run: make generate
 
+      - name: Debug build settings
+        run: |
+          xcodebuild -project Murmur.xcodeproj -scheme Murmur -showBuildSettings -configuration Release 2>/dev/null \
+            | grep -E "^\s+(CODE_SIGN|DEVELOPMENT_TEAM|PROVISIONING|PRODUCT_BUNDLE_ID|MARKETING_VERSION|CURRENT_PROJECT_VERSION)" \
+            | sort -u
+
       - name: Write ExportOptions.plist
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/project.yml
+++ b/project.yml
@@ -58,14 +58,15 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Murmur/Murmur.entitlements
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_EMIT_LOC_STRINGS: true
+      # Override XcodeGen's target-level default of CODE_SIGN_IDENTITY=
+      # "iPhone Developer". With CODE_SIGN_STYLE=Automatic, Xcode rejects
+      # any explicit identity as a conflict — automatic signing must be
+      # the sole authority. Empty string clears xcodegen's default.
       configs:
-        # XcodeGen defaults CODE_SIGN_IDENTITY to "iPhone Developer" at the
-        # target level. Override per-config: Debug stays development, Release
-        # uses distribution so archive builds (CI + local) sign correctly.
         Debug:
-          CODE_SIGN_IDENTITY: "Apple Development"
+          CODE_SIGN_IDENTITY: ""
         Release:
-          CODE_SIGN_IDENTITY: "Apple Distribution"
+          CODE_SIGN_IDENTITY: ""
     info:
       path: Murmur/Info.plist
       properties:


### PR DESCRIPTION
## Summary

PR #142 set `CODE_SIGN_IDENTITY: \"Apple Distribution\"` for the Release config to override XcodeGen's `\"iPhone Developer\"` default. That turned out to be exactly what triggers the recurring \"automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified\" error.

With `CODE_SIGN_STYLE=Automatic`, Xcode treats any explicit `CODE_SIGN_IDENTITY` (including its own xcodegen default) as a conflict — automatic signing wants to be the sole authority on identity selection.

## Fix

Set `CODE_SIGN_IDENTITY: \"\"` (empty string) in both Debug and Release configs. That clears XcodeGen's default without specifying a value, so automatic signing picks the right identity per action (Apple Development for Debug, Apple Distribution for archive) without anything to conflict against.

Also added a debug step that prints resolved `CODE_SIGN_*` / `PROVISIONING_*` / bundle ID settings before the archive runs. If this fails again, we'll have the actual values Xcode is using rather than guessing.

## Test plan

- [ ] Merge → push to main triggers Release workflow → debug step prints settings → archive succeeds → upload to TestFlight succeeds