### PR TITLE
docs: story-arc + Phase 2 runbook for repo re-unification

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,0 +1,166 @@
+# Murmur — the story so far
+
+One repository, two eras. Murmur began as a SwiftUI iOS app and was reborn on
+2026-07-01 as a field-work voice agent built on a Rust core. This document is the
+narrative arc; the git history is the primary source. Where a section says "browse
+in history," the commits are really there — nothing has been squashed away.
+
+---
+
+## Era I — Murmur, the Swift app (≈2026-02 → 2026-07-01)
+
+**What it was.** Speak into your phone, get organized entries. An autonomous
+second brain: voice → transcription → an LLM agent that captured, categorized,
+surfaced, and acted on your entries (todos, notes, reminders, ideas, lists,
+habits, questions). Not a transcription app — a thinking partner that managed
+mental load.
+
+**Shape of the codebase.**
+
+- **`Murmur/`** — SwiftUI iOS app, generated from `project.yml` via XcodeGen.
+- **`Packages/MurmurCore/`** — Swift package: transcription pipeline, LLM
+  service (PPQ.ai), data models.
+
+**Landmarks (all browsable in git history):**
+
+- **Agent pipeline** — voice → `AppleSpeechTranscriber` → `Pipeline.processWithAgent`
+  → `PPQLLMService` → `AgentActionExecutor` → conversation thread. Multi-turn,
+  real tool-result feedback, resilient per-tool-call error isolation,
+  file-based agent memory (`update_memory` tool).
+- **Composition system** — unified `HomeComposition` model driving two home
+  variants (Scanner: urgency-grouped; Navigator: category-grouped), LLM-composed
+  via a forced `compose_view` tool, with a layout-diff refresh path.
+- **Categories as behavior** — a category earns its existence only by driving
+  different behavior (7 categories; `thought` was removed for having none).
+- **Shipping infrastructure** — TestFlight release pipeline, CI signing,
+  credit system, Studio analytics SDK.
+- **~151 merged PRs** of product and platform work.
+
+**How to browse Era I.** The Swift app tree is preserved in history. After the
+Phase-2 pivot commit (below) removes it from the working tree, you can still read
+any of it:
+
+```
+# The last commit where the Swift app was live in the tree:
+git log --oneline --all -- Murmur/ Packages/MurmurCore/ | head -1
+# Browse the app as it stood then:
+git show <that-sha>:Murmur/MurmurApp.swift
+git ls-tree -r <that-sha> -- Murmur/
+```
+
+Design specs, plans, and reviews from this era live under `docs/` (e.g.
+`docs/specs/`, `docs/plans/`, `docs/reviews/`, and the pre-pivot
+`docs/superpowers/specs/` design docs).
+
+---
+
+## Era transition — the 2026-07-01 pivot
+
+Murmur pivoted from a general-purpose second brain to **AI meeting notes for
+blue-collar field work**: general contractors walking a site, inspectors, trades
+— speak through the walk, get a structured document (site walk → landscape /
+property / inspection report).
+
+The pivot is documented, not just decided:
+
+- **Vision spec** (4 revisions): `docs/superpowers/specs/2026-07-01-murmur-rebuild-vision-design.md`
+- **UI mocks**: `docs/superpowers/mocks/2026-07-01-rebuild-ui/`
+- **Canon** (rebuild decisions, agreement noted per row): `meta/CANON.md`,
+  section "Rebuild Decisions (2026-07 pivot)".
+
+Why rebuild rather than refactor: the product's atomic unit changed (entry →
+site-walk session/job with items and documents), the architecture changed (Rust
+core + native shells over a Swift-only app), and the constraints changed
+(local-first, audio never leaves device, vocabulary → STT biasing loop). The
+Swift codebase was superseded but kept as reference — hence this single repo.
+
+Key architecture decisions from the pivot (see `meta/CANON.md`):
+
+- **Rust workspace** — `harness` → `murmur-core` → `stt` → `ffi` (UniFFI) —
+  with native SwiftUI / Compose shells. Native chosen over Tauri for background
+  audio and feel.
+- **Local-first** — SQLite, UUIDv7, tombstones, single-writer store; sync-ready
+  but no sync/accounts in v1.
+- **Product rules R1–R9** — hidden transcript, deliberate stop, under-extraction
+  bias (R6), spend meter (R9), and more (spec §3).
+
+---
+
+## Era II — the Rust rebuild (2026-07-01 → present)
+
+Built in the open at **`damsac/sitewalk`** (the working title graduated to a repo
+name; the brand stays **Murmur**). The rebuild proceeded as a numbered plan
+series, each plan a chapter:
+
+| Plan | What | Status |
+|------|------|--------|
+| 01 | `crates/harness` — agent loop, tools, Anthropic + mock providers | done (14 commits) |
+| 02 | memory + reflection + context assembler (provenance, snapshots, importance-aware forgetting) | done (15 commits) |
+| 03 | `crates/murmur-core` — SQLite store, jobs/sessions/items/contacts, tombstones, sync-ready | done (14 commits) |
+| 04 | processing pipeline (two-phase extract + summary), reflection coordinator, R9 cost log | done (16 commits) |
+| 05 | live in-session extraction (`LiveExtractor`) | done (6 commits) |
+| 05b | `crates/evals` — synthetic corpus + deterministic grader (F0.5, R6-weighted) | done (8 commits) |
+| 06-spike | STT benchmark: whisper-rs feasibility / RTF / biasing, GO-KILL exit criteria | **GO** |
+| 06 | STT for real (+ items `source` column, swap-contract fix) | next |
+| 07 | layout protocol + FFI (UniFFI) — where the iOS `WalkEngine` bridge lands | queued |
+
+**iOS shell** — sac built the native SwiftUI app (design system + full flow)
+behind a `WalkEngine` protocol seam at the FFI boundary (`AppModel.init(engine:)`
+is the swap point), against a `DemoWalkEngine` until Plan 07 wires the real core.
+Landed as sitewalk **PR #1**; follow-ups tracked in sitewalk **issue #2**.
+
+**Research that shaped it** — memory frontier research (snapshots, provenance,
+importance-aware forgetting) and STT frontier research (engine survey, iOS 26
+SpeechAnalyzer dropping custom-vocabulary biasing, benchmark plan) live under
+`docs/research/`.
+
+**How to browse Era II.** Until the Phase-2 merge, the code lives at
+`github.com/damsac/sitewalk`. After the unrelated-histories merge, sitewalk's full
+commit history is grafted into this repo and browsable here:
+
+```
+# Rebuild history is carried over intact (not copy-imported):
+git log --oneline <SITEWALK_MERGE_COMMIT_SHA>^2   # PLACEHOLDER — filled in Phase 2
+# The Rust workspace sits at the repo root after migration.
+```
+
+---
+
+## Era III — the 2026-07-04 re-unification
+
+The rebuild was living in a separate repo (`damsac/sitewalk`). We decided to fold
+it **back into `damsac/Murmur`** so one repository tells the whole arc — Swift era
+→ pivot → Rust rebuild — with no history lost.
+
+**Phase 1** (done): land the pivot chapter on Murmur `main` — vision spec, UI
+mocks, plan series 01–07, memory/STT research, rebuild-era meta. Merged as a
+merge commit (branch history preserved) in **PR #152**.
+
+**Phase 2** (gated on in-flight rebuild work landing): see
+`docs/reunify/RUNBOOK.md`. In order:
+
+1. An explicit **pivot commit** removes the Swift app (`Murmur/`,
+   `Packages/MurmurCore/`) from the working tree — preserved in history only.
+   Conceptually: *"pivot: retire the Swift app from the tree (Era I preserved in
+   history)."* Its SHA gets recorded here in Phase 2:
+   `<PIVOT_COMMIT_SHA>` — **PLACEHOLDER**.
+2. sitewalk `main` is fetched as a remote and merged with
+   `git merge --allow-unrelated-histories` — never a copy-import — so Era II's
+   history is carried over intact. The merge commit's SHA:
+   `<SITEWALK_MERGE_COMMIT_SHA>` — **PLACEHOLDER**.
+3. The Rust workspace ends up at the repo root; `README.md` is replaced (draft at
+   `docs/reunify/README.next.md`); sitewalk issue #2 is migrated here.
+4. `damsac/sitewalk` gets a pointer README and is archived (`gh repo archive`) —
+   history preserved and browsable, code frozen.
+
+**Browsing map after re-unification:**
+
+| To see… | Do… |
+|---------|-----|
+| The Swift app as it lived | `git show <PIVOT_COMMIT_SHA>^:Murmur/…` (parent of the pivot commit) |
+| The pivot decision | `docs/superpowers/specs/2026-07-01-murmur-rebuild-vision-design.md` + `meta/CANON.md` |
+| The Rust rebuild's chapter-by-chapter history | `git log <SITEWALK_MERGE_COMMIT_SHA>^2` |
+| The current product & workspace | repo root + `README.md` |
+
+*Placeholders marked `<…_SHA>` are filled in during Phase 2 once the pivot and
+unrelated-histories merge commits exist.*

