### PR TITLE
meta: rebuild-era STATE/ROADMAP/CANON

### DIFF
--- a/meta/CANON.md
+++ b/meta/CANON.md
@@ -49,3 +49,21 @@ Append new decisions here with date, who proposed, who agreed.
 | 2026-02-28 | PRs must include Thinking section | dam | Review thinking, not just code |
 | 2026-02-28 | Metacraft skills installed at user level (~/.claude/skills/) | dam | Shared tooling: genesis, meta-agent, session-lifecycle, tmux-lanes, gather, skill-creator |
 | 2026-02-28 | Use cancelRecording() over stopRecording() in agent path | dam | Optimizing for speed. Accept potential loss of final partial transcript (~500ms of speech) rather than blocking for finalization. Revisit if users report missing words. |
+
+## Rebuild Decisions (2026-07 pivot — agreement noted per row)
+
+Everything above this section describes the pre-pivot app and is historical. The rebuild's canon:
+
+| Date | Decision | Proposed by | Agreed via |
+|------|----------|-------------|------------|
+| 2026-07-01 | Pivot: AI meeting notes for blue-collar field work (site walks → documents). Ground-up rebuild; Swift codebase superseded, kept as reference | dam | sac's SITEWALK design study shaped spec Rev 2; sac built the iOS app against it (PR #1) — de facto. Formal spec review still owed |
+| 2026-07-01 | Architecture: Rust workspace (harness → murmur-core → stt → ffi/UniFFI) + native SwiftUI/Compose shells. Native over Tauri (background audio, feel) | dam | pending sac's spec review |
+| 2026-07-01 | Division of labor: dam = harness/core/STT/FFI; sac = renderers/components/visual direction | dam | operating as such since |
+| 2026-07-01 | Local-first: SQLite, UUIDv7, tombstones, single-writer store; sync-ready, no sync/accounts in v1. Audio never leaves device | dam | pending sac's spec review |
+| 2026-07-02 | Product rules R1–R9 (hidden transcript, deliberate stop, under-extraction bias R6, spend meter R9, …) — spec §3 | dam | pending sac's spec review |
+| 2026-07-03 | Repo: `damsac/sitewalk` (sac's working title graduated to repo name; brand stays Murmur) | dam | sac PR'd into it |
+| 2026-07-04 | Swap-contract fix: items get a `source` column (live/authoritative/manual); process() clears live items only AFTER successful extraction | dam | core-side, informs sac's board UX |
+| 2026-07-04 | STT: benchmark-first — whisper.cpp Rust-side is the preferred bet, 06-spike confirms or kills. Driver: vocabulary→STT biasing needs it; iOS 26 SpeechAnalyzer dropped custom vocabulary | dam | supersedes HANDOFF's "STT stays in Swift" — flagged to sac in PR #1 review |
+| 2026-07-04 | UI↔core seam: `WalkEngine` protocol at the FFI boundary, domain types only (never harness wire types); swap point `AppModel.init(engine:)` | sac | dam's PR #1 review endorses |
+| proposed | Template keys: `landscape \| property \| inspection` as canonical | sac (in code) | awaiting explicit ack from both |
+| proposed | STT DONE semantics: flush final utterance (supersedes 2026-02-28 cancel-for-speed canon for the site-walk context) | dam | joint call pending |

--- a/meta/ROADMAP.md
+++ b/meta/ROADMAP.md
@@ -4,60 +4,43 @@ Shared priorities and sequencing. Who's doing what, what's next, what's blocked.
 
 Updated when priorities shift. Either person can propose changes via PR.
 
+**2026-07-01 pivot:** Murmur rebuilt from scratch as a field-work voice agent (site walks → documents). The pre-pivot roadmap is archived in this file's git history. Code: `damsac/sitewalk`. Docs/specs/plans: this repo, `pr/dam/rebuild-vision` → `docs/superpowers/`.
+
 ---
 
 ## Active
 
-| Work | Owner | Status | Branch |
-|------|-------|--------|--------|
-| TestFlight prep (checklist items 3, 6, 13–15, 20) | dam + sac | In progress | dam, PR pending |
-| Wire error views (MicDenied, OutOfCredits, APIError) | sac + dam | Not started | — |
+| Work | Owner | Status |
+|------|-------|--------|
+| sitewalk PR #1 — iOS app behind WalkEngine seam | sac | reviewed; small fixes then merge |
+| 06-spike — whisper-rs STT benchmark (GO/KILL) | dam | plan ready (`docs/superpowers/plans/2026-07-04-rust-core-06-spike-stt-benchmark.md`); needs an executor |
+| Harness patches: PPQ Bearer auth + `ANTHROPIC_BASE_URL` | sac | on sac's machine, needs a PR |
 
-## Up Next
+## Up Next (sequenced)
 
-- User-facing home view toggle (Settings: Scanner/Navigator) — Zones is now default, toggle for alternatives
-- VoiceOver accessibility + `accessibilityReduceMotion` broadly
-- Search (entries become unfindable at scale)
-- LLM cost visibility tool (usage log + Settings UI)
-- Conversation lifecycle: reset mechanism, context indicator
+1. **Plan 06 — STT** (dam; blocked on spike verdict). Also carries: items `source` column migration, swap-contract fix (clear live items only after successful process), template-keys alignment.
+2. **Plan 07 — layout protocol + FFI** (dam builds bridge, sac consumes). Replaces `DemoWalkEngine` behind `AppModel.init(engine:)`. FFI boundary at domain types; never hold the Store lock across `maybe_extract`.
+3. **Prompt-optimization loop** on the 05b eval suite (rank on F0.5, gate on recall).
+4. **Photo attachment schema** (rides a migration after `source`).
 
-## Open Questions
+## Decisions needed (joint)
 
-These need resolution. Either person can claim one and propose an answer via PR.
+- Template keys: adopt sac's `landscape | property | inspection` as canonical? (dam: yes — needs sac's ack)
+- STT DONE semantics: flush final utterance vs speed (old canon chose speed for quick-capture; site walks argue flush)
+- Fate of the Gallery/Screens static twins after design freeze
 
