### PR TITLE
fix(ci): manual export signing with pre-downloaded profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,15 @@ jobs:
           printf '%s' "$ASC_API_KEY_P8" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
           chmod 600 "$RUNNER_TEMP/private_keys/AuthKey.p8"
 
+      - name: Download App Store provisioning profile
+        uses: Apple-Actions/download-provisioning-profiles@v3
+        with:
+          bundle-id: com.isaacwm.murmur
+          profile-type: IOS_APP_STORE
+          issuer-id: ${{ secrets.ASC_API_ISSUER_ID }}
+          api-key-id: ${{ secrets.ASC_API_KEY_ID }}
+          api-private-key: ${{ secrets.ASC_API_KEY_P8 }}
+
       - name: Generate Xcode project
         run: make generate
 
@@ -130,9 +139,14 @@ jobs:
             <key>destination</key>
             <string>upload</string>
             <key>signingStyle</key>
-            <string>automatic</string>
+            <string>manual</string>
             <key>teamID</key>
             <string>$APPLE_TEAM_ID</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.isaacwm.murmur</key>
+              <string>Murmur App Store</string>
+            </dict>
             <key>uploadSymbols</key>
             <true/>
           </dict>
@@ -175,7 +189,6 @@ jobs:
             -archivePath "$RUNNER_TEMP/Murmur.xcarchive" \
             -exportPath "$RUNNER_TEMP/export" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
-            -allowProvisioningUpdates \
             -authenticationKeyID "$ASC_API_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_API_ISSUER_ID" \
             -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey.p8" \


### PR DESCRIPTION
## Summary

PR #145 unblocked the archive step (clearing `CODE_SIGN_IDENTITY` so automatic signing has nothing to fight). The archive now succeeds with `Apple Distribution`, correct bundle ID, correct team. ✓

The export step still fails with:

```
error: exportArchive Cloud signing permission error
error: exportArchive No profiles for 'com.isaacwm.murmur' were found
```

Even though the App Store profile *does* exist for this bundle ID — Apple's **cloud signing** service is rejecting the API key during `-exportArchive`, despite the same key working fine for the archive step.

## Why

Research (PR thread on the brand) shows production iOS workflows don't use cloud signing for export. The widely-copied pattern (Apple-Actions reference workflows, Bitrise's `xcode-archive` step, the huynguyencong gist) uses **manual export signing with a pre-downloaded profile**. Apple's docs imply cloud signing should work, but in practice teams find it flaky and switch to manual.

## Fix

1. **Pre-download the App Store provisioning profile** via `Apple-Actions/download-provisioning-profiles@v3` (uses the same ASC API key, lands the profile in `~/Library/MobileDevice/Provisioning Profiles/`)
2. **Switch ExportOptions.plist to manual signing** with an explicit `provisioningProfiles` dict mapping `com.isaacwm.murmur` → `Murmur App Store`
3. **Drop `-allowProvisioningUpdates`** from the export step — we don't need cloud signing anymore since the profile is local

The archive step stays on automatic signing (it's working). The downloaded profile becomes available for the archive step too as a side effect.

## Test plan

- [ ] Merge → push to main triggers Release workflow → archive succeeds → profile downloads → export with manual signing succeeds → upload to TestFlight succeeds → build appears in App Store Connect
- [ ] If profile name `Murmur App Store` is wrong, error will be clear ("provisioning profile not found"); easy to correct

## References

- Apple-Actions reference: [download-provisioning-profiles](https://github.com/Apple-Actions/download-provisioning-profiles)
- Production gist: https://gist.github.com/huynguyencong/004e98e4d9e7671f93fec280ddb7fc18
- Bitrise reference: https://github.com/bitrise-steplib/steps-xcode-archive