### PR TITLE
fix(ci): relink brew tools after cache restore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
           key: brew-${{ runner.os }}-xcodegen-xcbeautify
 
       - name: Install tools
-        run: brew install xcodegen xcbeautify
+        run: |
+          brew install xcodegen xcbeautify || true
+          brew link --overwrite xcodegen xcbeautify || true
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Summary

Reruns of the Release workflow fail at `make generate` with `xcodegen: No such file or directory`. Cache restore puts the Homebrew Cellar back, but the symlinks in `/opt/homebrew/bin` aren't cached, and `brew install` sees the files already present and exits without re-linking — so `xcodegen` ends up off PATH.

## Fix

Match the pattern already used in `ci.yml`:

```bash
brew install xcodegen xcbeautify || true
brew link --overwrite xcodegen xcbeautify || true
```

`brew link --overwrite` recreates the symlinks regardless of cache state.

## Test plan

- [ ] Merge → push to main triggers Release workflow → `xcodegen` is on PATH → archive + sign + upload chain runs through