### PR TITLE
STT noise-gate knobs: launch-arg tunable vad_rms + no_speech_prob

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -1521,6 +1521,20 @@ public struct EngineConfig {
      * this from `#if targetEnvironment(simulator)`.
      */
     public var sttUseGpu: Bool
+    /**
+     * Per-window RMS-energy pre-gate for STT (see `SttConfig::vad_rms_threshold`).
+     * Default `0.0` = decode everything. Device tuning sweeps this (~0.01) to
+     * suppress construction-noise decodes without dropping speech. Not secret:
+     * fine to print in `Debug`. Swift `sttvad=<float>` launch arg overrides it.
+     */
+    public var sttVadRmsThreshold: Float
+    /**
+     * no_speech_prob post-check for STT (see `SttConfig::no_speech_prob_threshold`).
+     * Default `0.6`. Higher = keep more borderline segments; lower = drop more
+     * suspected hallucinations. Not secret: fine to print in `Debug`. Swift
+     * `sttnsp=<float>` launch arg overrides it.
+     */
+    public var sttNoSpeechProbThreshold: Float
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -1539,7 +1553,19 @@ public struct EngineConfig {
          * in ggml_metal_buffer_set_tensor) instead of degrading (falsified D7
          * assumption); CPU/BLAS decode on sim is proven working. Swift derives
          * this from `#if targetEnvironment(simulator)`.
-         */sttUseGpu: Bool) {
+         */sttUseGpu: Bool, 
+        /**
+         * Per-window RMS-energy pre-gate for STT (see `SttConfig::vad_rms_threshold`).
+         * Default `0.0` = decode everything. Device tuning sweeps this (~0.01) to
+         * suppress construction-noise decodes without dropping speech. Not secret:
+         * fine to print in `Debug`. Swift `sttvad=<float>` launch arg overrides it.
+         */sttVadRmsThreshold: Float, 
+        /**
+         * no_speech_prob post-check for STT (see `SttConfig::no_speech_prob_threshold`).
+         * Default `0.6`. Higher = keep more borderline segments; lower = drop more
+         * suspected hallucinations. Not secret: fine to print in `Debug`. Swift
+         * `sttnsp=<float>` launch arg overrides it.
+         */sttNoSpeechProbThreshold: Float) {
         self.dbPath = dbPath
         self.deviceId = deviceId
         self.apiKey = apiKey
@@ -1550,6 +1576,8 @@ public struct EngineConfig {
         self.sttModelPath = sttModelPath
         self.sttFlushOnFinish = sttFlushOnFinish
         self.sttUseGpu = sttUseGpu
+        self.sttVadRmsThreshold = sttVadRmsThreshold
+        self.sttNoSpeechProbThreshold = sttNoSpeechProbThreshold
     }
 }
 
@@ -1587,6 +1615,12 @@ extension EngineConfig: Equatable, Hashable {
         if lhs.sttUseGpu != rhs.sttUseGpu {
             return false
         }
+        if lhs.sttVadRmsThreshold != rhs.sttVadRmsThreshold {
+            return false
+        }
+        if lhs.sttNoSpeechProbThreshold != rhs.sttNoSpeechProbThreshold {
+            return false
+        }
         return true
     }
 
@@ -1601,6 +1635,8 @@ extension EngineConfig: Equatable, Hashable {
         hasher.combine(sttModelPath)
         hasher.combine(sttFlushOnFinish)
         hasher.combine(sttUseGpu)
+        hasher.combine(sttVadRmsThreshold)
+        hasher.combine(sttNoSpeechProbThreshold)
     }
 }
 
@@ -1621,7 +1657,9 @@ public struct FfiConverterTypeEngineConfig: FfiConverterRustBuffer {
                 modelReflection: FfiConverterString.read(from: &buf), 
                 sttModelPath: FfiConverterOptionString.read(from: &buf), 
                 sttFlushOnFinish: FfiConverterBool.read(from: &buf), 
-                sttUseGpu: FfiConverterBool.read(from: &buf)
+                sttUseGpu: FfiConverterBool.read(from: &buf), 
+                sttVadRmsThreshold: FfiConverterFloat.read(from: &buf), 
+                sttNoSpeechProbThreshold: FfiConverterFloat.read(from: &buf)
         )
     }
 
@@ -1636,6 +1674,8 @@ public struct FfiConverterTypeEngineConfig: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.sttModelPath, into: &buf)
         FfiConverterBool.write(value.sttFlushOnFinish, into: &buf)
         FfiConverterBool.write(value.sttUseGpu, into: &buf)
