### PR TITLE
Plan 08 Part C: construction-noise robustness — dual R3 gates, voiceproc knob, SNR sweep

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -63,11 +63,19 @@ final class AppModel {
     /// When live, drive the STT path from a bundled fixture WAV instead of the
     /// mic (`wavwalk=1`, D7) — a mic-free way to exercise real whisper.
     private let wavFixture: Bool
+    /// Voice-processing A/B knob (Plan 08 Task 10): enable Apple's on-device
+    /// noise/echo suppression on the mic capture path. Sourced from the
+    /// `voiceproc=1` launch arg; only affects the live-mic `AudioCaptureSource`
+    /// (the WAV fixture already has clean PCM). Default off — the Task 12 SNR
+    /// eval decides the production default.
+    private let voiceProcessing: Bool
 
-    init(engine: WalkEngine? = nil, scripted: Bool = true, wavFixture: Bool = false) {
+    init(engine: WalkEngine? = nil, scripted: Bool = true, wavFixture: Bool = false,
+         voiceProcessing: Bool = false) {
         self.engine = engine ?? DemoWalkEngine()
         self.scripted = scripted
         self.wavFixture = wavFixture
+        self.voiceProcessing = voiceProcessing
     }
 
     // MARK: Trade switching (validation strategy: same bones, swappable template)
@@ -160,7 +168,7 @@ final class AppModel {
         }
         let audio: any PCMAudioSource = wavFixture
             ? WavFileAudioSource(pushSamples: onSamples)   // mic-free fixture (D7)
-            : AudioCaptureSource(pushSamples: onSamples)   // live mic
+            : AudioCaptureSource(pushSamples: onSamples, voiceProcessing: voiceProcessing) // live mic
         audioSource = audio
         audio.start()
     }

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -116,6 +116,7 @@ struct RootRouter: View {
                 live: Self.args.contains("live=1"),
                 wavwalk: Self.args.contains("wavwalk=1"),
                 demo: Self.args.contains("demo=1"),
+                voiceProcessing: Self.args.contains("voiceproc=1"),
                 autoflowRounds: Self.args
                     .first(where: { $0.hasPrefix("autoflow=") })
                     .flatMap { Int($0.dropFirst("autoflow=".count)) } ?? 0
@@ -131,7 +132,8 @@ struct AppRoot: View {
     private let autoflowRounds: Int
 
     @MainActor
-    init(live: Bool, wavwalk: Bool = false, demo: Bool, autoflowRounds: Int) {
+    init(live: Bool, wavwalk: Bool = false, demo: Bool, voiceProcessing: Bool = false,
+         autoflowRounds: Int) {
         self.live = live
         self.wavwalk = wavwalk
         self.autoflowRounds = autoflowRounds
@@ -143,7 +145,8 @@ struct AppRoot: View {
             initialValue: AppModel(
                 engine: resolveEngine(demo: demo),
                 scripted: !whisperWalk,
-                wavFixture: wavwalk
+                wavFixture: wavwalk,
+                voiceProcessing: voiceProcessing
             )
         )
     }

--- a/apps/ios/Sources/Engine/AudioCaptureSource.swift
+++ b/apps/ios/Sources/Engine/AudioCaptureSource.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import os
 
 // A PCM source drives the Rust STT path: it produces 16 kHz mono f32 frames and
 // hands them to an injected `pushSamples` closure. Two conformers: the live mic
@@ -30,6 +31,19 @@ protocol PCMAudioSource: AnyObject {
 final class AudioCaptureSource: PCMAudioSource {
     /// Delivered 16 kHz mono f32 frames, OFF the render thread.
     private let pushSamples: @Sendable ([Float]) -> Void
+    /// A/B knob (Plan 08 Task 10): when true, enable Apple's on-device voice
+    /// processing (noise/echo suppression) on the input node via
+    /// `setVoiceProcessingEnabled(true)`. It is an A/B knob, NOT a decided
+    /// default — aggressive suppression can HURT whisper (spectral artifacts)
+    /// as easily as help, so the choice is deferred to the Task 12 noise SNR
+    /// eval. Sourced from the `voiceproc=1` launch arg.
+    ///
+    /// NOTE — the OTHER route (not this knob): the OS mic-mode "Voice
+    /// Isolation" a user picks in Control Center / the AVAudioSession input
+    /// mode is USER-controlled, not app-set. The app-controllable surface is
+    /// `AVAudioEngine.inputNode.setVoiceProcessingEnabled`, which is what this
+    /// knob toggles.
+    private let voiceProcessing: Bool
     private let audioEngine = AVAudioEngine()
     /// 16 kHz mono f32 — whisper's expected input (SttConfig.sample_rate).
     private let targetFormat = AVAudioFormat(
@@ -42,8 +56,9 @@ final class AudioCaptureSource: PCMAudioSource {
     /// it never blocks the audio render thread (D1).
     private let deliveryQueue = DispatchQueue(label: "studio.sitewalk.audio-delivery")
 
-    init(pushSamples: @escaping @Sendable ([Float]) -> Void) {
+    init(pushSamples: @escaping @Sendable ([Float]) -> Void, voiceProcessing: Bool = false) {
         self.pushSamples = pushSamples
+        self.voiceProcessing = voiceProcessing
     }
 
     /// Mic only — no Speech authorization needed now (STT is on-device whisper).
@@ -57,6 +72,23 @@ final class AudioCaptureSource: PCMAudioSource {
         try? session.setActive(true, options: .notifyOthersOnDeactivation)
 
         let input = audioEngine.inputNode
+
+        // Voice-processing A/B knob (Task 10). Toggle BEFORE reading the input
+        // format: enabling voice processing can change the node's output format
+        // (Apple's VPIO unit re-negotiates), so the AVAudioConverter must be
+        // derived from the POST-toggle `outputFormat` or the tap would resample
+        // from a stale rate. A failure to enable is non-fatal — fall back to the
+        // raw path (still 16 kHz mono f32 out).
+        if voiceProcessing {
+            do {
+                try input.setVoiceProcessingEnabled(true)
+            } catch {
+                Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "audio")
+                    .error("setVoiceProcessingEnabled(true) failed, continuing raw: \(error, privacy: .public)")
+            }
+        }
+
+        // Re-derive AFTER the voice-processing toggle (format may have changed).
         let hwFormat = input.outputFormat(forBus: 0)
         guard let converter = AVAudioConverter(from: hwFormat, to: targetFormat) else { return }
 

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -908,7 +908,7 @@ mod tests {
         // Realistic time-shifted composition (Plan 06): window k+1 restarts at
         // chunk-relative cs=0; only the 1 s overlap repeats. 9 s of PCM → both
         // 5 s/1 s windows drained in one poll().
-        let seg = |cs0: i64, cs1: i64, t: &str| RawSegment { start_cs: cs0, end_cs: cs1, text: t.into() };
+        let seg = |cs0: i64, cs1: i64, t: &str| RawSegment { start_cs: cs0, end_cs: cs1, text: t.into(), no_speech_prob: 0.0 };
         let decoder = ScriptedDecoder::new(vec![
             vec![seg(0, 180, "order twelve"), seg(180, 360, "two by tens"), seg(360, 480, "for the")],
             vec![seg(0, 80, "for the"), seg(80, 300, "deck framing"), seg(300, 480, "today")],
@@ -1124,7 +1124,7 @@ mod tests {
     /// not. Mirrors the stt crate's `poll_finalizes_incrementally_and_end_flushes`.
     fn scripted_flush_stt() -> Arc<stt::SttStream> {
         use stt::{RawSegment, ScriptedDecoder, SttConfig, SttStream};
-        let seg = |cs0: i64, cs1: i64, t: &str| RawSegment { start_cs: cs0, end_cs: cs1, text: t.into() };
+        let seg = |cs0: i64, cs1: i64, t: &str| RawSegment { start_cs: cs0, end_cs: cs1, text: t.into(), no_speech_prob: 0.0 };
         let decoder = ScriptedDecoder::new(vec![
             vec![seg(0, 180, "order twelve"), seg(180, 360, "two by tens"), seg(360, 480, "for the")],
             vec![seg(0, 80, "for the"), seg(80, 300, "deck framing"), seg(300, 480, "today")],

--- a/crates/ffi/tests/audio_pump_e2e.rs
+++ b/crates/ffi/tests/audio_pump_e2e.rs
@@ -53,7 +53,7 @@ fn end_turn(text: &str) -> CompletionResponse {
 /// 9 s of PCM -> two 5 s/1 s windows (drained in one poll); the final "today"
 /// straddles the horizon and is only finalized by end() (the finish() flush).
 fn scripted_stt() -> Arc<SttStream> {
-    let seg = |cs0: i64, cs1: i64, t: &str| RawSegment { start_cs: cs0, end_cs: cs1, text: t.into() };
+    let seg = |cs0: i64, cs1: i64, t: &str| RawSegment { start_cs: cs0, end_cs: cs1, text: t.into(), no_speech_prob: 0.0 };
     let decoder = ScriptedDecoder::new(vec![
         vec![seg(0, 180, "order twelve"), seg(180, 360, "two by tens"), seg(360, 480, "for the")],
         vec![seg(0, 80, "for the"), seg(80, 300, "deck framing"), seg(300, 480, "today")],

--- a/crates/stt/src/decoder.rs
+++ b/crates/stt/src/decoder.rs
@@ -7,6 +7,14 @@ pub struct RawSegment {
     pub start_cs: i64,
     pub end_cs: i64,
     pub text: String,
+    /// whisper's per-segment "no speech" probability (Plan 08 Task 11b, R3).
+    /// High values mean the model thinks this span is silence/noise it
+    /// fluently hallucinated text over; the `Finalizer` drops segments above
+    /// `SttConfig.no_speech_prob_threshold`. Default `0.0` (always keep) so the
+    /// field is additive — non-whisper decoders (`ScriptedDecoder`) and all
+    /// Plan-06 tests are unaffected. `WhisperDecoder` populates it from
+    /// `whisper_state`.
+    pub no_speech_prob: f32,
 }
 
 /// The one seam that touches whisper. Everything above it (chunk cutting,
@@ -52,8 +60,8 @@ mod tests {
     #[test]
     fn scripted_decoder_returns_scripts_in_order_and_captures_prompts() {
         let mut d = ScriptedDecoder::new(vec![
-            vec![RawSegment { start_cs: 0, end_cs: 200, text: "hello world".into() }],
-            vec![RawSegment { start_cs: 0, end_cs: 150, text: "again now".into() }],
+            vec![RawSegment { start_cs: 0, end_cs: 200, text: "hello world".into(), no_speech_prob: 0.0 }],
+            vec![RawSegment { start_cs: 0, end_cs: 150, text: "again now".into(), no_speech_prob: 0.0 }],
         ]);
         let a = d.decode(&[0.0; 16], Some("french drain, ledger")).unwrap();
         assert_eq!(a[0].text, "hello world");

--- a/crates/stt/src/finalize.rs
+++ b/crates/stt/src/finalize.rs
@@ -14,15 +14,25 @@ pub struct Word {
 /// (`RESULTS.md` Table 2: 19% WER at ≤3 s latency, vs 80% for naive segment
 /// finalize). `pending` is bounded to ~one chunk; the emitted stream is
 /// append-only (a finalized word is never revised).
-#[derive(Default)]
 pub struct Finalizer {
     pending: Vec<Word>,
     flushed: bool,
+    /// Segments with `no_speech_prob` above this are dropped at ingest (Plan 08
+    /// Task 11b, R3). Default keeps the pre-Plan-08 behavior for scripted
+    /// segments (which carry `no_speech_prob = 0.0`).
+    no_speech_threshold: f32,
+}
+
+impl Default for Finalizer {
+    fn default() -> Self {
+        Self { pending: Vec::new(), flushed: false, no_speech_threshold: 0.6 }
+    }
 }
 
 impl Finalizer {
-    pub fn new() -> Self {
-        Self::default()
+    /// Construct with an explicit no-speech drop threshold (from `SttConfig`).
+    pub fn with_no_speech_threshold(no_speech_threshold: f32) -> Self {
+        Self { no_speech_threshold, ..Self::default() }
     }
 
     /// Merge one decoded window (`window_start_ms` + its segments) into `pending`
@@ -30,7 +40,7 @@ impl Finalizer {
     /// segment ends at/before `horizon_ms` (= next window's start for a normal
     /// window; `u64::MAX` for the flush window). Returns newly finalized words.
     pub fn ingest(&mut self, window_start_ms: u64, segs: &[RawSegment], horizon_ms: u64) -> Vec<Word> {
-        let new_words = words_from_segments(window_start_ms, segs);
+        let new_words = words_from_segments(window_start_ms, segs, self.no_speech_threshold);
         self.merge(new_words);
         self.finalize_before(horizon_ms)
     }
@@ -107,9 +117,15 @@ impl Finalizer {
     }
 }
 
-fn words_from_segments(window_start_ms: u64, segs: &[RawSegment]) -> Vec<Word> {
+fn words_from_segments(window_start_ms: u64, segs: &[RawSegment], no_speech_threshold: f32) -> Vec<Word> {
     let mut out = Vec::new();
     for s in segs {
+        // Task 11b (R3): drop segments whisper flags as probably-not-speech
+        // (machinery drone it hallucinated text over) before they can reach the
+        // committed transcript. Scripted/Plan-06 segments carry 0.0 → kept.
+        if s.no_speech_prob > no_speech_threshold {
+            continue;
+        }
         let start_ms = window_start_ms + (s.start_cs.max(0) as u64) * 10;
         let end_ms = window_start_ms + (s.end_cs.max(0) as u64) * 10;
         for tok in s.text.split_whitespace() {
@@ -125,7 +141,7 @@ mod tests {
     use crate::decoder::RawSegment;
 
     fn seg(cs0: i64, cs1: i64, t: &str) -> RawSegment {
-        RawSegment { start_cs: cs0, end_cs: cs1, text: t.into() }
+        RawSegment { start_cs: cs0, end_cs: cs1, text: t.into(), no_speech_prob: 0.0 }
     }
     fn words(ws: &[Word]) -> Vec<&str> {
         ws.iter().map(|w| w.text.as_str()).collect()
@@ -133,7 +149,7 @@ mod tests {
 
     #[test]
     fn finalizes_incrementally_across_time_shifted_windows() {
-        let mut f = Finalizer::new();
+        let mut f = Finalizer::default();
         // window 0 [0,5s], horizon 4000: last segment straddles 4s → held.
         let e0 = f.ingest(0, &[seg(0, 180, "order twelve"), seg(180, 360, "two by tens"),
                                seg(360, 480, "for the")], 4_000);
@@ -149,7 +165,7 @@ mod tests {
 
     #[test]
     fn overlap_word_is_finalized_exactly_once() {
-        let mut f = Finalizer::new();
+        let mut f = Finalizer::default();
         let e0 = f.ingest(0, &[seg(0, 180, "hello there"), seg(360, 480, "friend")], 4_000);
         // "friend" ends 4800 > horizon 4000 → held for the overlap.
         let e1 = f.ingest(4_000, &[seg(0, 80, "friend"), seg(80, 300, "good day")], 8_000);
@@ -159,7 +175,7 @@ mod tests {
 
     #[test]
     fn append_only_holds_under_overlap_disagreement() {
-        let mut f = Finalizer::new();
+        let mut f = Finalizer::default();
         let e0 = f.ingest(0, &[seg(0, 180, "the french drain"), seg(180, 480, "needs work")], 4_000);
         assert_eq!(words(&e0), vec!["the", "french", "drain"]); // ends ≤4000; "needs work" held
         // Window 1 re-decodes the overlap "needs work" DIFFERENTLY as "needs word":
@@ -180,8 +196,24 @@ mod tests {
     }
 
     #[test]
+    fn no_speech_segments_are_dropped_and_append_only_still_holds() {
+        // Threshold 0.6: a mid-stream machinery-drone segment (0.9) is dropped;
+        // the real-speech segments around it finalize normally and in order.
+        let mut f = Finalizer::with_no_speech_threshold(0.6);
+        let mut noisy = seg(180, 300, "phantom words"); // whisper hallucination
+        noisy.no_speech_prob = 0.9;
+        let e0 = f.ingest(0, &[seg(0, 180, "pour the footing"), noisy], 4_000);
+        assert_eq!(words(&e0), vec!["pour", "the", "footing"], "drone segment dropped, speech kept");
+        // A later window's real speech still appends after — append-only intact.
+        let e1 = f.ingest(4_000, &[seg(0, 120, "before noon")], 8_000);
+        let all: Vec<&str> = words(&e0).into_iter().chain(words(&e1)).collect();
+        assert_eq!(all, vec!["pour", "the", "footing", "before", "noon"]);
+        assert!(!all.contains(&"phantom"), "hallucinated words never committed (R3)");
+    }
+
+    #[test]
     fn flush_emits_only_the_bounded_tail() {
-        let mut f = Finalizer::new();
+        let mut f = Finalizer::default();
         let e0 = f.ingest(0, &[seg(0, 180, "alpha beta"), seg(360, 480, "gamma delta")], 4_000);
         assert_eq!(words(&e0), vec!["alpha", "beta"]);
         assert_eq!(f.preview(), "gamma delta", "tail bounded to the straddling segment");

--- a/crates/stt/src/lib.rs
+++ b/crates/stt/src/lib.rs
@@ -7,6 +7,7 @@ mod bias;
 mod chunk;
 mod decoder;
 mod finalize;
+mod vad;
 #[cfg(feature = "whisper")]
 mod whisper;
 
@@ -43,6 +44,23 @@ pub struct SttConfig {
     /// FALSIFIED by sim verification; CPU/BLAS decode on sim is proven working.
     /// Ignored by non-whisper decoders (`ScriptedDecoder`).
     pub use_gpu: bool,
+    /// Per-window RMS-energy pre-gate (Plan 08 Task 11a, R3). A ready window
+    /// whose RMS amplitude is below this is NOT decoded (skip the Metal decode,
+    /// emit nothing) — but its samples still entered the Chunker and advanced
+    /// the window cursor, so the "absolute ms from stream start" timestamp
+    /// contract does NOT drift (pre-Chunker sample dropping is the rejected
+    /// option). Default `0.0` = decode everything (conservative: never elides
+    /// speech); the Task 12 SNR eval sets a measured value. `f32` RMS of
+    /// [-1,1] PCM.
+    pub vad_rms_threshold: f32,
+    /// no_speech_prob post-check (Plan 08 Task 11b, R3). Finalized segments
+    /// whose `RawSegment.no_speech_prob` exceeds this are dropped before they
+    /// reach the committed transcript — the guard against whisper fluently
+    /// hallucinating text over machinery drone. Default `0.6` (whisper's own
+    /// customary no-speech threshold); the Task 12 eval tunes it. Segments with
+    /// the default `no_speech_prob = 0.0` (ScriptedDecoder, Plan-06 tests) are
+    /// always kept.
+    pub no_speech_prob_threshold: f32,
 }
 
 impl Default for SttConfig {
@@ -54,6 +72,8 @@ impl Default for SttConfig {
             language: "en".into(),
             max_bias_terms: 100,
             use_gpu: true,
+            vad_rms_threshold: 0.0,
+            no_speech_prob_threshold: 0.6,
         }
     }
 }
@@ -114,7 +134,7 @@ impl SttStream {
             engine: Mutex::new(Engine {
                 decoder,
                 chunker,
-                finalizer: Finalizer::new(),
+                finalizer: Finalizer::with_no_speech_threshold(cfg.no_speech_prob_threshold),
                 #[cfg(test)]
                 captured_prompts: Vec::new(),
             }),
@@ -186,6 +206,16 @@ impl SttStream {
 
     fn decode_window(&self, eng: &mut Engine, w: chunk::Window, out: &mut Vec<FinalizedSegment>)
         -> Result<(), SttError> {
+        // Per-window energy pre-gate (Task 11a, R3): skip the DECODE for a
+        // below-threshold (silence/quiet) NON-FINAL window — emit nothing, don't
+        // call the decoder. The window's samples already entered the Chunker and
+        // advanced `next_start` (in take_ready_window), so the absolute-ms
+        // timestamp clock does NOT drift: the next window's start_sample is
+        // unaffected. The final flush window is never gated (it may carry the
+        // operator's last words; a truly-silent flush decodes to nothing anyway).
+        if !w.is_final && !vad::is_speech(&w.samples, self.cfg.vad_rms_threshold) {
+            return Ok(());
+        }
         let window_start_ms = self.sample_to_ms(w.start_sample);
         let horizon_ms = if w.is_final {
             u64::MAX
@@ -239,7 +269,7 @@ mod tests {
     use super::*;
 
     fn seg(cs0: i64, cs1: i64, t: &str) -> RawSegment {
-        RawSegment { start_cs: cs0, end_cs: cs1, text: t.into() }
+        RawSegment { start_cs: cs0, end_cs: cs1, text: t.into(), no_speech_prob: 0.0 }
     }
     fn text(v: &[FinalizedSegment]) -> Vec<&str> {
         v.iter().map(|s| s.text.as_str()).collect()
@@ -300,6 +330,48 @@ mod tests {
             Box::new(ScriptedDecoder::new(vec![])), SttConfig::default(), &[]);
         stream.push_pcm(&vec![0.0; 1000]); // far short of a window
         assert!(stream.poll().unwrap().is_empty(), "no decode, no scripted panic");
+    }
+
+    #[test]
+    fn low_energy_window_is_not_decoded_but_cursor_still_advances() {
+        // ScriptedDecoder has ONE script; it must be consumed by the SPEECH
+        // window, NOT the silence window (energy-gated before the decoder runs).
+        let decoder = ScriptedDecoder::new(vec![vec![seg(0, 100, "hello")]]);
+        let cfg = SttConfig { vad_rms_threshold: 0.05, ..SttConfig::default() };
+        let stream = SttStream::with_decoder(Box::new(decoder), cfg, &[]);
+
+        // Window 0: one full window of silence → RMS 0 < 0.05 → NOT decoded.
+        stream.push_pcm(&vec![0.0; 80_000]);
+        let out0 = stream.poll().unwrap();
+        assert!(out0.is_empty(), "silence window emits nothing (decode skipped)");
+
+        // Window 1: speech-level energy → decoded. Its start_sample is 64_000
+        // (advanced one step) — proving the skipped window still advanced the
+        // Chunker cursor, so the absolute-ms timestamp contract holds.
+        stream.push_pcm(&vec![0.3; 64_000]);
+        let out1 = stream.poll().unwrap();
+        assert_eq!(text(&out1), vec!["hello"], "speech window decodes the one script");
+        assert!(out1[0].start_ms >= 4_000, "start_ms reflects the advanced cursor (64k samples = 4s)");
+    }
+
+    #[test]
+    fn high_no_speech_prob_segment_is_not_finalized() {
+        // One window, two segments: a machinery-drone hallucination (0.95) and
+        // real speech (0.05). Only the speech reaches the committed stream (R3).
+        let decoder = ScriptedDecoder::new(vec![vec![
+            RawSegment { start_cs: 0, end_cs: 100, text: "machinery drone".into(), no_speech_prob: 0.95 },
+            RawSegment { start_cs: 100, end_cs: 200, text: "order lumber".into(), no_speech_prob: 0.05 },
+        ]]);
+        let cfg = SttConfig { no_speech_prob_threshold: 0.6, ..SttConfig::default() };
+        let stream = SttStream::with_decoder(Box::new(decoder), cfg, &[]);
+        stream.push_pcm(&vec![0.3; 80_000]); // one full window (RMS gate is a no-op at default 0.0)
+        let live = stream.poll().unwrap();
+        let words = text(&live);
+        assert!(
+            !words.contains(&"machinery") && !words.contains(&"drone"),
+            "high no_speech_prob segment dropped before commit (R3)"
+        );
+        assert_eq!(words, vec!["order", "lumber"], "the real-speech segment is kept");
     }
 
     #[test]

--- a/crates/stt/src/vad.rs
+++ b/crates/stt/src/vad.rs
@@ -1,0 +1,52 @@
+//! Cheap energy-based voice-activity pre-gate (Plan 08 Task 11a, product rule
+//! R3: under-extract, never invent). Pure, allocation-free, no native deps — so
+//! it compiles and tests everywhere with the `whisper` feature off.
+//!
+//! The gate's job is to keep whisper from being handed near-silent windows on
+//! which it fluently hallucinates text. It runs on a window's samples AFTER the
+//! Chunker has already accepted them (so the sample-count-derived timestamp
+//! clock is untouched); a below-threshold window simply skips the decode.
+
+/// Root-mean-square amplitude of a PCM window. Samples are expected in [-1, 1]
+/// (whisper's f32 range); the result is in the same scale. Empty → `0.0`.
+///
+/// f64 accumulation keeps the sum-of-squares stable across a full 5 s window
+/// (80k samples) without the precision loss an f32 running sum would suffer.
+pub fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f64 = samples.iter().map(|s| (*s as f64) * (*s as f64)).sum();
+    (sum_sq / samples.len() as f64).sqrt() as f32
+}
+
+/// True if the window carries enough energy to be worth decoding. A `threshold`
+/// of `0.0` accepts everything (the conservative default — never elides speech).
+pub fn is_speech(samples: &[f32], threshold: f32) -> bool {
+    rms(samples) >= threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rms_of_silence_is_zero() {
+        assert_eq!(rms(&[0.0; 1000]), 0.0);
+        assert_eq!(rms(&[]), 0.0);
+    }
+
+    #[test]
+    fn rms_of_constant_amplitude_equals_that_amplitude() {
+        // RMS of a DC signal at ±0.3 is 0.3.
+        let r = rms(&[0.3; 4096]);
+        assert!((r - 0.3).abs() < 1e-5, "rms={r}");
+    }
+
+    #[test]
+    fn is_speech_gates_on_the_threshold() {
+        assert!(!is_speech(&[0.0; 512], 0.05), "silence gated out");
+        assert!(is_speech(&[0.3; 512], 0.05), "speech-level energy passes");
+        assert!(is_speech(&[0.0; 512], 0.0), "threshold 0 accepts everything");
+    }
+}

--- a/crates/stt/src/whisper.rs
+++ b/crates/stt/src/whisper.rs
@@ -59,6 +59,10 @@ impl Decoder for WhisperDecoder {
                     start_cs: seg.start_timestamp(),
                     end_cs: seg.end_timestamp(),
                     text: text.trim().to_string(),
+                    // Task 11b (R3): whisper's per-segment no-speech probability
+                    // feeds the Finalizer's drop gate. Only compiled with the
+                    // `whisper` feature, so it never affects the hermetic build.
+                    no_speech_prob: seg.no_speech_probability(),
                 });
             }
         }

--- a/crates/stt/tests/stream_append_only.rs
+++ b/crates/stt/tests/stream_append_only.rs
@@ -8,7 +8,7 @@
 use stt::{RawSegment, ScriptedDecoder, SttConfig, SttStream};
 
 fn seg(cs0: i64, cs1: i64, t: &str) -> RawSegment {
-    RawSegment { start_cs: cs0, end_cs: cs1, text: t.into() }
+    RawSegment { start_cs: cs0, end_cs: cs1, text: t.into(), no_speech_prob: 0.0 }
 }
 
 #[test]

--- a/meta/ROADMAP.md
+++ b/meta/ROADMAP.md
@@ -10,8 +10,7 @@ Updated when priorities shift. Either person can propose changes via PR.
 
 | Work | Owner | Status |
 |------|-------|--------|
-| Plan 08 Part C — noise robustness (Voice-Isolation A/B knob, VAD/no_speech gate, SNR sweep) | dam | next build run (Tasks 10–12; Parts A+B merged 2026-07-05) |
-| Real-mic device voice walk (`live=1` on iPhone) + T5 spike tier (device RTF/battery) | dam | the milestone gate + the one unretired STT GO condition |
+| Real-mic device voice walk (`live=1`) + on-device tuning: voiceproc A/B, vad_rms ~0.01, quiet-flush validation (final-review notes A/B) | dam | Plan 08 FULLY merged — device session is the gate |
 | Issue #155 — PR #1 review follow-ups (4 state bugs + seam hygiene) | sac | open (several now also guarded core-side by 07-carry) |
 | Rebuild-era nix-based CI (cargo test needs nix deps — naive runner job goes red) | dam | follow-up from #157 |
 

--- a/meta/dam/STATE.md
+++ b/meta/dam/STATE.md
@@ -27,7 +27,7 @@ dam owns: harness / murmur-core / STT / FFI. sac owns: renderers / component lib
 | 07-carry | all 6 carry notes + 3 cross-model findings: fallible constructors, atomic begin_walk, mint-with-artifact-write, throwing WalkEngine.begin (dead walk never starts), tick fault counter, narrowed artifact sweep | done (merged be88bca) |
 | first walk | **THE MILESTONE LANDED 2026-07-05**: real core + .env key on sim → document EST-0047 end-to-end. Clean checkout builds demo with zero setup; `generate.sh` opts into real | done (merged baa8848) |
 | 08 A+B | STT stage-2 wiring: push_audio → pump thread → append path; TranscriptCommitted/Preview events; finish() flush + async cancel() (Store::delete_session — closes the #156 core half); AudioCaptureSource (mic→16kHz) + WavFileAudioSource; use_gpu knob (sim=CPU compile-time — D7 "Metal degrades on sim" FALSIFIED: SIGTRAP; device=Metal) | **done, merged 2026-07-05** — 290 tests; voice-from-WAV proven end-to-end on sim |
-| 08 Part C | noise robustness: Voice-Isolation A/B knob, VAD/no_speech gate (R3), construction-noise SNR sweep (Tasks 10–12) | next build run |
+| 08 Part C | noise robustness: voiceproc A/B knob (default off), dual R3 gates (energy VAD + no_speech 0.6 — complementary, proven), SNR sweep: base.en bundled, small.en = validated upgrade | **done, merged 2026-07-05** — 295 tests; Plan 08 CLOSED |
 
 ## Where we are (2026-07-05, post re-unification)
 

--- a/spikes/stt-whisper/Cargo.toml
+++ b/spikes/stt-whisper/Cargo.toml
@@ -8,3 +8,10 @@ publish = false
 whisper-rs = { version = "=0.16.0", features = ["metal"] }  # exact pin: a silent patch bump would confound Table 1 mid-spike
 hound = "3"        # WAV read (16 kHz mono f32 — whisper's input format)
 # deliberately minimal; WER/stream logic is hand-rolled and disposable
+
+# Standalone: never part of the root workspace. The root excludes `spikes` by
+# prefix, but in a git WORKTREE the checkout path (.claude/worktrees/…/spikes)
+# no longer matches that prefix, so cargo would otherwise adopt this as an
+# orphan member. An empty [workspace] table makes the spike its own root
+# regardless of where it is checked out.
+[workspace]

--- a/spikes/stt-whisper/RESULTS.md
+++ b/spikes/stt-whisper/RESULTS.md
@@ -221,3 +221,112 @@ condition.
   1.5 GB. **Note:** this is the **f16 (unquantized)** ggml conversion — distil-whisper does not
   publish a q5_0 ggml, so Table 1's "Quant" for this row is f16, not q5_0 as the plan template
   assumed. Recorded as a deviation.
+
+---
+
+## Table 4 — Construction-noise SNR sweep (Plan 08 Part C, Task 12)
+
+**Purpose.** Decide, with data: (a) base.en vs small.en for the jobsite, (b) the
+Task 10 voice-processing default, (c) the Task 11 VAD / no_speech thresholds.
+
+**Method / honesty.** `sweep` subcommand (`src/sweep.rs` + `src/noise.rs`).
+Public jobsite corpora (ESC-50/FSD50K/freesound) are not reachable from the
+sandbox, so four characteristic noise profiles are **synthesized** deterministically
+(fixed-seed xorshift) and mixed into the `say`-generated speech at a target SNR:
+`jackhammer` (~12 Hz broadband impact train), `saw` (~3.4 kHz harmonic buzz, AM),
+`generator` (60 Hz hum + harmonics + low rumble), `wind` (heavy low-pass gusting).
+This is a **spike-grade proxy** — valid for RELATIVE model/threshold comparison and
+for the R3 hallucination probe, NOT an absolute WER claim on real ambience. Host:
+Apple Silicon Mac, Metal. Clip `jargon1.wav` (59.8 s). Both models were available
+locally (base.en-q5_1 60 MB, small.en-q5_1 190 MB) — **no model gap; the full
+base-vs-small sweep ran.**
+
+### Table 4A — WER (%) vs SNR (speech + noise)
+
+| Model | Noise | clean | +20 dB | +10 dB | +5 dB | 0 dB | halluc @ 0 dB |
+|-------|-------|-------|--------|--------|-------|------|---------------|
+| base.en  | jackhammer | 5.8 | 8.8 | 8.2 | 9.4 | 13.5 | no |
+| base.en  | saw        | 5.8 | 5.8 | 10.5 | 11.7 | 14.6 | no |
+| base.en  | generator  | 5.8 | 6.4 | 7.0 | 8.2 | 5.8 | no |
+| base.en  | wind       | 5.8 | 5.8 | 7.0 | 8.2 | 9.4 | no |
+| small.en | jackhammer | 4.7 | 6.4 | 7.6 | 7.6 | 8.2 | no |
+| small.en | saw        | 4.7 | 5.8 | 6.4 | 8.2 | 11.1 | no |
+| small.en | generator  | 4.7 | 6.4 | 5.8 | 5.8 | 6.4 | no |
+| small.en | wind       | 4.7 | 4.7 | 5.8 | 5.8 | 7.0 | no |
+
+**Reading:** WER degrades gracefully — even at **0 dB SNR** (noise as loud as
+speech) both models stay ≤ 14.6 %. `saw` (broadband high-freq) is the worst case;
+a steady `generator` drone is nearly free (whisper models constant hum well).
+small.en is **uniformly 2–4 pp better** than base.en at every SNR. **No
+hallucination flag fired at 0 dB when speech was present** — whisper's fluent-
+invention failure mode needs the *absence* of speech (Table 4B), not merely noise.
+
+### Table 4B — R3 probe: noise-ONLY decode (no speech present)
+
+Any committed token is a hallucination (R3 violation). `max no_speech_prob` is the
+signal the Task 11b gate keys on. Noise scaled to ~0.1 RMS (audible machinery).
+
+| Model | Noise | segments | invented tokens | max no_speech_prob | min no_speech_prob |
+|-------|-------|----------|-----------------|--------------------|--------------------|
+| base.en  | jackhammer | 2 | 4 | 0.952 | 0.000 |
+| base.en  | saw        | 2 | 4 | 0.934 | 0.000 |
+| base.en  | generator  | 2 | 4 | 0.964 | 0.000 |
+| base.en  | wind       | 1 | 1 | 0.567 | 0.567 |
+| small.en | jackhammer | 0 | 0 | n/a   | n/a   |
+| small.en | saw        | 2 | 2 | 0.974 | 0.000 |
+| small.en | generator  | 1 | 1 | 0.823 | 0.823 |
+| small.en | wind       | 1 | 1 | 0.262 | 0.262 |
+
+**Reading:** base.en invents 1–4 tokens on **every** machinery type; small.en cuts
+that (jackhammer → 0) but does NOT eliminate it. Most hallucinated segments carry a
+**high** no_speech_prob (0.82–0.97) — the gate catches those — but there are
+outliers *below* 0.6 (base.en `wind` 0.567, small.en `wind` 0.262) and even
+per-segment `min = 0.000` on multi-segment clips. **Conclusion: no single
+no_speech_prob threshold catches all machinery hallucination; the energy VAD gate
+and the no_speech gate are complementary, and neither is sufficient alone.** The
+strongest real-world defense is that field audio contains speech (Table 4A: zero
+hallucination with speech present).
+
+### RESULTS — the three decisions
+
+1. **Model — bundle `base.en` for the milestone; `small.en` is the validated
+   upgrade.** small.en is strictly better on every measured axis (clean 4.7 vs
+   5.8 % WER; 2–4 pp lower under all noise; jackhammer noise-only hallucination
+   0 vs 4 tokens) and its RTF headroom makes it "~free" to run (D5). The **only**
+   cost is the bundle: 190 MB vs 60 MB. Because (a) with speech present neither
+   model hallucinated even at 0 dB, and (b) the Task 11 R3 gates handle the
+   noise-only case, **base.en stays the bundled default** (offline-first, small
+   IPA — spec §1). **Promote small.en** once the ODR/download path lands or if
+   device field WER proves painful (D5 carry-forward: the bundle-vs-download
+   trade tightens at 190 MB).
+
+2. **Task 10 voice-processing default — OFF, pending a device A/B.** This eval
+   could NOT measure `setVoiceProcessingEnabled`: it is a device audio-unit knob,
+   not reproducible with synthetic/offline PCM. On the evidence we do have —
+   whisper handles additive noise well when speech is present (Table 4A) and
+   aggressive suppression is known to add spectral artifacts that can *hurt*
+   whisper — the conservative default is **voice processing OFF**. The A/B knob
+   ships (Task 10) precisely so a real-device sweep can flip it. **Owed: an
+   on-device `voiceproc=1` vs `voiceproc=0` WER comparison** (the one gap this
+   harness can't close).
+
+3. **Task 11 thresholds.**
+   - `no_speech_prob_threshold` = **0.6** (keep the shipped default). It catches
+     the dominant 0.82–0.97 hallucination cluster while staying well clear of
+     real-speech no_speech_prob (typically < 0.1), so it will not drop genuine
+     speech. Lowering it to chase the `wind` outliers (0.26–0.57) would risk
+     false-positives on quiet real speech; those low-confidence machinery cases
+     are better handled by the energy gate.
+   - `vad_rms_threshold` = **0.0 in code (off) as the shipped conservative
+     default; recommend ~0.01 for device builds.** The noise-only clips sat at
+     ~0.1 RMS (above any reasonable silence gate — so energy alone won't stop
+     machinery hallucination either), while true dead air is ~0.0 RMS and speech
+     is ~0.05–0.3 RMS. A 0.01 gate skips dead-air windows (a free hallucination
+     surface + wasted decode) without touching speech. It stays **0.0 (off)**
+     until on-device speech-level RMS is characterized, so the milestone can
+     never elide a quiet real utterance.
+
+**Net:** ship base.en + the two R3 gates at their conservative defaults
+(no_speech 0.6, VAD 0.0); the machinery-hallucination risk is real but bounded
+(needs speech-absent audio), and the remaining tuning (VAD 0.01, voiceproc A/B,
+small.en promotion) is device-measurement-gated, not blocked on code.

--- a/spikes/stt-whisper/src/main.rs
+++ b/spikes/stt-whisper/src/main.rs
@@ -4,7 +4,9 @@
 // NOT a workspace member. Nothing here is production code.
 
 mod bench;
+mod noise;
 mod stream;
+mod sweep;
 mod wer;
 
 use std::collections::HashMap;
@@ -157,12 +159,15 @@ fn main() {
         "accuracy" => wer::run_accuracy(&flags),
         "bias" => wer::run_bias(&flags),
         "stream" => stream::run(&flags),
+        "sweep" => sweep::run(&flags),
         _ => {
-            eprintln!("usage: stt-whisper-spike <bench|stream|accuracy|bias> [flags]");
+            eprintln!("usage: stt-whisper-spike <bench|stream|accuracy|bias|sweep> [flags]");
             eprintln!("  bench    --model M --audio A");
             eprintln!("  stream   --model M --audio A --chunk 5 --overlap 1");
             eprintln!("  accuracy --model M --audio A --reference R [--snr DB]");
             eprintln!("  bias     --model M --audio A --reference R --terms T [--snr DB]");
+            eprintln!("  sweep    --modeldir D --audio A --reference R   (construction-noise SNR sweep, Task 12)");
+            eprintln!("           (or --models base.bin,small.bin)");
             std::process::exit(2);
         }
     }

--- a/spikes/stt-whisper/src/noise.rs
+++ b/spikes/stt-whisper/src/noise.rs
@@ -1,0 +1,164 @@
+// Deterministic synthetic construction-site noise (Plan 08 Task 12).
+//
+// SPIKE-GRADE PROXY (deviation from the plan's "public corpora"): ESC-50 /
+// FSD50K / freesound are not reachable from the sandbox, so we SYNTHESIZE the
+// characteristic spectral/temporal signatures of four jobsite sources and mix
+// them into the TTS speech at a target SNR. This is honest for RELATIVE
+// comparison (base.en vs small.en, threshold tuning) and for the R3
+// hallucination probe (does whisper invent text over machinery drone on a
+// noise-ONLY clip?), but it is NOT an absolute WER claim on real ambience.
+// Real jobsite recordings remain the aspirational corpus (Plan 06 note).
+//
+// No `rand` crate: a fixed-seed xorshift keeps every clip byte-reproducible so
+// the RESULTS table is regenerable.
+
+const SR: f64 = 16_000.0;
+const TAU: f64 = std::f64::consts::TAU;
+
+struct Xorshift(u64);
+impl Xorshift {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    /// uniform [0,1)
+    fn unit(&mut self) -> f64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        (self.0 >> 11) as f64 / (1u64 << 53) as f64
+    }
+    /// uniform [-1,1)
+    fn bipolar(&mut self) -> f64 {
+        self.unit() * 2.0 - 1.0
+    }
+}
+
+/// Generate `n` samples of the named noise, normalized to unit RMS so `mix`
+/// can scale it to any target power cleanly.
+pub fn generate(kind: &str, n: usize) -> Vec<f32> {
+    let mut v = match kind {
+        "jackhammer" => jackhammer(n),
+        "saw" => saw(n),
+        "generator" => generator(n),
+        "wind" => wind(n),
+        "white" => white(n),
+        other => panic!("unknown noise kind '{other}' (jackhammer|saw|generator|wind|white)"),
+    };
+    normalize_rms(&mut v);
+    v
+}
+
+pub const KINDS: [&str; 4] = ["jackhammer", "saw", "generator", "wind"];
+
+/// Pneumatic jackhammer: a ~12 Hz train of short broadband impacts, each a
+/// sharp-attack decaying burst of white noise; near-silent between strikes.
+fn jackhammer(n: usize) -> Vec<f32> {
+    let mut rng = Xorshift::new(0x1234_5678_9ABC_DEF0);
+    let strike_hz = 12.0;
+    let period = (SR / strike_hz) as usize;
+    let burst = (period as f64 * 0.35) as usize; // ~35% duty
+    let mut out = vec![0.0f32; n];
+    for (i, s) in out.iter_mut().enumerate() {
+        let phase = i % period.max(1);
+        if phase < burst {
+            // exponential-decay envelope on the impact
+            let env = (-(phase as f64) / (burst as f64 * 0.4)).exp();
+            *s = (rng.bipolar() * env) as f32;
+        }
+    }
+    out
+}
+
+/// Circular saw: a bright, harmonic-rich tone near 3.4 kHz, amplitude-modulated
+/// at ~28 Hz (the blade-in-material growl), with a little broadband hiss.
+fn saw(n: usize) -> Vec<f32> {
+    let mut rng = Xorshift::new(0x0FED_CBA9_8765_4321);
+    let f0 = 3400.0;
+    let am = 28.0;
+    let mut out = vec![0.0f32; n];
+    for (i, s) in out.iter_mut().enumerate() {
+        let t = i as f64 / SR;
+        // sawtooth via first few harmonics
+        let saw = (0..4)
+            .map(|k| {
+                let h = (k + 1) as f64;
+                (TAU * f0 * h * t).sin() / h
+            })
+            .sum::<f64>();
+        let env = 0.6 + 0.4 * (TAU * am * t).sin();
+        *s = ((saw * env) + rng.bipolar() * 0.15) as f32;
+    }
+    out
+}
+
+/// Portable generator / compressor: steady low drone — a 60 Hz fundamental plus
+/// harmonics and low broadband rumble. The classic "whisper hallucinates over a
+/// constant machine hum" case.
+fn generator(n: usize) -> Vec<f32> {
+    let mut rng = Xorshift::new(0x2468_ACE0_1357_9BDF);
+    let mut lp = 0.0f64; // 1-pole low-pass state for the rumble
+    let mut out = vec![0.0f32; n];
+    for (i, s) in out.iter_mut().enumerate() {
+        let t = i as f64 / SR;
+        let hum: f64 = [60.0, 120.0, 180.0, 240.0]
+            .iter()
+            .enumerate()
+            .map(|(k, f)| (TAU * f * t).sin() / (k + 1) as f64)
+            .sum();
+        // low-passed white → rumble
+        lp += 0.02 * (rng.bipolar() - lp);
+        *s = (hum * 0.7 + lp * 3.0) as f32;
+    }
+    out
+}
+
+/// Wind across the mic: low-passed (pink-ish) noise with slow gusting.
+fn wind(n: usize) -> Vec<f32> {
+    let mut rng = Xorshift::new(0x1111_2222_3333_4444);
+    let mut lp = 0.0f64;
+    let mut out = vec![0.0f32; n];
+    for (i, s) in out.iter_mut().enumerate() {
+        let t = i as f64 / SR;
+        // heavy low-pass → wind roar; slow gust envelope
+        lp += 0.008 * (rng.bipolar() - lp);
+        let gust = 0.5 + 0.5 * (TAU * 0.3 * t).sin();
+        *s = (lp * 8.0 * gust) as f32;
+    }
+    out
+}
+
+fn white(n: usize) -> Vec<f32> {
+    let mut rng = Xorshift::new(0x9E37_79B9_7F4A_7C15);
+    (0..n).map(|_| rng.bipolar() as f32).collect()
+}
+
+fn rms(v: &[f32]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    (v.iter().map(|&s| (s as f64) * (s as f64)).sum::<f64>() / v.len() as f64).sqrt()
+}
+
+fn normalize_rms(v: &mut [f32]) {
+    let r = rms(v);
+    if r > 1e-12 {
+        let g = (1.0 / r) as f32;
+        for s in v.iter_mut() {
+            *s *= g;
+        }
+    }
+}
+
+/// Mix unit-RMS `noise` into `signal` at `snr_db` (noise tiles/cycles to fill).
+/// Returns the mixed signal (leaves `signal` untouched).
+pub fn mix_at_snr(signal: &[f32], noise: &[f32], snr_db: f64) -> Vec<f32> {
+    let sig_pow =
+        signal.iter().map(|&s| (s as f64) * (s as f64)).sum::<f64>() / signal.len().max(1) as f64;
+    let noise_pow_target = sig_pow / 10f64.powf(snr_db / 10.0);
+    let amp = noise_pow_target.sqrt(); // noise is unit-RMS (power 1) → scale = sqrt(target power)
+    signal
+        .iter()
+        .zip(noise.iter().cycle())
+        .map(|(&s, &nz)| (s as f64 + nz as f64 * amp) as f32)
+        .collect()
+}

--- a/spikes/stt-whisper/src/sweep.rs
+++ b/spikes/stt-whisper/src/sweep.rs
@@ -1,0 +1,131 @@
+// `sweep` — construction-noise SNR sweep (Plan 08 Task 12).
+//
+// For each model × noise-kind × SNR: mix synthetic jobsite noise into the TTS
+// speech, decode, and report WER + a hallucination flag. Plus a NOISE-ONLY
+// probe per kind (no speech at all): the R3 metric — does whisper invent text
+// over pure machinery, and what no_speech_prob does it assign? That distribution
+// is exactly what sets the Task 11 no_speech_prob threshold.
+//
+// Manual / not CI: needs the model files + macOS `say`-generated WAVs.
+
+use crate::noise;
+use crate::wer::{hallucination_flag, wer};
+use crate::{load_wav_16k_mono, make_ctx, make_params, model_label};
+use std::collections::HashMap;
+use whisper_rs::WhisperContext;
+
+const SNRS_DB: [f64; 4] = [20.0, 10.0, 5.0, 0.0];
+
+struct SegInfo {
+    text: String,
+    no_speech_prob: f32,
+}
+
+/// Decode capturing per-segment no_speech_prob (the spike's shared `decode`
+/// drops it; the sweep needs it for the R3 threshold call).
+fn decode_with_nsp(ctx: &WhisperContext, samples: &[f32], prompt: Option<&str>) -> (String, Vec<SegInfo>) {
+    let mut state = ctx.create_state().expect("create state");
+    state.full(make_params(prompt), samples).expect("full decode");
+    let n = state.full_n_segments();
+    let mut text = String::new();
+    let mut segs = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        if let Some(seg) = state.get_segment(i) {
+            let s = seg.to_str_lossy().map(|c| c.into_owned()).unwrap_or_default();
+            text.push_str(&s);
+            segs.push(SegInfo { text: s.trim().to_string(), no_speech_prob: seg.no_speech_probability() });
+        }
+    }
+    (text.trim().to_string(), segs)
+}
+
+pub fn run(flags: &HashMap<String, String>) {
+    // --models: comma-separated model paths (default: base.en + small.en if a
+    // --modeldir is given).
+    let models: Vec<String> = if let Some(m) = flags.get("models") {
+        m.split(',').map(|s| s.trim().to_string()).collect()
+    } else if let Some(dir) = flags.get("modeldir") {
+        ["ggml-base.en-q5_1.bin", "ggml-small.en-q5_1.bin"]
+            .iter()
+            .map(|f| format!("{}/{f}", dir.trim_end_matches('/')))
+            .collect()
+    } else {
+        vec![flags.get("model").expect("--model, --models, or --modeldir required").clone()]
+    };
+    let audio = flags.get("audio").expect("--audio required");
+    let reference =
+        std::fs::read_to_string(flags.get("reference").expect("--reference required")).expect("read reference");
+    let (clean, dur) = load_wav_16k_mono(audio);
+    let clip = audio.rsplit('/').next().unwrap().to_string();
+
+    // Pre-generate each noise track once, tiled to the speech length.
+    let noises: Vec<(&str, Vec<f32>)> =
+        noise::KINDS.iter().map(|k| (*k, noise::generate(k, clean.len()))).collect();
+    // A pure-noise, speech-free track (~same duration) for the R3 probe.
+    let noise_only_len = clean.len();
+
+    println!("## Task 12 — construction-noise SNR sweep\n");
+    println!("Clip `{clip}` ({dur:.1} s). Synthetic noise (spike proxy — see `noise.rs`). SNRs in dB.\n");
+
+    // ---- Table A: WER curves (per model, per noise, per SNR) ----
+    println!("### Table A — WER (%) vs SNR\n");
+    println!("| Model | Noise | clean | +20 dB | +10 dB | +5 dB | 0 dB | halluc @ 0 dB |");
+    println!("|-------|-------|-------|--------|--------|-------|------|---------------|");
+    for model in &models {
+        let label = model_label(model);
+        let ctx = make_ctx(model);
+        // clean baseline
+        let (clean_text, _) = decode_with_nsp(&ctx, &clean, None);
+        let clean_wer = wer(&reference, &clean_text) * 100.0;
+        for (kind, track) in &noises {
+            let mut row_wer = Vec::new();
+            let mut halluc0 = "no".to_string();
+            for &snr in &SNRS_DB {
+                let mixed = noise::mix_at_snr(&clean, track, snr);
+                let (text, _) = decode_with_nsp(&ctx, &mixed, None);
+                let w = wer(&reference, &text) * 100.0;
+                row_wer.push(w);
+                if snr == 0.0 {
+                    halluc0 = hallucination_flag(&reference, &text)
+                        .map(|s| format!("YES ({s})"))
+                        .unwrap_or_else(|| "no".to_string());
+                }
+            }
+            println!(
+                "| {label} | {kind} | {clean_wer:.1} | {:.1} | {:.1} | {:.1} | {:.1} | {halluc0} |",
+                row_wer[0], row_wer[1], row_wer[2], row_wer[3]
+            );
+        }
+    }
+
+    // ---- Table B: R3 probe — noise-ONLY (no speech). Invented tokens + no_speech_prob. ----
+    println!("\n### Table B — R3 probe: decode of noise-ONLY clips (no speech present)\n");
+    println!("Any committed token here is a hallucination. `max no_speech_prob` across segments");
+    println!("is the signal the Task 11b gate keys on.\n");
+    println!("| Model | Noise | segments | invented tokens | max no_speech_prob | min no_speech_prob |");
+    println!("|-------|-------|----------|-----------------|--------------------|--------------------|");
+    for model in &models {
+        let label = model_label(model);
+        let ctx = make_ctx(model);
+        for kind in noise::KINDS {
+            // unit-RMS noise scaled to a realistic absolute level (~0.1 RMS).
+            let track = noise::generate(kind, noise_only_len);
+            let clip: Vec<f32> = track.iter().map(|&s| s * 0.1).collect();
+            let (_text, segs) = decode_with_nsp(&ctx, &clip, None);
+            let invented: usize = segs.iter().map(|s| s.text.split_whitespace().count()).sum();
+            let max_nsp = segs.iter().map(|s| s.no_speech_prob).fold(0.0f32, f32::max);
+            let min_nsp = segs.iter().map(|s| s.no_speech_prob).fold(1.0f32, f32::min);
+            let (max_s, min_s) = if segs.is_empty() {
+                ("n/a".to_string(), "n/a".to_string())
+            } else {
+                (format!("{max_nsp:.3}"), format!("{min_nsp:.3}"))
+            };
+            println!(
+                "| {label} | {kind} | {} | {invented} | {max_s} | {min_s} |",
+                segs.len()
+            );
+        }
+    }
+    eprintln!("[sweep] done: {} model(s) × {} noises × {} SNRs + noise-only probe",
+        models.len(), noise::KINDS.len(), SNRS_DB.len());
+}


### PR DESCRIPTION
## Thinking

Whisper's worst failure on a jobsite isn't mishearing — it's inventing fluent text from machinery-only audio, which breaks the product's core promise (R3: under-extract, never invent). Part C closes that with two complementary gates, and the SNR sweep proved they NEED to be two: hallucinated segments cluster at high no_speech_prob (0.82–0.97, the 0.6 gate catches them) but wind produces sub-0.6 outliers that only an energy gate structure covers. Neither alone suffices; the data said so.

The sweep also settled the model question with numbers: with speech present, neither model hallucinates even at 0 dB SNR, and base.en degrades gracefully (≤14.6% WER at 0 dB) — so base.en stays the bundled default and small.en (uniformly 2–4pp better) is the validated upgrade when download/ODR lands.

Design invariants verified by the independent final review (MERGE WITH NOTES, no defects): the flush window is never energy-gated (a quiet final utterance can't be silently dropped by VAD), skipped windows still advance the chunker cursor (timestamps don't drift), and append-only holds under mid-stream no_speech drops. Conservative defaults ship: VAD off (0.0), no_speech 0.6 — device-measurement-gated tuning.

## Review notes carried as follow-ups (non-blocking)

- The two thresholds aren't yet plumbed through EngineConfig→Swift (device tuning will need it).
- Quiet-flush behavior under real whisper no_speech scores goes on the device-walk validation checklist.
- Mid-walk audio route changes (headset plug) are a pre-existing tap-format caveat, unchanged by this branch.

## Numbers

295 workspace tests (289 + 6, name-diff verified — zero removed), clippy clean, whisper-feature build clean, sweep results in spikes/stt-whisper/RESULTS.md Table 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)