-- Token budget: how many active entries before truncating context?
-- Conversation lifecycle: when does multi-turn reset? Timer, explicit button, or N seconds of silence?
-- Undo stacking: independent undo for rapid actions?
-- ~~Home view default~~: resolved — Zones is now the default; SacHomeView removed
+## Completed (rebuild era)
 
-## Completed
-
-| Work | Date | Commits |
-|------|------|---------|
-| Agent protocol + action types in MurmurCore | 2026-02-22 | `c27110d..d7c53cf` |
-| Tool schemas (create, update, complete, archive entries) | 2026-02-22 | `c27110d..d7c53cf` |
-| Smart list with flat sorting, daily brief | 2026-02-22 | `49cb1bc..e0936cf` |
-| Gesture handlers (swipe right = complete, swipe left = snooze) | 2026-02-26 | `a2fc7e8..d2e2838` |
-| Response toast with undo support | 2026-02-26 | `a2fc7e8` |
-| Remove progressive disclosure system | 2026-02-22 | `f389a81..23125d9` |
-| App icon redesign | 2026-02-22 | `6ddc930..c4b8337` |
-| Focus strip + category sections | 2026-02-26 | PR #59 |
-| Resilient action parsing + multi-turn wiring | 2026-03-01 | PR #83 |
-| Unified home composition (delete DailyFocus, variant system) | 2026-03-04 | PR #93 |
-| Layout diff system (Phases 1–3) | 2026-03-04 | `30aebc6..ab40bf0` |
-| Three-zone focus screen + keyboard UX fixes | 2026-03-05 | PR #94 |
-| Card redesign (borderless rows, flow chips) | 2026-03-05 | `455f2d5` |
-| Launch screen | 2026-03-05 | `379f927` |
-| Reactive wave visualizer + processing glow | 2026-03-06 | `b9bb343` |
-| Color palette tightening | 2026-03-06 | `8871103` |
-| Inline editing in entry detail | 2026-03-06 | `f2658d8` |
-| Calendar view + habits by cadence | 2026-03-07 | PR #97 |
-| Tab swipe (TabView page style for zones) | 2026-03-07 | `1931934`, `23b46a5` |
-| Real token usage for credits + switch to Haiku | 2026-03-14 | `e8a4a46` |
-| TestFlight prep: export compliance, portrait lock | 2026-03-14 | `6512f3d` |
-| Error handling hardening design spec | 2026-03-14 | `5528c59` |
-| Due date formatting, layout animations, UI polish | 2026-03-14 | `24c4430` |
-| Simplify categories (remove `thought`, down to 7) | 2026-03-01 | various |
-| TestFlight prep: items 16–19 (export compliance, portrait lock, DevMode gate, privacy manifest) | 2026-03-22 | Phase 1 |
-| Remove SacHomeView, Zones as default home | 2026-03-22 | Phase 2 |
-| Dead code purge + code quality improvements | 2026-03-22 | Phase 3 |
+| Work | Date | Where |
+|------|------|-------|
+| Vision spec (4 revs) + UI mocks + user stories | 2026-07-01 | `docs/superpowers/specs/`, `docs/superpowers/mocks/` |
+| Plan 01 — harness foundation (agent loop, tools, providers) | 2026-07-01 | sitewalk, 14 commits |
+| Plan 02 — memory/reflection/context (provenance, snapshots) | 2026-07-02 | sitewalk, 15 commits |
+| Plan 03 — domain + SQLite store (tombstones, sync-ready) | 2026-07-02 | sitewalk, 14 commits |
+| Plan 04 — processing pipeline + reflection coordinator + R9 cost log | 2026-07-03 | sitewalk, 16 commits |
+| Plan 05 — live in-session extraction | 2026-07-03/04 | sitewalk, 6 commits |
+| Plan 05b — eval suite (corpus + deterministic grader + runners) | 2026-07-04 | sitewalk, 8 commits |
+| Memory frontier research | 2026-07-02 | `docs/research/` |
+| STT frontier research (SpeechAnalyzer biasing regression, engine survey) | 2026-07-04 | `docs/research/` |
+| sitewalk repo → damsac org, public | 2026-07-04 | github.com/damsac/sitewalk |
+| iOS app: design system + full flow behind WalkEngine seam | 2026-07-04 | sitewalk PR #1 (sac) |