+        FfiConverterFloat.write(value.sttVadRmsThreshold, into: &buf)
+        FfiConverterFloat.write(value.sttNoSpeechProbThreshold, into: &buf)
     }
 }
 

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -18,6 +18,11 @@ private let engineLog = Logger(subsystem: "com.damsac.sitewalk", category: "engi
 //                                              auto-finishes it (state machine demo)
 //   demo=1                                   → force DemoWalkEngine even if a
 //                                              key is configured (D10)
+//   sttgpu=0|1                               → force whisper CPU / GPU (Metal)
+//   sttvad=<float>                           → STT per-window RMS pre-gate
+//                                              (default 0.0; ~0.01 cuts noise)
+//   sttnsp=<float>                           → STT no_speech_prob drop
+//                                              threshold (default 0.6)
 
 /// Engine selection (Plan 07 D10/Task 11): real `MurmurEngine` when an API
 /// key + config resolve, `DemoWalkEngine` when launched with `demo=1` OR
@@ -25,6 +30,51 @@ private let engineLog = Logger(subsystem: "com.damsac.sitewalk", category: "engi
 /// demos still run with zero backend. `nil` here means "use AppModel's
 /// DemoWalkEngine default." Delete nothing (D10) — every existing launch arg
 /// keeps working.
+/// Reads the value of a `<prefix><float>` launch arg (e.g. `sttvad=0.01`),
+/// falling back to `fallback` when the arg is absent OR its value doesn't
+/// parse as a Float. A malformed arg logs a breadcrumb and keeps the default —
+/// a typo in a QA/device launch arg must never crash the app.
+private func floatLaunchArg(_ prefix: String, in args: [String], default fallback: Float) -> Float {
+    guard let arg = args.first(where: { $0.hasPrefix(prefix) }) else { return fallback }
+    let raw = String(arg.dropFirst(prefix.count))
+    guard let parsed = Float(raw) else {
+        engineLog.notice("ignoring malformed \(prefix, privacy: .public) launch arg (kept default)")
+        return fallback
+    }
+    return parsed
+}
+
+/// Resolves the three whisper knobs from launch args (all overridable for the
+/// on-device sweep and design QA):
+///   `sttgpu=0|1` — force whisper CPU / GPU (Metal). Default: GPU on device,
+///     CPU on the simulator (Metal hard-crashes on sim — SIGTRAP in
+///     ggml_metal_buffer_set_tensor via MTLSimDevice; D7's "degrades to CPU"
+///     assumption was falsified, so a sim build can never crash by default).
+///   `sttvad=<float>` — per-window RMS pre-gate (default 0.0 = decode
+///     everything; ~0.01 suppresses construction noise without dropping speech).
+///   `sttnsp=<float>` — no_speech_prob drop threshold (default 0.6).
+/// Float args parse defensively (see floatLaunchArg): a typo keeps the default.
+private struct SttKnobs {
+    var useGpu: Bool
+    var vadRms: Float
+    var noSpeechProb: Float
+}
+
+private func resolveSttKnobs(_ args: [String]) -> SttKnobs {
+    #if targetEnvironment(simulator)
+    var useGpu = false
+    #else
+    var useGpu = true
+    #endif
+    if args.contains("sttgpu=0") { useGpu = false }
+    if args.contains("sttgpu=1") { useGpu = true }
+    let vadRms = floatLaunchArg("sttvad=", in: args, default: 0.0)
+    let noSpeechProb = floatLaunchArg("sttnsp=", in: args, default: 0.6)
+    engineLog.notice("stt gpu=\(useGpu, privacy: .public)")
+    engineLog.notice("stt vad_rms=\(vadRms, privacy: .public) no_speech_prob=\(noSpeechProb, privacy: .public)")
+    return SttKnobs(useGpu: useGpu, vadRms: vadRms, noSpeechProb: noSpeechProb)
+}
+
 @MainActor
 private func resolveEngine(demo: Bool) -> WalkEngine? {
     if demo {
@@ -56,22 +106,7 @@ private func resolveEngine(demo: Bool) -> WalkEngine? {
     if sttModelPath == nil {
         engineLog.notice("stt model not bundled — live walk will run text-only")
     }
-    // GPU (Metal) for whisper: DEVICE only. On the iOS SIMULATOR Metal
-    // hard-crashes (SIGTRAP in ggml_metal_buffer_set_tensor via MTLSimDevice)
-    // instead of degrading — the D7 "falls back to CPU" assumption was
-    // falsified by sim verification. Compile-time targetEnvironment is the
-    // signal (a sim build can never crash by default); CPU/BLAS decode on sim
-    // is proven working. `sttgpu=0` / `sttgpu=1` launch args override for
-    // testing (e.g. forcing CPU on device to compare decode paths).
-    #if targetEnvironment(simulator)
-    var sttUseGpu = false
-    #else
-    var sttUseGpu = true
-    #endif
-    let launchArgs = ProcessInfo.processInfo.arguments
-    if launchArgs.contains("sttgpu=0") { sttUseGpu = false }
-    if launchArgs.contains("sttgpu=1") { sttUseGpu = true }
-    engineLog.notice("stt gpu=\(sttUseGpu, privacy: .public)")
+    let stt = resolveSttKnobs(ProcessInfo.processInfo.arguments)
     let config = EngineConfig(
         dbPath: dbPath,
         deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "unknown-device",
@@ -82,7 +117,9 @@ private func resolveEngine(demo: Bool) -> WalkEngine? {
         modelReflection: "claude-haiku-4-5",
         sttModelPath: sttModelPath,
         sttFlushOnFinish: true, // D6 default: flush the last utterance on DONE
-        sttUseGpu: sttUseGpu
+        sttUseGpu: stt.useGpu,
+        sttVadRmsThreshold: stt.vadRms,
+        sttNoSpeechProbThreshold: stt.noSpeechProb
     )
     engineLog.notice("engine=real (murmur-core MurmurEngine, key len=\(apiKey.count, privacy: .public))")
     // Throwing constructor (no panics across FFI): if the store can't open,

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -51,6 +51,16 @@ pub struct EngineConfig {
     /// assumption); CPU/BLAS decode on sim is proven working. Swift derives
     /// this from `#if targetEnvironment(simulator)`.
     pub stt_use_gpu: bool,
+    /// Per-window RMS-energy pre-gate for STT (see `SttConfig::vad_rms_threshold`).
+    /// Default `0.0` = decode everything. Device tuning sweeps this (~0.01) to
+    /// suppress construction-noise decodes without dropping speech. Not secret:
+    /// fine to print in `Debug`. Swift `sttvad=<float>` launch arg overrides it.
+    pub stt_vad_rms_threshold: f32,
+    /// no_speech_prob post-check for STT (see `SttConfig::no_speech_prob_threshold`).
+    /// Default `0.6`. Higher = keep more borderline segments; lower = drop more
+    /// suspected hallucinations. Not secret: fine to print in `Debug`. Swift
+    /// `sttnsp=<float>` launch arg overrides it.
+    pub stt_no_speech_prob_threshold: f32,
 }
 
 impl std::fmt::Debug for EngineConfig {
@@ -66,6 +76,8 @@ impl std::fmt::Debug for EngineConfig {
             .field("stt_model_path", &self.stt_model_path)
             .field("stt_flush_on_finish", &self.stt_flush_on_finish)
             .field("stt_use_gpu", &self.stt_use_gpu)
+            .field("stt_vad_rms_threshold", &self.stt_vad_rms_threshold)
+            .field("stt_no_speech_prob_threshold", &self.stt_no_speech_prob_threshold)
             .finish()
     }
 }
@@ -134,6 +146,12 @@ pub struct MurmurEngine {
     /// GPU toggle for the whisper backend (see `EngineConfig::stt_use_gpu`).
     #[cfg_attr(not(feature = "whisper"), allow(dead_code))]
     pub(crate) stt_use_gpu: bool,
+    /// RMS pre-gate for the whisper backend (see `EngineConfig::stt_vad_rms_threshold`).
+    #[cfg_attr(not(feature = "whisper"), allow(dead_code))]
+    pub(crate) stt_vad_rms_threshold: f32,
+    /// no_speech_prob post-check (see `EngineConfig::stt_no_speech_prob_threshold`).
+    #[cfg_attr(not(feature = "whisper"), allow(dead_code))]
+    pub(crate) stt_no_speech_prob_threshold: f32,
     _runtime: Option<Arc<tokio::runtime::Runtime>>,
 }
 
@@ -163,6 +181,8 @@ impl MurmurEngine {
             stt_model_path: config.stt_model_path.clone(),
             stt_flush_on_finish: config.stt_flush_on_finish,
             stt_use_gpu: config.stt_use_gpu,
+            stt_vad_rms_threshold: config.stt_vad_rms_threshold,
+            stt_no_speech_prob_threshold: config.stt_no_speech_prob_threshold,
             _runtime: Some(runtime),
         }))
     }
@@ -178,7 +198,12 @@ impl MurmurEngine {
     pub(crate) fn build_stt_stream(&self, bias: &[String]) -> Result<Option<Arc<stt::SttStream>>, EngineError> {
         match &self.stt_model_path {
             Some(path) => {
-                let cfg = stt::SttConfig { use_gpu: self.stt_use_gpu, ..stt::SttConfig::default() };
+                let cfg = stt::SttConfig {
+                    use_gpu: self.stt_use_gpu,
+                    vad_rms_threshold: self.stt_vad_rms_threshold,
+                    no_speech_prob_threshold: self.stt_no_speech_prob_threshold,
+                    ..stt::SttConfig::default()
+                };
                 let stream = stt::SttStream::with_model(std::path::Path::new(path), cfg, bias)
                 // Never print a key here (it isn't in scope, but keep the
                 // message store/model-only — Plan 07 R6 redaction posture).
@@ -225,6 +250,8 @@ impl MurmurEngine {
             stt_model_path: None,
             stt_flush_on_finish: true,
             stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
             _runtime: None,
         })
     }
@@ -247,6 +274,8 @@ mod tests {
             stt_model_path: Some("/bundle/ggml-base.en-q5_1.bin".into()),
             stt_flush_on_finish: true,
             stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
         };
         let printed = format!("{cfg:?}");
         assert!(!printed.contains("sk-super-secret"), "api key must never be printable");
@@ -254,6 +283,11 @@ mod tests {
         assert!(printed.contains("ggml-base.en-q5_1.bin"), "model path is fine to print");
         assert!(printed.contains("stt_flush_on_finish"));
         assert!(printed.contains("stt_use_gpu"), "gpu knob is plumbed and printable");
+        assert!(printed.contains("stt_vad_rms_threshold"), "vad knob is plumbed and printable");
+        assert!(
+            printed.contains("stt_no_speech_prob_threshold"),
+            "no_speech_prob knob is plumbed and printable"
+        );
     }
 
     #[test]
@@ -271,9 +305,38 @@ mod tests {
             stt_model_path: None,
             stt_flush_on_finish: true,
             stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
         };
         let providers = build_providers(&cfg);
         assert!(Arc::ptr_eq(&providers.live, &providers.reflection));
+    }
+
+    #[test]
+    fn stt_threshold_knobs_thread_from_config_onto_the_engine() {
+        // The two noise-gate knobs must survive the EngineConfig -> MurmurEngine
+        // hop so build_stt_stream can hand them to SttConfig (device tuning).
+        // Non-default values prove it's real plumbing, not a defaulted field.
+        let cfg = EngineConfig {
+            db_path: ":memory:".into(),
+            device_id: "dev".into(),
+            api_key: "sk-test".into(),
+            base_url: None,
+            model_live: "claude-haiku-4-5".into(),
+            model_processing: "claude-sonnet-4-5".into(),
+            model_reflection: "claude-haiku-4-5".into(),
+            stt_model_path: None,
+            stt_flush_on_finish: true,
+            stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.01,
+            stt_no_speech_prob_threshold: 0.42,
+        };
+        let engine = MurmurEngine::new(cfg).expect("engine construction with :memory: store");
+        assert_eq!(engine.stt_vad_rms_threshold, 0.01, "vad threshold threaded onto the engine");
+        assert_eq!(
+            engine.stt_no_speech_prob_threshold, 0.42,
+            "no_speech_prob threshold threaded onto the engine"
+        );
     }
 
     #[test]
@@ -292,6 +355,8 @@ mod tests {
             stt_model_path: None,
             stt_flush_on_finish: true,
             stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
         };
         assert!(matches!(MurmurEngine::new(cfg), Err(EngineError::Store(_))));
     }
@@ -309,6 +374,8 @@ mod tests {
             stt_model_path: None,
             stt_flush_on_finish: true,
             stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
         };
         let providers = build_providers(&cfg);
         assert!(Arc::ptr_eq(&providers.live, &providers.reflection), "same model shares one Arc");

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -1090,6 +1090,8 @@ mod tests {
             stt_model_path: Some(model),
             stt_flush_on_finish: true,
             stt_use_gpu: true, // host-side smoke — Metal is fine here
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
         };
         let engine = MurmurEngine::new(cfg).expect("engine construction");
         let session =


### PR DESCRIPTION
## Thinking

Plan 08 Part C's final review flagged (Note A) that the two noise-gate thresholds were stt-internal — a device build couldn't tune them without a code change, and the imminent device session exists precisely to sweep them. This threads both through EngineConfig → uniffi → Swift launch args (`sttvad=` / `sttnsp=`), following the reviewed `stt_use_gpu` pattern exactly: additive record fields, key redaction untouched, defensive float parsing (a QA typo logs a breadcrumb and keeps the default — never crashes), sim-CPU safety unchanged.

Diff reviewed by the meta lane; first change gated by the new CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)