--- a/docs/reunify/README.next.md
+++ b/docs/reunify/README.next.md
@@ -1,0 +1,77 @@
+<!--
+  ⚠️ DRAFT — FOR PHASE 2 OF THE REPO RE-UNIFICATION.
+  This is the intended replacement for the repo-root README.md AFTER the
+  unrelated-histories merge brings sitewalk's Rust workspace to the root and the
+  Swift app is retired from the tree. Do NOT copy this over the live README.md
+  during Phase 1 — the live README still describes the Swift app, which is still
+  in the tree. Promotion happens in docs/reunify/RUNBOOK.md, step "swap README".
+-->
+
+# Murmur
+
+**Speak through a site walk, get a structured document.** Murmur is a field-work
+voice agent for general contractors, inspectors, and trades: talk your way through
+a walk-through and an on-device agent turns it into an organized report — a
+landscape, property, or inspection document — without you touching the phone.
+
+Audio never leaves the device. Local-first, sync-ready.
+
+> Murmur began life as a general-purpose voice-to-second-brain iOS app. On
+> 2026-07-01 it pivoted to field work and was rebuilt on a Rust core. The whole
+> arc lives in this one repository — see **[docs/HISTORY.md](../HISTORY.md)**.
+
+## Workspace layout
+
+Murmur is a Rust workspace with native shells:
+
+```
+crates/
+  harness/       agent loop, tools, LLM providers (Anthropic + mock)
+  murmur-core/   domain + SQLite store (jobs, sessions, items, contacts;
+                 tombstones, UUIDv7, single-writer, sync-ready)
+  stt/           speech-to-text (whisper-rs) + vocabulary→STT biasing
+  ffi/           UniFFI boundary — WalkEngine protocol, domain types only
+  evals/         synthetic site-walk corpus + deterministic grader (F0.5)
+apps/
+  ios/           native SwiftUI shell (WalkEngine seam, AppModel.init(engine:))
+docs/            specs, plans, research, history
+meta/            dam + sac collaboration hub (CANON, ROADMAP, STATE)
+```
+
+*(Confirm exact crate/app paths against the tree at migration time — this reflects
+the plan series 01–07 as of the re-unification.)*
+
+## How it works
+
+1. **Capture** — start a walk, talk. The transcript stays hidden (R1); you stop
+   deliberately (R2).
+2. **Live extraction** — as you speak, the agent drafts items onto the board;
+   it biases toward under-extraction (R6).
+3. **Process** — on finish, a two-phase extract-and-summarize pass produces the
+   authoritative document (budgeted; live items are re-extracted, so the board
+   "swaps").
+4. **Spend meter** — token cost is surfaced (R9).
+
+Full product rules R1–R9 are in the vision spec:
+`docs/superpowers/specs/2026-07-01-murmur-rebuild-vision-design.md`.
+
+## Building
+
+*(Fill in from the migrated workspace — Rust toolchain + `cargo build`,
+`cargo test`, `cargo clippy`; iOS shell via the app in `apps/ios/`. Replace the
+Swift-era `make`/XcodeGen instructions, which no longer apply.)*
+
+## Collaboration
+
+Built by **damsac** — dam (harness / murmur-core / STT / FFI) and sac (renderers /
+component library / visual direction). The `meta/` directory is the hub:
+`CANON.md` (agreed decisions), `ROADMAP.md` (priorities), `dam/STATE.md` +
+`sac/STATE.md` (current focus). PRs require a **Thinking** section — reviewers read
+thinking first, code second.
+
+## History
+
+This repo tells the whole story: the Swift/SwiftUI Murmur (Era I), the 2026-07-01
+field-work pivot, the Rust rebuild (Era II, formerly `damsac/sitewalk`), and the
+2026-07-04 re-unification. Start at **[docs/HISTORY.md](../HISTORY.md)** for how to
+browse each era in git history.