--- a/meta/dam/STATE.md
+++ b/meta/dam/STATE.md
@@ -6,35 +6,43 @@ What dam is working on right now. Updated with every PR.
 
 ## Current focus
 
-- **TestFlight polish** — UI cleanup, scroll fixes, LLM tool improvements, speech-to-text in entry detail
-- **Error handling design** — spec written at `docs/superpowers/specs/2026-03-14-error-handling-hardening-design.md`, not yet implemented
+**The rebuild.** Murmur pivoted 2026-07-01 to AI meeting notes for blue-collar field work (GC site walks, inspections). Ground-up rewrite: Rust core + native shells. This repo (`damsac/Murmur`) is now the docs home — specs, plans, research live on `pr/dam/rebuild-vision`. Code lives at **`damsac/sitewalk`** (public).
 
-## What happened last session
+dam owns: harness / murmur-core / STT / FFI. sac owns: renderers / component library / visual direction.
 
-- Fixed scroll bug in All tab — replaced offset-based tab switching with conditional rendering in SacHomeView, ZonedFocusHomeView, DamHomeView
-- Fixed habit completion via LLM — added `check_off_habit` to update_entries tool so LLM marks habit done for period instead of archiving
-- Added notes support to LLM — agent can now read and write entry notes via create_entries and update_entries
-- Added speech-to-text mic button in entry detail notes — records speech, sends through LLM pipeline with entry context so agent writes notes
-- System prompt updated with habit-specific guidance
+## Where the core is (sitewalk main @ 7cf4bdb, 214 tests, clippy clean)
 
-## Recent decisions
+| Plan | What | Status |
+|------|------|--------|
+| 01 | `crates/harness` — agent loop, tools, Anthropic provider, mock provider | done |
+| 02 | memory + reflection + context assembler (provenance, snapshots, forgetting) | done |
+| 03 | `crates/murmur-core` — SQLite store, jobs/sessions/items/contacts, tombstones, sync-ready | done |
+| 04 | processing pipeline (two-phase extract+summary), reflection coordinator, R9 cost log | done |
+| 05 | live in-session extraction (`LiveExtractor`) — incremental passes onto the live board | done |
+| 05b | `crates/evals` — synthetic site-walk corpus + deterministic grader (F0.5, R6-weighted) | done |
+| 06-spike | STT benchmark: whisper-rs feasibility/RTF/biasing, GO-KILL exit criteria | plan ready, not run |
+| 06 | STT for real (+ items `source` column, swap-contract fix) | blocked on spike |
+| 07 | layout protocol + FFI (UniFFI) — **this is where sac's WalkEngine bridge lands** | queued |
 
