### PR TITLE
fix(ci): import Apple Distribution certificate before signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,12 @@ jobs:
           printf '%s' "$ASC_API_KEY_P8" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
           chmod 600 "$RUNNER_TEMP/private_keys/AuthKey.p8"
 
+      - name: Import Apple Distribution certificate
+        uses: Apple-Actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERT_P12 }}
+          p12-password: ${{ secrets.APPLE_CERT_PASSWORD }}
+
       - name: Download App Store provisioning profile
         uses: Apple-Actions/download-provisioning-profiles@v3
         with:


### PR DESCRIPTION
## Summary

PR #146 set up manual export signing with a downloaded profile, but export still failed:

```
error: exportArchive No signing certificate "iOS Distribution" found
```

Manual signing needs the actual cert installed in the keychain. We had the profile downloaded but no cert imported.

## Fix

Add `Apple-Actions/import-codesign-certs@v3` step that pulls `APPLE_CERT_P12` (base64 of `.p12` file) and `APPLE_CERT_PASSWORD` secrets and imports the cert into a temporary keychain xcodebuild reads from.

## Required secrets (new)

- `APPLE_CERT_P12` — base64-encoded `.p12` of an Apple Distribution certificate
- `APPLE_CERT_PASSWORD` — password used when exporting the `.p12`

## Test plan

- [ ] Both new secrets added in GitHub
- [ ] Merge → push to main triggers Release workflow → cert imports → profile downloads → archive succeeds → export with manual signing succeeds → upload to TestFlight succeeds → build appears in App Store Connect