--- a/docs/reunify/RUNBOOK.md
+++ b/docs/reunify/RUNBOOK.md
@@ -13,6 +13,12 @@ commit-by-commit history is the story — it must arrive via
 Run everything from a clean checkout of `damsac/Murmur` on an up-to-date `main`.
 Work on a branch (`pr/dam/reunify-merge`) and land via PR — `main` is protected.
 
+**Gate (Phase 2 preconditions):** the in-flight sitewalk lanes must land and push
+to sitewalk `main` first — Plan 08 + its review, the carry-notes fix branch, and
+the first-real-walk key wiring. Open sitewalk issues (**#2**, **#3**) do **not**
+block — they **migrate** to Murmur (step 6). Treat "migrate open issues" as the
+precondition, not "resolve" them.
+
 ---
 
 ## 0. Preconditions (verify first)
@@ -136,11 +142,13 @@ gh pr merge --merge
 
 ---
 
-## 6. Migrate sitewalk issue #2
+## 6. Migrate open sitewalk issues (#2, #3)
 
-sitewalk issue #2 = "PR #1 review follow-ups: seam hygiene + 4 state-transition
-bugs." Re-file on Murmur (gh has no cross-repo transfer for archived targets;
-recreate + link):
+Migrate every open sitewalk issue — as of this writing #2 ("PR #1 review
+follow-ups: seam hygiene + 4 state-transition bugs") and #3. Re-file each on
+Murmur (gh has no cross-repo transfer for archived targets; recreate + link).
+Re-check `gh issue list --repo damsac/sitewalk --state open` at run time in case
+new ones opened. Example for #2:
 
 ```bash
 gh issue view 2 --repo damsac/sitewalk --json title,body,labels > /tmp/sw-issue-2.json
@@ -188,6 +196,6 @@ gh repo archive damsac/sitewalk --yes
 - [ ] `git log HEAD^2` on the merge commit shows sitewalk's rebuild history
 - [ ] `docs/HISTORY.md` placeholders replaced with real SHAs
 - [ ] `README.md` describes the field-work product + Rust workspace
-- [ ] Murmur issue mirrors sitewalk#2; sitewalk#2 closed with a link
+- [ ] Every open sitewalk issue (#2, #3, …) mirrored to Murmur; originals closed with a link
 - [ ] sitewalk has a pointer README and is archived
 - [ ] Signing secrets (`Certificates.p12`, `distribution.cer`, `docs/legal/`) never committed

--- a/docs/reunify/RUNBOOK.md
+++ b/docs/reunify/RUNBOOK.md
@@ -1,0 +1,193 @@
+# Phase 2 runbook — re-unify sitewalk into Murmur
+
+This is the exact command sequence for folding `damsac/sitewalk` back into
+`damsac/Murmur` via an unrelated-histories merge. **Do not run any of this until
+the in-flight sitewalk work has landed** (sitewalk PR #1 merged, issue #2
+follow-ups resolved or explicitly deferred, harness patches PR'd). Phase 1 (PR
+#152, the pivot chapter) is already on Murmur `main`.
+
+Principle: **carry history over, never copy-import.** The Rust rebuild's
+commit-by-commit history is the story — it must arrive via
+`git merge --allow-unrelated-histories`, not by copying files into a commit.
+
+Run everything from a clean checkout of `damsac/Murmur` on an up-to-date `main`.
+Work on a branch (`pr/dam/reunify-merge`) and land via PR — `main` is protected.
+
+---
+
+## 0. Preconditions (verify first)
+
+```bash
+cd /Users/claude/Murmur
+git switch main && git pull --ff-only origin main
+git status --porcelain            # MUST be clean except known untracked secrets
+# Never stage these — signing secrets at repo root:
+#   Certificates.p12   distribution.cer   docs/legal/   (and Packages/MurmurCore/Sources/ScenarioRunner/)
+# Stage every file explicitly by path in this runbook. NEVER `git add -A` / `git add .`.
+gh repo view damsac/sitewalk --json isArchived    # must be false (not yet archived)
+```
+
+Confirm sitewalk is at the intended tip:
+
+```bash
+git ls-remote git@github.com:damsac/sitewalk.git refs/heads/main
+```
+
+---
+
+## 1. Pivot commit — retire the Swift app from the tree (FIRST, so the merge is clean)
+
+Removing the Swift app before the merge means sitewalk's Rust workspace lands
+without path collisions against `Murmur/` and `Packages/MurmurCore/`.
+
+```bash
+git switch -c pr/dam/reunify-merge
+
+# Remove the Swift app tree (history preserves it):
+git rm -r Murmur/ Packages/MurmurCore/
+# Swift-era build/config that no longer applies at the root:
+git rm project.yml project.local.yml.template Makefile 2>/dev/null || true
+# (Leave meta/, docs/, flake.nix, .gitignore — sitewalk's versions win in step 3.)
+
+git commit -m "pivot: retire the Swift app from the tree (Era I preserved in history)"
+```
+
+Record this SHA in `docs/HISTORY.md` (replace `<PIVOT_COMMIT_SHA>`):
+
+```bash
+git rev-parse HEAD
+```
+
+> Note the exact set of root files to remove against the live tree at run time —
+> `git rm` only what actually exists. Do NOT remove the untracked secrets or
+> `docs/legal/`.
+
+---
+
+## 2. Add sitewalk as a remote and fetch its history
+
+```bash
+git remote add sitewalk git@github.com:damsac/sitewalk.git
+git fetch sitewalk main
+```
+
+---
+
+## 3. Merge with unrelated histories
+
+```bash
+git merge --allow-unrelated-histories sitewalk/main \
+  -m "reunify: merge damsac/sitewalk history into Murmur (Rust rebuild rejoins)"
+```
+
+**Expected collisions** (both repos have these paths). sitewalk's versions are
+current — **sitewalk wins**:
+
+| Path | Resolution |
+|------|-----------|
+| `meta/` | sitewalk version wins (current STATE/ROADMAP/CANON of the rebuild) |
+| `docs/` | **merge by hand** — Murmur has the pivot-chapter docs (HISTORY.md, superpowers/, this runbook) that sitewalk lacks; keep BOTH sides. Take sitewalk's rebuild docs, keep Murmur's `docs/HISTORY.md`, `docs/reunify/`, `docs/superpowers/`. |
+| `.gitignore` | sitewalk version wins (Rust-oriented); re-add any Murmur-only ignores still needed |
+| `flake.nix` | sitewalk version wins (Rust dev shell) |
+
+Resolve, then stage each resolved path **explicitly**:
+
+```bash
+git checkout --theirs meta/ .gitignore flake.nix     # sitewalk = "theirs"
+git add meta/ .gitignore flake.nix
+# docs/: reconcile by hand (keep both eras' docs), then:
+git add docs/
+git commit --no-edit    # completes the merge commit
+```
+
+Record the merge SHA in `docs/HISTORY.md` (replace `<SITEWALK_MERGE_COMMIT_SHA>`).
+Its second parent (`^2`) is the sitewalk history root:
+
+```bash
+git rev-parse HEAD
+git log --oneline HEAD^2 | head    # sanity: sitewalk's rebuild commits are present
+```
+
+---
+
+## 4. Swap the README and finalize docs
+
+```bash
+git mv docs/reunify/README.next.md README.md   # promote the drafted README
+# Edit README.md: remove the DRAFT banner, confirm crate/app paths against the tree.
+git add README.md docs/HISTORY.md               # HISTORY.md now has real SHAs
+git commit -m "docs: post-reunification README + fill history SHAs"
+```
+
+---
+
+## 5. Verify, push, PR
+
+```bash
+cargo build && cargo test && cargo clippy       # Rust workspace at root now
+git log --graph --oneline -20                   # both histories visible
+git push origin pr/dam/reunify-merge
+gh pr create --base main --head pr/dam/reunify-merge \
+  --title "Re-unify: merge sitewalk history into Murmur (Phase 2)" \
+  --body "..."   # include a Thinking section (house rule)
+# Merge with a MERGE COMMIT (not squash) — preserves both histories.
+gh pr merge --merge
+```
+
+---
+
+## 6. Migrate sitewalk issue #2
+
+sitewalk issue #2 = "PR #1 review follow-ups: seam hygiene + 4 state-transition
+bugs." Re-file on Murmur (gh has no cross-repo transfer for archived targets;
+recreate + link):
+
+```bash
+gh issue view 2 --repo damsac/sitewalk --json title,body,labels > /tmp/sw-issue-2.json
+gh issue create --repo damsac/Murmur \
+  --title "PR #1 review follow-ups: seam hygiene + 4 state-transition bugs (migrated from sitewalk#2)" \
+  --body "Migrated from damsac/sitewalk#2 ahead of archiving.\n\n<original body>"
+# Comment on sitewalk#2 with the new Murmur issue link, then close sitewalk#2.
+gh issue comment 2 --repo damsac/sitewalk --body "Migrated to damsac/Murmur#<N>. Closing; sitewalk is being archived."
+gh issue close 2 --repo damsac/sitewalk
+```
+
+---
+
+## 7. Pointer README on sitewalk, then archive
+
+Push a pointer README to sitewalk **before** archiving (archived repos are
+read-only):
+
+```bash
+# In a sitewalk checkout, on main:
+cat > README.md <<'EOF'
+# sitewalk → merged into damsac/Murmur
+
+This repo held the Rust rebuild of **Murmur** (field-work voice agent). As of
+2026-07-04 its full history has been merged back into **[damsac/Murmur](https://github.com/damsac/Murmur)**
+via `git merge --allow-unrelated-histories` — nothing was lost. Development
+continues there.
+
+This repository is **archived** (read-only). Its commit history is preserved and
+also browsable inside damsac/Murmur (see `docs/HISTORY.md` there).
+EOF
+git add README.md
+git commit -m "docs: archive pointer — history merged into damsac/Murmur"
+git push origin main
+
+# Then archive:
+gh repo archive damsac/sitewalk --yes
+```
+
+---
+
+## Post-conditions checklist
+
+- [ ] Swift app removed from Murmur tree; recoverable via `git show <PIVOT_COMMIT_SHA>^:…`
+- [ ] `git log HEAD^2` on the merge commit shows sitewalk's rebuild history
+- [ ] `docs/HISTORY.md` placeholders replaced with real SHAs
+- [ ] `README.md` describes the field-work product + Rust workspace
+- [ ] Murmur issue mirrors sitewalk#2; sitewalk#2 closed with a link
+- [ ] sitewalk has a pointer README and is archived
+- [ ] Signing secrets (`Certificates.p12`, `distribution.cer`, `docs/legal/`) never committed


### PR DESCRIPTION
## Thinking

Phase 1 of the repo re-unification landed the *pivot chapter* on main (PR #152). This PR lands the **story-arc documentation** — the connective tissue that makes the one-repo-tells-the-whole-arc decision legible to anyone browsing later, and the exact runbook for Phase 2.

It's docs-only and purely additive: `docs/HISTORY.md`, `docs/reunify/README.next.md`, `docs/reunify/RUNBOOK.md`. Nothing here removes the Swift app, runs the unrelated-histories merge, or archives sitewalk — those are Phase 2, gated on three in-flight sitewalk lanes landing (Plan 08 + review, carry-notes fix, first-real-walk key wiring).

Two deliberate safety properties, both reviewed and approved:
- **Placeholders, not guesses.** The sitewalk-merge and pivot-commit SHAs don't exist yet, so `docs/HISTORY.md` carries clearly-marked `<…_SHA>` **PLACEHOLDER**s that Phase 2 fills. They're harmless on main until then.
- **Draft README stays a draft.** The post-migration README lives at `docs/reunify/README.next.md` with a DRAFT banner; the live `README.md` (still describing the Swift app, which is still in the tree) is untouched. Promotion is a Phase-2 runbook step.

One amendment applied after review (`c33569c`): the runbook's precondition "issue #2 follow-ups resolved" was too strong. Open sitewalk issues (#2, #3) **migrate** to Murmur rather than block Phase 2 — the real gate is the in-flight lanes landing on sitewalk main. Step 6 and the gate note now reflect that.

Merge commit (not squash) per house rules.

## Files

- `docs/HISTORY.md` — the narrative in four eras (Swift app → 2026-07-01 pivot → Rust rebuild plans 01–07 + STT spike GO → 2026-07-04 re-unification), with how to browse each era in git history.
- `docs/reunify/README.next.md` — DRAFT post-migration README (field-work one-liner, Rust workspace layout, HISTORY pointer). Not promoted.
- `docs/reunify/RUNBOOK.md` — exact Phase 2 command sequence with signing-secret guards (explicit staging by path, never `git add -A`), the unrelated-histories merge, collision resolution, issue migration, pointer README, and archive.