-- Scroll fix: conditional rendering over offset-based tab switching (GeometryReader + HStack + offset caused gesture conflicts between simultaneous ScrollViews)
-- Habit tools: `check_off_habit` field on update_entries, not a new tool — keeps tool surface small
-- Notes via LLM pipeline: speech-to-text in entry detail goes through the full LLM pipeline (not raw transcript append) so the agent can structure/summarize
-- Notes in context: truncated to 100 chars in LLM context line to avoid blowing up token usage
+## What sac should know
 
-## Open questions
-
-- Credit value redefinition: $0.001 → $0.0005 per credit to make packs profitable
-- Conversation reset: timer, explicit button, or N seconds of silence?
-- Token budget for context window
-- Home view default for testers: which variant ships?
-- Note dictation UX: should the recording overlay show when dictating notes, or should there be a more subtle inline indicator?
+- **Your PR #1 is reviewed** (comment on the PR): merges after small fixes. Key asks: fixture-type honesty (they're the interim domain model, incl. in the WalkEngine signature), a `TranscriptSource` injection seam, four verified state-transition bugs (DISCARD marks SENT, share-cancel finalizes, discard-while-paused spins, `recognition.cancel()` drops the final phrase).
+- **STT may move Rust-side.** iOS 26's SpeechAnalyzer dropped custom-vocabulary biasing, which our vocabulary→STT loop needs. The 06-spike benchmark decides. Your seam survives either way (`append(transcript:)` takes text).
+- **Answers to your HANDOFF questions**: events batched per live pass; core mints document numbers; photos need a schema migration (queued); your `landscape | property | inspection` template keys — proposed as canonical, say yes and it's locked.
+- **The bridge contract's core-side realities**: `finish()` = `end_and_record_session` + `process()` — two-phase, budgeted <8s; live items get tombstoned and re-extracted at process time (the board will "swap" — UI should anticipate); `LiveExtractor.maybe_extract` is `&mut self`, the FFI wrapper serializes it.
 
 ## What I need from sac
 
-- Help wiring error views (MicDenied, OutOfCredits, APIError) — on roadmap as shared task
-- Empty state fix for SacHomeView FocusTabView
-- Sign off on onboarding demo transcript
-- Test the scroll fix in SacHomeView All tab
+- Apply the PR #1 review conditions (or push back — it's a conversation).
+- The two harness patches on your machine (PPQ Bearer auth + `ANTHROPIC_BASE_URL`) as a proper PR with tests.
+- Template-keys ack (see above) before the artifact seam ossifies.
+- Read the vision spec + STT research on `pr/dam/rebuild-vision` — the branch is finally pushed; a formal spec review from you is still owed.
+
+## Open questions
+
+- STT engine: whisper-rs Rust-side vs staged hybrid — the 06-spike benchmark decides (dam's preference: Rust-side if the numbers hold).
+- STT finish semantics on DONE (flush final phrase vs speed) — old canon says speed, site-walk reality says flush. Joint call with sac, flagged in PR #1 review.
+
+---
+
+*Pre-pivot state (TestFlight era) archived in git history of this file.*


### PR DESCRIPTION
## Thinking

The meta files on main still describe the TestFlight era (March–May). Since the 2026-07-01 pivot, the real state lives scattered across the rebuild branch and the sitewalk repo — sac shouldn't have to hunt a branch to find out what dam is doing. This puts the rebuild-era meta on main: dam's STATE (core plan-series status + what each of us needs from the other), ROADMAP (sequencing through Plan 07), and CANON (rebuild decisions log with honest per-row agreement provenance — two rows explicitly await sac's ack: template keys, STT DONE semantics).

Cherry-picked from pr/dam/rebuild-vision (0a66a21). Pre-pivot content is archived in git history, noted in each file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)