### PR TITLE
Plan 10 build: vocabulary management — the write half of the biasing loop

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -535,12 +535,32 @@ fileprivate struct FfiConverterString: FfiConverter {
 public protocol MurmurEngineProtocol : AnyObject {
     
     /**
+     * Add one user vocabulary term (`FactSource::Stated`, D3). Idempotent
+     * (case-insensitive). Errors: `Full` at 100 terms, `Empty` for blank input,
+     * a poisoned lock, or a persistence failure. Returns the resulting list so
+     * the editor updates in one round-trip.
+     */
+    func addVocabularyTerm(term: String) throws  -> [String]
+    
+    /**
      * `Store::start_session` + persists the template key, hands back a
      * fresh per-session `WalkSession` (D4). Fallible across FFI (no panics):
      * a poisoned store lock or a store error surfaces to Swift as
      * `EngineError::BeginWalk` rather than crashing the host app.
      */
     func beginWalk(jobId: String?, template: String) throws  -> WalkSession
+    
+    /**
+     * The user's vocabulary terms, insertion order. Read-only — no lock held
+     * across FFI beyond the clone.
+     */
+    func listVocabulary() throws  -> [String]
+    
+    /**
+     * Remove one vocabulary term (case-insensitive). Returns the resulting list.
+     * Removing a term that isn't present is not an error (idempotent).
+     */
+    func removeVocabularyTerm(term: String) throws  -> [String]
     
 }
 
@@ -612,6 +632,20 @@ public convenience init(config: EngineConfig)throws  {
 
     
     /**
+     * Add one user vocabulary term (`FactSource::Stated`, D3). Idempotent
+     * (case-insensitive). Errors: `Full` at 100 terms, `Empty` for blank input,
+     * a poisoned lock, or a persistence failure. Returns the resulting list so
+     * the editor updates in one round-trip.
+     */
+open func addVocabularyTerm(term: String)throws  -> [String] {
+    return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_add_vocabulary_term(self.uniffiClonePointer(),
+        FfiConverterString.lower(term),$0
+    )
+})
+}
+    
+    /**
      * `Store::start_session` + persists the template key, hands back a
      * fresh per-session `WalkSession` (D4). Fallible across FFI (no panics):
      * a poisoned store lock or a store error surfaces to Swift as
@@ -622,6 +656,29 @@ open func beginWalk(jobId: String?, template: String)throws  -> WalkSession {
     uniffi_ffi_fn_method_murmurengine_begin_walk(self.uniffiClonePointer(),
         FfiConverterOptionString.lower(jobId),
         FfiConverterString.lower(template),$0
+    )
+})
+}
+    
+    /**
+     * The user's vocabulary terms, insertion order. Read-only — no lock held
+     * across FFI beyond the clone.
+     */
+open func listVocabulary()throws  -> [String] {
+    return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_list_vocabulary(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Remove one vocabulary term (case-insensitive). Returns the resulting list.
+     * Removing a term that isn't present is not an error (idempotent).
+     */
+open func removeVocabularyTerm(term: String)throws  -> [String] {
+    return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_remove_vocabulary_term(self.uniffiClonePointer(),
+        FfiConverterString.lower(term),$0
     )
 })
 }
@@ -1721,6 +1778,13 @@ public enum EngineError {
      */
     case BeginWalk(message: String)
     
+    /**
+     * A memory / vocabulary mutation failed (lock poisoned, vocabulary full, or
+     * an empty term). Recoverable by the host — surface, don't crash. Never
+     * contains an api key (memory/vocab strings only).
+     */
+    case Memory(message: String)
+    
 }
 
 
@@ -1749,6 +1813,10 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 4: return .Memory(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -1766,6 +1834,8 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(2))
         case .BeginWalk(_ /* message is ignored*/):
             writeInt(&buf, Int32(3))
+        case .Memory(_ /* message is ignored*/):
+            writeInt(&buf, Int32(4))
 
         
         }
@@ -1951,6 +2021,31 @@ fileprivate struct FfiConverterSequenceFloat: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
+    typealias SwiftType = [String]
+
+    public static func write(_ value: [String], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterString.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [String] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [String]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterString.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeBoardItem: FfiConverterRustBuffer {
     typealias SwiftType = [BoardItem]
 
@@ -2059,7 +2154,16 @@ private var initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_add_vocabulary_term() != 28855) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_begin_walk() != 41375) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_list_vocabulary() != 10809) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_remove_vocabulary_term() != 40682) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_walkeventlistener_on_event() != 10314) {

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -44,6 +44,11 @@ final class AppModel {
     /// lands, "most-recently-captured id" is the honest interim rule.
     var lastCapturedID: UUID?
 
+    // Vocabulary editor state (Plan 10). The list is the source of truth the
+    // editor renders; `vocabularyError` carries a thrown FFI error for display.
+    private(set) var vocabulary: [String] = []
+    var vocabularyError: String?
+
     // Review state
     var document: DocumentModel?
     var editingRowID: UUID?
@@ -222,6 +227,44 @@ final class AppModel {
             self.document = doc
             self.phase = .review
             self.path = [.review]
+        }
+    }
+
+    // MARK: Vocabulary (Plan 10) — the write half of the vocabulary → STT
+    // biasing loop. Defensive: a thrown FFI error becomes a logged breadcrumb +
+    // an unchanged list, never a crash (the editor may show `vocabularyError`).
+
+    private var vocabularyLogger: Logger {
+        Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "vocabulary")
+    }
+
+    func loadVocabulary() {
+        do {
+            vocabulary = try engine.listVocabulary()
+        } catch {
+            vocabularyLogger.error("loadVocabulary failed: \(error, privacy: .public)")
+            vocabularyError = "\(error)"
+        }
+    }
+
+    func addVocabulary(_ term: String) {
+        do {
+            vocabulary = try engine.addVocabularyTerm(term)
+            vocabularyError = nil
+        } catch {
+            // sac: how errors surface (full-at-100, empty) is a design call.
+            vocabularyLogger.error("addVocabulary failed: \(error, privacy: .public)")
+            vocabularyError = "\(error)"
+        }
+    }
+
+    func removeVocabulary(_ term: String) {
+        do {
+            vocabulary = try engine.removeVocabularyTerm(term)
+            vocabularyError = nil
+        } catch {
+            vocabularyLogger.error("removeVocabulary failed: \(error, privacy: .public)")
+            vocabularyError = "\(error)"
         }
     }
 

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -19,6 +19,13 @@ final class DemoWalkEngine: WalkEngine {
     /// per event (Task 10).
     private var board: [CapturedFixture] = []
 
+    /// In-memory vocabulary so the editor is usable with no backend (Plan 10
+    /// D8). Seeded with a couple of demo terms. Mirrors the Rust semantics
+    /// loosely — normalize + case-insensitive dedup + a 100-term cap — enough
+    /// to drive the editor; the real semantics live in `harness::Memory`.
+    private var vocabulary: [String] = ["french drain", "ledger board"]
+    private static let maxVocabularyTerms = 100
+
     /// Per-trade trigger phrases, index-aligned with `trade.captured`.
     private static let triggers: [String: [String]] = [
         "landscape": ["mulch", "boxwood", "zone two", "edge the beds", "twelve hundred"],
@@ -59,6 +66,34 @@ final class DemoWalkEngine: WalkEngine {
 
     // No Rust session to tear down in the demo path.
     func cancel() async {}
+
+    // MARK: Vocabulary (Plan 10) — in-memory demo conformance.
+
+    private func normalize(_ term: String) -> String {
+        term.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
+    func listVocabulary() -> [String] { vocabulary }
+
+    func addVocabularyTerm(_ term: String) -> [String] {
+        let normalized = normalize(term)
+        guard !normalized.isEmpty else { return vocabulary }
+        // Case-insensitive dedup (keep first-seen casing); cap; reject silently
+        // in the demo (the real engine throws — the editor surfaces that).
+        if vocabulary.contains(where: { $0.caseInsensitiveCompare(normalized) == .orderedSame }) {
+            return vocabulary
+        }
+        if vocabulary.count < Self.maxVocabularyTerms {
+            vocabulary.append(normalized)
+        }
+        return vocabulary
+    }
+
+    func removeVocabularyTerm(_ term: String) -> [String] {
+        let normalized = normalize(term)
+        vocabulary.removeAll { $0.caseInsensitiveCompare(normalized) == .orderedSame }
+        return vocabulary
+    }
 
     func finish() async -> DocumentModel {
         continuation?.finish()

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -200,6 +200,24 @@ final class MurmurEngine: WalkEngine {
         return document
     }
 
+    // MARK: - Vocabulary (Plan 10): forward to the FFI CRUD methods. Each is
+    // throwing across the boundary (vocabulary full, empty term, poisoned lock,
+    // persistence failure); the thrown error propagates to AppModel, which logs
+    // a breadcrumb and leaves the list unchanged (never crashes). add/remove
+    // return the resulting list so the editor updates in one round-trip.
+
+    func listVocabulary() throws -> [String] {
+        try engine.listVocabulary()
+    }
+
+    func addVocabularyTerm(_ term: String) throws -> [String] {
+        try engine.addVocabularyTerm(term: term)
+    }
+
+    func removeVocabularyTerm(_ term: String) throws -> [String] {
+        try engine.removeVocabularyTerm(term: term)
+    }
+
     // MARK: - Formatting layer (D2): core is display-copy-free; this is
     // where cents → "$285", doc_number → "EST-0047", job_date_unix →
     // "JUL 01 2026", and label keys → display copy happen.

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -82,4 +82,15 @@ protocol WalkEngine: AnyObject {
     /// joins the pump (a decode can be in flight) — callers run it from a
     /// detached `Task` so the main actor never blocks. `DemoWalkEngine` no-ops.
     func cancel() async
+
+    // Vocabulary → STT biasing loop, write half (Plan 10). These mutate the
+    // `Memory` "vocabulary" section the engine reads at `begin_walk` to bias
+    // whisper. Throwing: the real FFI methods are fallible across the boundary
+    // (vocabulary full, empty term, a poisoned lock, a persistence failure) —
+    // the editor surfaces the error and leaves its list unchanged rather than
+    // crashing. add/remove return the RESULTING list so the editor updates in
+    // one round-trip. `DemoWalkEngine` conforms with an in-memory list.
+    func listVocabulary() throws -> [String]
+    func addVocabularyTerm(_ term: String) throws -> [String]
+    func removeVocabularyTerm(_ term: String) throws -> [String]
 }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -5,14 +5,27 @@ import SwiftUI
 
 struct BoardView: View {
     @Bindable var model: AppModel
+    // sac: entry point + presentation (sheet vs. a new AppModel.Phase) is your
+    // call; a gear → .sheet is a functional default, not a design decision.
+    @State private var showVocabulary = false
 
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(model.trade.dateLabel)
-                    .font(Theme.F.mono(10, .semibold))
-                    .tracking(2.0)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                HStack(alignment: .top) {
+                    Text(model.trade.dateLabel)
+                        .font(Theme.F.mono(10, .semibold))
+                        .tracking(2.0)
+                        .foregroundStyle(Theme.C.orangeDeep)
+                    Spacer()
+                    // sac: placement/glyph/affordance for the vocabulary editor
+                    // entry point is yours — this gear is a functional default.
+                    Button { showVocabulary = true } label: {
+                        Image(systemName: "gearshape")
+                            .foregroundStyle(Theme.C.ink60)
+                    }
+                    .buttonStyle(.plain)
+                }
                 Text(model.trade.countTitle)
                     .font(Theme.F.ui(26, .bold))
                 Menu {
@@ -61,5 +74,9 @@ struct BoardView: View {
         }
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
+        // sac: sheet vs. push, chrome, and dismissal affordance are yours.
+        .sheet(isPresented: $showVocabulary) {
+            VocabularyView(model: model)
+        }
     }
 }

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+// Vocabulary editor (Plan 10, write half of the vocabulary → STT biasing loop).
+//
+// sac: This whole screen is a functional placeholder — visual design is yours.
+// A bare List is used only because the app has none yet; restyle to the Theme
+// (Theme.C / Theme.F / Theme.S) or hand-roll rows like the rest of the app.
+// The onboarding interview (which SEEDS this vocabulary) is out of scope here.
+struct VocabularyView: View {
+    @Bindable var model: AppModel
+    @State private var newTerm = ""
+
+    var body: some View {
+        List {
+            Section {                                    // sac: header/empty-state design
+                ForEach(model.vocabulary, id: \.self) { term in
+                    Text(term)
+                }
+                .onDelete { idx in
+                    idx.map { model.vocabulary[$0] }.forEach(model.removeVocabulary)
+                }
+            }
+
+            Section {                                    // sac: add affordance design (this is placeholder)
+                HStack {
+                    TextField("Add a term", text: $newTerm) // sac: styling / focus / placeholder copy
+                    Button("Add") {
+                        let term = newTerm
+                        newTerm = ""
+                        if !term.trimmingCharacters(in: .whitespaces).isEmpty {
+                            model.addVocabulary(term)
+                        }
+                    }
+                }
+                // sac: the thrown-error surface (full-at-100, empty, too-long) is
+                // yours to design; this is a bare placeholder.
+                if let error = model.vocabularyError {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .onAppear { model.loadVocabulary() }
+        // sac: title, chrome, navigation style are yours.
+    }
+}

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -25,6 +25,11 @@ pub enum EngineError {
     /// A walk could not be started (store lock, session insert, template set).
     #[error("failed to begin walk: {0}")]
     BeginWalk(String),
+    /// A memory / vocabulary mutation failed (lock poisoned, vocabulary full, or
+    /// an empty term). Recoverable by the host — surface, don't crash. Never
+    /// contains an api key (memory/vocab strings only).
+    #[error("memory error: {0}")]
+    Memory(String),
 }
 
 /// Config crossing the FFI boundary. `api_key` is an opaque `String` from the

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -10,6 +10,7 @@ pub mod document;
 pub mod engine;
 pub mod events;
 pub mod session;
+pub mod vocabulary;
 
 pub use convert::{document_payload, partial_document_from_items};
 pub use document::{DocLine, DocumentPayload};

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -1282,6 +1282,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn vocabulary_added_via_ffi_feeds_begin_walk_bias_assembly() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(vec![])),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        );
+        // WRITE half (the new FFI path):
+        engine.add_vocabulary_term("french drain".into()).unwrap();
+        engine.add_vocabulary_term("ledger board".into()).unwrap();
+
+        // READ half (what begin_walk assembles): the terms flow through
+        // collect_bias_terms → build_bias_prompt exactly as begin_walk uses them.
+        let bias = {
+            let mem = engine.memory.lock().unwrap();
+            collect_bias_terms(&mem, Some("landscape"))
+        };
+        assert_eq!(bias, vec!["french drain".to_string(), "ledger board".to_string()]);
+        let prompt = stt::build_bias_prompt(&bias, stt::SttConfig::default().max_bias_terms).unwrap();
+        assert!(
+            prompt.contains("french drain") && prompt.contains("ledger board"),
+            "the whisper initial_prompt carries the user's added terms: {prompt}"
+        );
+    }
+
+    #[tokio::test]
     async fn tick_cannot_interleave_with_finish() {
         let store = Store::open_in_memory("device-a").unwrap();
         let session_row = store.start_session(None).unwrap();

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -96,7 +96,7 @@ impl Drop for WalkSession {
 fn collect_bias_terms(memory: &Memory, _template: Option<&str>) -> Vec<String> {
     let max = stt::SttConfig::default().max_bias_terms;
     memory
-        .section_texts("vocabulary")
+        .section_texts(harness::VOCABULARY_SECTION)
         .into_iter()
         .map(str::to_string)
         .take(max)

--- a/crates/ffi/src/vocabulary.rs
+++ b/crates/ffi/src/vocabulary.rs
@@ -1,0 +1,140 @@
+//! Vocabulary CRUD across UniFFI (Plan 10). The write half of the vocabulary →
+//! STT biasing loop: these mutate the `Memory` "vocabulary" section that
+//! `begin_walk`'s `collect_bias_terms` reads. Lock-then-save discipline mirrors
+//! `harness::UpdateMemoryTool` (mutate under the lock, clamp the global cap,
+//! snapshot, release, persist). Panic-free across FFI (Plan 07 CANON).
+
+use harness::{FactSource, VocabAdd, DEFAULT_WORD_CAP};
+
+use crate::engine::{EngineError, MurmurEngine};
+
+impl MurmurEngine {
+    fn memory_err(msg: impl Into<String>) -> EngineError {
+        EngineError::Memory(msg.into())
+    }
+}
+
+#[uniffi::export]
+impl MurmurEngine {
+    /// The user's vocabulary terms, insertion order. Read-only — no lock held
+    /// across FFI beyond the clone.
+    pub fn list_vocabulary(&self) -> Result<Vec<String>, EngineError> {
+        let mem = self.memory.lock().map_err(|_| Self::memory_err("memory lock poisoned"))?;
+        Ok(mem.vocabulary_terms().into_iter().map(str::to_string).collect())
+    }
+
+    /// Add one user vocabulary term (`FactSource::Stated`, D3). Idempotent
+    /// (case-insensitive). Errors: `Full` at 100 terms, `Empty` for blank input,
+    /// a poisoned lock, or a persistence failure. Returns the resulting list so
+    /// the editor updates in one round-trip.
+    pub fn add_vocabulary_term(&self, term: String) -> Result<Vec<String>, EngineError> {
+        let snapshot = {
+            let mut mem = self.memory.lock().map_err(|_| Self::memory_err("memory lock poisoned"))?;
+            let now = now_secs();
+            match mem.add_vocabulary_term(&term, now, FactSource::Stated) {
+                VocabAdd::Added | VocabAdd::Duplicate => {}
+                VocabAdd::Full => {
+                    return Err(Self::memory_err(format!(
+                        "vocabulary is full ({} terms); remove one first",
+                        harness::MAX_VOCABULARY_TERMS
+                    )))
+                }
+                VocabAdd::Empty => return Err(Self::memory_err("term is empty")),
+                VocabAdd::TooLong => {
+                    return Err(Self::memory_err(format!(
+                        "term is too long (max {} words)",
+                        harness::MAX_VOCABULARY_TERM_WORDS
+                    )))
+                }
+            }
+            mem.clamp_to_cap(DEFAULT_WORD_CAP); // global 500-word invariant, like UpdateMemoryTool
+            mem.clone()
+        };
+        self.memory_store.save(&snapshot).map_err(|e| EngineError::Store(e.to_string()))?;
+        Ok(snapshot.vocabulary_terms().into_iter().map(str::to_string).collect())
+    }
+
+    /// Remove one vocabulary term (case-insensitive). Returns the resulting list.
+    /// Removing a term that isn't present is not an error (idempotent).
+    pub fn remove_vocabulary_term(&self, term: String) -> Result<Vec<String>, EngineError> {
+        let snapshot = {
+            let mut mem = self.memory.lock().map_err(|_| Self::memory_err("memory lock poisoned"))?;
+            mem.remove_vocabulary_term(&term);
+            mem.clone()
+        };
+        self.memory_store.save(&snapshot).map_err(|e| EngineError::Store(e.to_string()))?;
+        Ok(snapshot.vocabulary_terms().into_iter().map(str::to_string).collect())
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::{MurmurEngine, Providers};
+    use harness::{HarnessError, Memory, MemoryStore, MockProvider};
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    struct SpyStore {
+        saved: StdMutex<Vec<Memory>>,
+    }
+    impl MemoryStore for SpyStore {
+        fn load(&self) -> Result<Memory, HarnessError> {
+            Ok(Memory::default())
+        }
+        fn save(&self, m: &Memory) -> Result<(), HarnessError> {
+            self.saved.lock().unwrap().push(m.clone());
+            Ok(())
+        }
+    }
+    fn engine(store: Arc<SpyStore>) -> Arc<MurmurEngine> {
+        let s = murmur_core::Store::open_in_memory("device-a").unwrap();
+        MurmurEngine::with_providers(
+            s,
+            Memory::default(),
+            store,
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(vec![])),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn add_list_remove_round_trip_and_persist() {
+        let store = Arc::new(SpyStore { saved: StdMutex::new(Vec::new()) });
+        let e = engine(store.clone());
+        assert_eq!(e.add_vocabulary_term("french drain".into()).unwrap(), vec!["french drain"]);
+        assert_eq!(e.list_vocabulary().unwrap(), vec!["french drain"]);
+        // persisted: the last save carries the term
+        assert!(store.saved.lock().unwrap().last().unwrap().vocabulary_terms().contains(&"french drain"));
+        assert!(e.remove_vocabulary_term("French Drain".into()).unwrap().is_empty(), "case-insensitive remove");
+    }
+
+    #[tokio::test]
+    async fn add_is_idempotent_and_full_is_an_error() {
+        let store = Arc::new(SpyStore { saved: StdMutex::new(Vec::new()) });
+        let e = engine(store);
+        e.add_vocabulary_term("term".into()).unwrap();
+        assert_eq!(e.add_vocabulary_term("TERM".into()).unwrap(), vec!["term"], "duplicate is Ok, not an error");
+        // fill to the cap, then the next add throws
+        for i in 0..harness::MAX_VOCABULARY_TERMS {
+            let _ = e.add_vocabulary_term(format!("t{i}"));
+        }
+        assert!(matches!(e.add_vocabulary_term("overflow".into()), Err(EngineError::Memory(_))));
+        assert!(matches!(e.add_vocabulary_term("   ".into()), Err(EngineError::Memory(_))), "empty is an error");
+    }
+
+    #[test]
+    fn read_side_cap_matches_the_write_side_constant() {
+        // D2: the mirrored consts must agree across the crate boundary.
+        assert_eq!(harness::MAX_VOCABULARY_TERMS, stt::SttConfig::default().max_bias_terms);
+    }
+}

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -17,7 +17,10 @@ pub use llm::{
 };
 pub use mock::MockProvider;
 pub use providers::AnthropicProvider;
-pub use memory::{FactSource, Memory, MemoryEntry, DEFAULT_WORD_CAP};
+pub use memory::{
+    FactSource, Memory, MemoryEntry, VocabAdd, DEFAULT_WORD_CAP, MAX_VOCABULARY_TERMS,
+    MAX_VOCABULARY_TERM_WORDS, VOCABULARY_SECTION,
+};
 pub use memory::store::{FileMemoryStore, MemoryStore};
 pub use memory::tool::{Clock, UpdateMemoryTool};
 pub use reflection::engine::{ReflectionEngine, ReflectionOutcome};

--- a/crates/harness/src/memory/mod.rs
+++ b/crates/harness/src/memory/mod.rs
@@ -8,6 +8,33 @@ use serde::{Deserialize, Serialize};
 /// Default word cap for a whole memory (spec §7: reflection compresses, never accumulates).
 pub const DEFAULT_WORD_CAP: usize = 500;
 
+/// The one memory section read by the STT biasing layer (`collect_bias_terms`
+/// → `build_bias_prompt` → whisper `initial_prompt`). Canonical name — every
+/// crate references this constant rather than the bare string "vocabulary".
+pub const VOCABULARY_SECTION: &str = "vocabulary";
+
+/// Write-time cap on vocabulary terms. MUST equal `stt::SttConfig::max_bias_terms`
+/// (the read-side cap); `harness` cannot depend on `stt`, so this mirrors it —
+/// a Task 6 FFI test asserts they are numerically equal. iOS `contextualStrings`
+/// / whisper `initial_prompt` budget (spec Rev 2 amendment F: ≤100 curated terms).
+pub const MAX_VOCABULARY_TERMS: usize = 100;
+
+/// Max words in a single vocabulary term. Vocabulary is jargon/hotwords, not
+/// sentences; this bounds the word budget (Plan 10 D3) and keeps the whisper
+/// `initial_prompt` a clean glossary. A longer input is a paste error.
+pub const MAX_VOCABULARY_TERM_WORDS: usize = 6;
+
+/// Outcome of [`Memory::add_vocabulary_term`]. Total (no `Result` needed):
+/// `Added`/`Duplicate` are success (idempotent); `Full`/`Empty`/`TooLong` are refusals.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VocabAdd {
+    Added,
+    Duplicate,
+    Full,
+    Empty,
+    TooLong,
+}
+
 /// Where a fact came from — drives eviction priority and debuggability.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -47,6 +74,14 @@ pub struct MemoryEntry {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Memory {
     pub sections: BTreeMap<String, Vec<MemoryEntry>>,
+}
+
+/// Normalize a vocabulary term for storage AND comparison: trim ends, collapse
+/// internal whitespace runs to a single space. Case is preserved. Used on BOTH
+/// the query and the stored text before comparing (D4, finding 1), because the
+/// pre-existing writers (`UpdateMemoryTool`, reflection) store verbatim.
+fn normalize_term(term: &str) -> String {
+    term.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 impl Memory {
@@ -190,6 +225,60 @@ impl Memory {
         }
         removed
     }
+
+    /// The user's vocabulary terms in insertion order, stored text AS-IS
+    /// (alias for `section_texts(VOCABULARY_SECTION)`). No normalization on read.
+    pub fn vocabulary_terms(&self) -> Vec<&str> {
+        self.section_texts(VOCABULARY_SECTION)
+    }
+
+    /// Stored casing of the term that matches `normalized` case-insensitively,
+    /// normalizing the STORED side too (finding 1). `None` if absent.
+    fn matching_vocabulary_term(&self, normalized: &str) -> Option<String> {
+        self.section_texts(VOCABULARY_SECTION)
+            .into_iter()
+            .find(|t| normalize_term(t).eq_ignore_ascii_case(normalized))
+            .map(str::to_string)
+    }
+
+    /// Add one vocabulary term. Normalizes (trim + collapse whitespace), rejects
+    /// empty (`Empty`) and >`MAX_VOCABULARY_TERM_WORDS` (`TooLong`), dedups
+    /// case-insensitively across BOTH sides (keeps first-seen stored casing),
+    /// and enforces `MAX_VOCABULARY_TERMS` at write time (`Full` — reject, never
+    /// silent-evict). `source` is `Stated` for user/onboarding terms; a future
+    /// auto-harvester (D9) passes `Inferred`. Does NOT enforce the 500-word cap —
+    /// callers clamp globally (the FFI layer / `UpdateMemoryTool` do).
+    pub fn add_vocabulary_term(&mut self, term: &str, now: u64, source: FactSource) -> VocabAdd {
+        let normalized = normalize_term(term);
+        if normalized.is_empty() {
+            return VocabAdd::Empty;
+        }
+        if normalized.split_whitespace().count() > MAX_VOCABULARY_TERM_WORDS {
+            return VocabAdd::TooLong;
+        }
+        if let Some(stored) = self.matching_vocabulary_term(&normalized) {
+            // Duplicate (even at cap): touch/upgrade provenance on the STORED
+            // casing via remember_from; never add a second variant.
+            self.remember_from(VOCABULARY_SECTION, &stored, now, source, None);
+            return VocabAdd::Duplicate;
+        }
+        if self.vocabulary_terms().len() >= MAX_VOCABULARY_TERMS {
+            return VocabAdd::Full;
+        }
+        self.remember_from(VOCABULARY_SECTION, &normalized, now, source, None);
+        VocabAdd::Added
+    }
+
+    /// Remove one vocabulary term (case-insensitive; normalizes BOTH sides so a
+    /// verbatim-stored term written by another path is still removable — finding
+    /// 1). Returns whether anything was removed.
+    pub fn remove_vocabulary_term(&mut self, term: &str) -> bool {
+        let normalized = normalize_term(term);
+        let Some(stored) = self.matching_vocabulary_term(&normalized) else {
+            return false;
+        };
+        self.forget(VOCABULARY_SECTION, &stored)
+    }
 }
 
 #[cfg(test)]
@@ -319,5 +408,85 @@ mod tests {
         assert_eq!(removed, 1, "oldest corrected entry is evicted");
         assert!(m.word_count() <= 4);
         assert_eq!(m.section_texts("people"), vec!["prefers text over calls"]);
+    }
+
+    #[test]
+    fn add_vocabulary_term_normalizes_and_defaults_stated() {
+        let mut m = Memory::default();
+        assert_eq!(m.add_vocabulary_term("  french   drain ", 10, FactSource::Stated), VocabAdd::Added);
+        // normalized: trimmed + internal whitespace collapsed
+        assert_eq!(m.vocabulary_terms(), vec!["french drain"]);
+        let e = &m.sections[VOCABULARY_SECTION][0];
+        assert_eq!(e.source, FactSource::Stated, "user vocabulary is Stated (survives casual eviction)");
+        assert_eq!(e.last_touched, 10);
+    }
+
+    #[test]
+    fn add_vocabulary_term_is_case_insensitively_idempotent() {
+        let mut m = Memory::default();
+        assert_eq!(m.add_vocabulary_term("French Drain", 1, FactSource::Stated), VocabAdd::Added);
+        assert_eq!(m.add_vocabulary_term("french drain", 2, FactSource::Stated), VocabAdd::Duplicate);
+        assert_eq!(m.vocabulary_terms(), vec!["French Drain"], "first-seen casing kept, one slot used");
+    }
+
+    #[test]
+    fn add_vocabulary_term_rejects_empty_and_overlong() {
+        let mut m = Memory::default();
+        assert_eq!(m.add_vocabulary_term("   ", 1, FactSource::Stated), VocabAdd::Empty);
+        // > MAX_VOCABULARY_TERM_WORDS (6): a sentence, not a term.
+        assert_eq!(
+            m.add_vocabulary_term("one two three four five six seven", 1, FactSource::Stated),
+            VocabAdd::TooLong,
+        );
+        assert!(m.vocabulary_terms().is_empty());
+        // exactly 6 words is allowed
+        assert_eq!(m.add_vocabulary_term("a b c d e f", 1, FactSource::Stated), VocabAdd::Added);
+    }
+
+    #[test]
+    fn matching_normalizes_the_stored_side_too() {
+        // finding 1: a pre-existing term written by another path (update_memory /
+        // reflection) with un-collapsed whitespace must still dedupe AND be removable.
+        let mut m = Memory::default();
+        m.remember_from(VOCABULARY_SECTION, "french   drain", 1, FactSource::Stated, None); // double space, verbatim
+        assert_eq!(m.vocabulary_terms(), vec!["french   drain"], "stored text is listed as-is");
+        // dedupe: adding the normalized form does not create a near-duplicate
+        assert_eq!(m.add_vocabulary_term("french drain", 2, FactSource::Stated), VocabAdd::Duplicate);
+        assert_eq!(m.vocabulary_terms().len(), 1);
+        // removable despite the whitespace/casing mismatch
+        assert!(m.remove_vocabulary_term("French Drain"), "normalize both sides before compare");
+        assert!(m.vocabulary_terms().is_empty());
+    }
+
+    #[test]
+    fn add_vocabulary_term_enforces_the_hundred_term_cap() {
+        let mut m = Memory::default();
+        for i in 0..MAX_VOCABULARY_TERMS {
+            assert_eq!(m.add_vocabulary_term(&format!("term{i}"), 1, FactSource::Stated), VocabAdd::Added);
+        }
+        assert_eq!(m.vocabulary_terms().len(), MAX_VOCABULARY_TERMS);
+        assert_eq!(m.add_vocabulary_term("one too many", 1, FactSource::Stated), VocabAdd::Full);
+        assert_eq!(m.vocabulary_terms().len(), MAX_VOCABULARY_TERMS, "cap holds; nothing silently evicted");
+        // a duplicate is NOT rejected as full — idempotent even at cap
+        assert_eq!(m.add_vocabulary_term("term0", 2, FactSource::Stated), VocabAdd::Duplicate);
+    }
+
+    #[test]
+    fn remove_vocabulary_term_is_case_insensitive_and_reports() {
+        let mut m = Memory::default();
+        m.add_vocabulary_term("French Drain", 1, FactSource::Stated);
+        assert!(m.remove_vocabulary_term("french drain"), "case-insensitive match");
+        assert!(m.vocabulary_terms().is_empty());
+        assert!(!m.remove_vocabulary_term("french drain"), "already gone");
+    }
+
+    #[test]
+    fn inferred_vocabulary_is_evicted_before_stated_vocabulary() {
+        // D3: an auto-harvested (Inferred) term goes before a user (Stated) term under cap pressure.
+        let mut m = Memory::default();
+        m.add_vocabulary_term("user term one", 100, FactSource::Stated);   // 3 words
+        m.add_vocabulary_term("harvested term", 200, FactSource::Inferred); // 2 words, newer
+        m.clamp_to_cap(3); // must drop the Inferred one despite it being newer
+        assert_eq!(m.vocabulary_terms(), vec!["user term one"]);
     }
 }

--- a/crates/harness/src/reflection/engine.rs
+++ b/crates/harness/src/reflection/engine.rs
@@ -65,7 +65,10 @@ impl ReflectionEngine {
              and write the corrected one; never merge the two into a blended claim. Facts \
              marked [corrected] are user corrections and outrank everything else — do not \
              drop or alter them. Typical sections: vocabulary, people, projects, \
-             preferences. Call {} exactly once with the full result.",
+             preferences. Vocabulary terms are domain jargon that improve transcription \
+             accuracy — preserve them verbatim and drop a vocabulary term only if it is \
+             clearly a transcription artifact, not a real term. Call {} exactly once with \
+             the full result.",
             self.word_cap, WRITE_MEMORY
         )
     }
@@ -370,6 +373,13 @@ mod tests {
         );
         // write_memory_response uses Usage { input_tokens: 100, output_tokens: 50 }
         assert_eq!(err.usage, Usage { input_tokens: 100, output_tokens: 50 });
+    }
+
+    #[test]
+    fn system_prompt_protects_vocabulary() {
+        let engine = ReflectionEngine::new(std::sync::Arc::new(MockProvider::new(vec![])));
+        let p = engine.system_prompt();
+        assert!(p.to_lowercase().contains("vocabulary"), "reflection must be told to preserve vocabulary");
     }
 
     #[tokio::test]

--- a/crates/harness/src/reflection/engine.rs
+++ b/crates/harness/src/reflection/engine.rs
@@ -377,9 +377,16 @@ mod tests {
 
     #[test]
     fn system_prompt_protects_vocabulary() {
+        // Pins the D5 preservation GUIDANCE, not the mere word "vocabulary"
+        // (which already appears in "Typical sections: ..." — review F1): the
+        // distinctive phrase below exists only in the preserve-vocabulary
+        // sentence, so this fails if that sentence is dropped.
         let engine = ReflectionEngine::new(std::sync::Arc::new(MockProvider::new(vec![])));
-        let p = engine.system_prompt();
-        assert!(p.to_lowercase().contains("vocabulary"), "reflection must be told to preserve vocabulary");
+        let p = engine.system_prompt().to_lowercase();
+        assert!(
+            p.contains("drop a vocabulary term only if"),
+            "reflection must carry the preserve-vocabulary guidance"
+        );
     }
 
     #[tokio::test]

--- a/crates/stt/src/lib.rs
+++ b/crates/stt/src/lib.rs
@@ -11,6 +11,7 @@ mod vad;
 #[cfg(feature = "whisper")]
 mod whisper;
 
+pub use bias::build_bias_prompt;
 pub use decoder::{Decoder, RawSegment, ScriptedDecoder, WordTiming};
 #[cfg(feature = "whisper")]
 pub use whisper::WhisperDecoder;

--- a/meta/ROADMAP.md
+++ b/meta/ROADMAP.md
@@ -22,6 +22,12 @@ Updated when priorities shift. Either person can propose changes via PR.
 4. **Prompt-optimization loop** on the 05b eval suite (rank on F0.5, gate on recall).
 5. **Photo attachment schema** (rides a migration after `source`).
 
+### Vocabulary → STT biasing loop (Plan 10)
+
+**Write half LANDED** — the differentiator's data path is now closable end-to-end. A vocabulary management surface on `harness::Memory` (`VOCABULARY_SECTION`/`MAX_VOCABULARY_TERMS`(100)/`MAX_VOCABULARY_TERM_WORDS`(6) constants, `VocabAdd`, symmetric-normalized case-insensitive dedup, write-time reject-when-full cap, a `Stated` provenance floor so user terms outlive `Inferred` ones under cap pressure); FFI CRUD on `MurmurEngine` (`list`/`add`/`remove_vocabulary_term`, throwing/panic-free, lock-then-save, `EngineError::Memory`); a functional-plain iOS editor wired through `WalkEngine` (**visuals are sac's** — `// sac:` handoff markers throughout); and a hermetic e2e proving add-via-FFI → `collect_bias_terms` → `build_bias_prompt`. Reflection carries one preserve-vocabulary prompt sentence (no new machinery). Real recall-lift on device is spike-harness-measured, **flagged for dam** (not CI). Plan: `docs/plans/2026-07-05-rust-core-10-vocabulary-loop.md`.
+
+**Still open:** the **onboarding interview** that SEEDS vocabulary (D9, joint dam+sac) — the `add_vocabulary_term` path is ready to receive its output; **auto-harvest** of proper nouns from live extraction (D9 seam — the `source` param takes `Inferred`, detection not built); a **protected-vocabulary tier** (D3, dam) — v1 ships the `Stated` floor + reflection prompt line and measures on device before escalating (`Corrected` overload vs. a new `Pinned` rank vs. vocabulary-aware `prune_stale`).
+
 ## Done 2026-07-05 (the big day)
 
 Re-unification complete (repo = **damsac/sitewalk**, one history, Swift Era I preserved; archive = sitewalk-archive) · issue/PR slate cleaned (19+2 Swift-era closed; #155/#156 remain) · CLAUDE.md + CI rewritten for the rebuild (#157) · **first real walk** (EST-0047, real core + key on sim) · **Plan 08 Parts A+B merged**: mic→whisper→append wiring, cancel() (closes #156's core half), transcript events, use_gpu knob (sim=CPU — D7's "Metal degrades on sim" was falsified: it SIGTRAPs), voice-walk-from-WAV proven end-to-end on sim (whisper decoded the fixture; transcript verified in SQLite). 290 tests.


### PR DESCRIPTION
## Thinking

The read half of the vocabulary→STT loop has been live since Plan 08 (memory section → whisper initial_prompt, +10–19pp in the spike); this makes it real by building the write half: normalized term management on Memory (single matching funnel so add/remove can't drift — the shape the plan review hand-verified after catching an unremovable-term bug in the draft), caps enforced at write (100 terms, 6 words/term) instead of silently truncating at read, three throwing FFI methods, a functional-plain Swift editor with `// sac:` markers on every visual decision, and a hermetic e2e proving an added term reaches the bias prompt.

Independent final: MERGE WITH NOTES, zero correctness findings — lock discipline, raw/normalized funnel, and error surfaces all held under tracing. Both notes resolved: the reflection-guard test now pins the actual preservation phrase (proven discriminating — fails with the sentence removed), and the build_bias_prompt re-export was verified to leak nothing beyond the documented seam.

322 workspace tests (+12, name-diffed, zero removed). Onboarding-interview seeding remains a joint dam+sac design; the add-path is ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)