### PR TITLE
sac: issue #155 follow-ups — discard/share/flush correctness + portable build-ffi

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -74,6 +74,10 @@ final class AppModel {
     /// (the WAV fixture already has clean PCM). Default off — the Task 12 SNR
     /// eval decides the production default.
     private let voiceProcessing: Bool
+    /// Injection seam for the scripted text source (issue #155): tests and
+    /// previews can substitute a source without touching the walk lifecycle.
+    @ObservationIgnored
+    var makeScriptedSource: (TradeFixture) -> TranscriptSource = { ScriptedSource(trade: $0) }
 
     init(engine: WalkEngine? = nil, scripted: Bool = true, wavFixture: Bool = false,
          voiceProcessing: Bool = false) {
@@ -149,7 +153,7 @@ final class AppModel {
 
     /// Text/demo path: canned transcript → engine.append (unchanged).
     private func startScriptedSource() {
-        let src = ScriptedSource(trade: trade)
+        let src = makeScriptedSource(trade)
         source = src
         audioSource = nil
         pumpTask = Task { [weak self] in
@@ -196,7 +200,7 @@ final class AppModel {
     }
 
     func discardWalk() {
-        source?.stop()
+        source?.abort()
         audioSource?.stop()
         pumpTask?.cancel()
         eventTask?.cancel()
@@ -223,6 +227,12 @@ final class AppModel {
         phase = .building
         path = [.building]
         Task {
+            // Flush before finish (issue #155 / CANON: flush over speed —
+            // the last words of a walk are often the price). `stop()` lets a
+            // final speech result land (grace-bounded in SpeechSource); the
+            // pump ends when the source's stream finishes, so awaiting it
+            // guarantees every flushed chunk reached engine.append first.
+            _ = await pumpTask?.value
             let doc = await engine.finish()
             self.document = doc
             self.phase = .review
@@ -319,6 +329,17 @@ final class AppModel {
                 tag: TagFixture(kind: .green, label: "SENT"), done: true
             )
         }
+        shareURL = nil
+        document = nil
+        phase = .board
+        path = []
+    }
+
+    /// Abandon a reviewed document WITHOUT marking the job sent (issue #155:
+    /// DISCARD previously routed through `completeSend()` and flipped the job
+    /// to SENT). The persisted core artifact is untouched — only the app-side
+    /// review state resets.
+    func discardDocument() {
         shareURL = nil
         document = nil
         phase = .board

--- a/apps/ios/Sources/Engine/TranscriptSource.swift
+++ b/apps/ios/Sources/Engine/TranscriptSource.swift
@@ -24,7 +24,13 @@ protocol TranscriptSource: AnyObject {
     func start()
     func pause()
     func resume()
+    /// Graceful end: FLUSH any in-flight transcription, then finish the
+    /// stream. Used on DONE — the last words of a walk are often the price
+    /// (CANON: flush over speed). May finish the stream up to ~1.5s late.
     func stop()
+    /// Hard end: drop everything in flight and finish the stream NOW.
+    /// Used on discard — nothing is kept, latency wins.
+    func abort()
 }
 
 // MARK: - Scripted (demo) source
@@ -55,7 +61,15 @@ final class ScriptedSource: TranscriptSource {
                     self.continuation.yield(self.script[self.index] + " ")
                     self.index += 1
                 }
-                try? await Task.sleep(for: .milliseconds(260))
+                // Break on cancellation — `try?` alone swallows the thrown
+                // CancellationError and, with sleep returning instantly once
+                // cancelled, the paused loop becomes a main-actor busy-spin
+                // (issue #155).
+                do {
+                    try await Task.sleep(for: .milliseconds(260))
+                } catch {
+                    break
+                }
             }
             self?.continuation.finish()
         }
@@ -63,10 +77,12 @@ final class ScriptedSource: TranscriptSource {
 
     func pause() { paused = true }
     func resume() { paused = false }
+    // Scripted text has nothing in flight to flush: both ends are immediate.
     func stop() {
         task?.cancel()
         continuation.finish()
     }
+    func abort() { stop() }
 }
 
 // MARK: - Live microphone source
@@ -129,6 +145,11 @@ final class SpeechSource: TranscriptSource {
                     self.delivered = text
                     self.continuation.yield(" " + text)
                 }
+                // Final result after a flush → close immediately rather than
+                // waiting out stop()'s grace ceiling.
+                if result.isFinal {
+                    self.continuation.finish()
+                }
             }
         }
     }
@@ -136,7 +157,23 @@ final class SpeechSource: TranscriptSource {
     func pause() { audioEngine.pause() }
     func resume() { try? audioEngine.start() }
 
+    /// Flush: stop the mic but let recognition FINISH the audio it already
+    /// has — `cancel()` here dropped the final utterance (issue #155; CANON:
+    /// flush over speed). The stream closes when the final result lands, with
+    /// a 1.5s grace ceiling so a stalled recognizer can't hang finishWalk().
     func stop() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+        request?.endAudio()
+        recognition?.finish()
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(1.5))
+            self?.continuation.finish()
+        }
+    }
+
+    /// Drop everything in flight — discard path, nothing is kept.
+    func abort() {
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
         request?.endAudio()

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-// Design fixtures mirroring design/mockup.html — three trades, same bones.
-// These exist so every component and screen can be built and reviewed
-// before the Rust core is wired in. No logic lives here.
+// Header honesty (issue #155): this file is TWO things that should split when
+// convenient. (1) The five struct types below (TagFixture, JobFixture,
+// CapturedFixture, DocRowFixture, TradeFixture) are the app's INTERIM DOMAIN
+// MODEL — the WalkEngine seam speaks them, and the real bridge maps core rows
+// into them. (2) The `Fixtures` enum is canned demo/design data mirroring
+// docs/design/mockup.html. Types are load-bearing; the canned data is not.
 
 enum TagKind { case red, yellow, green, plain }
 

--- a/apps/ios/Sources/Flow/DocumentPDF.swift
+++ b/apps/ios/Sources/Flow/DocumentPDF.swift
@@ -70,11 +70,13 @@ private struct PDFPageView: View {
 
 struct ShareSheet: UIViewControllerRepresentable {
     let url: URL
-    var onComplete: () -> Void
+    /// `true` only when the user completed an activity; a cancelled sheet
+    /// reports `false` and must not finalize the walk (issue #155).
+    var onComplete: (Bool) -> Void
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
         let vc = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        vc.completionWithItemsHandler = { _, _, _, _ in onComplete() }
+        vc.completionWithItemsHandler = { _, completed, _, _ in onComplete(completed) }
         return vc
     }
 

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -42,7 +42,7 @@ struct ReviewView: View {
             .background(Theme.C.paperDeep)
 
             HStack(spacing: 10) {
-                Button { model.completeSend() } label: {
+                Button { model.discardDocument() } label: {
                     Text("DISCARD")
                         .font(Theme.F.ui(14, .bold))
                         .tracking(1.1)
@@ -92,7 +92,15 @@ struct ReviewView: View {
             set: { if !$0 { model.shareURL = nil } }
         )) {
             if let url = model.shareURL {
-                ShareSheet(url: url) { model.completeSend() }
+                // Only a completed share finalizes the walk; cancelling the
+                // sheet returns to review with the document intact (issue #155).
+                ShareSheet(url: url) { completed in
+                    if completed {
+                        model.completeSend()
+                    } else {
+                        model.shareURL = nil
+                    }
+                }
             }
         }
     }

--- a/apps/ios/Sources/Screens/CaptureScreen.swift
+++ b/apps/ios/Sources/Screens/CaptureScreen.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+// TODO(design-freeze): static design-gallery twin of the Flow/ screen — already
+// drifting from the interactive version; DELETE when the design freezes (#155).
 
 // Screen 02 — Capture. State readable at arm's length: orange banner,
 // live transcript, items ticking onto the board. Offline never loses audio.

--- a/apps/ios/Sources/Screens/DocumentReviewScreen.swift
+++ b/apps/ios/Sources/Screens/DocumentReviewScreen.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+// TODO(design-freeze): static design-gallery twin of the Flow/ screen — already
+// drifting from the interactive version; DELETE when the design freezes (#155).
 
 // Screen 04 — Document review. It looks like paper because paper is the
 // pitch. Unheard values stay gaps, never guesses. Send is one thumb away.

--- a/apps/ios/Sources/Screens/JobsBoardScreen.swift
+++ b/apps/ios/Sources/Screens/JobsBoardScreen.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+// TODO(design-freeze): static design-gallery twin of the Flow/ screen — already
+// drifting from the interactive version; DELETE when the design freezes (#155).
 
 // Screen 01 — Jobs board. One line per site, airport-board discipline.
 // 62pt primary action in the thumb zone.

--- a/apps/ios/build-ffi.sh
+++ b/apps/ios/build-ffi.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$BINDINGS_DIR"' EXIT
 echo "==> building crates/ffi for aarch64-apple-ios-sim"
 nix develop -c bash -c '
   set -euo pipefail
-  export DEVELOPER_DIR=/Applications/Xcode-26.2.0.app/Contents/Developer
+  export DEVELOPER_DIR="${XCODE_DEVELOPER_DIR:-$(env -u DEVELOPER_DIR /usr/bin/xcode-select -p)}"
   export SDKROOT=$(/usr/bin/xcrun --sdk iphonesimulator --show-sdk-path)
   # Match the app deployment target (project.yml: iOS 17.0). Without this, rustc
   # links the cdylib probe at its default min (arm64-apple-ios10.0), and the
@@ -55,7 +55,7 @@ nix develop -c bash -c '
 echo "==> building crates/ffi for aarch64-apple-ios (device)"
 nix develop -c bash -c '
   set -euo pipefail
-  export DEVELOPER_DIR=/Applications/Xcode-26.2.0.app/Contents/Developer
+  export DEVELOPER_DIR="${XCODE_DEVELOPER_DIR:-$(env -u DEVELOPER_DIR /usr/bin/xcode-select -p)}"
   export SDKROOT=$(/usr/bin/xcrun --sdk iphoneos --show-sdk-path)
   # Match the app deployment target (project.yml: iOS 17.0) — see the sim
   # invocation above; without it the device cdylib link fails on a missing


### PR DESCRIPTION
## Thinking

Working dam's review conditions from #155, one product principle decided every call: **the walk's words are the product; latency is negotiable.** So DONE now *flushes* speech recognition instead of cancelling it (`recognition.finish()` + a 1.5s grace ceiling, closed early on `isFinal`; `finishWalk` awaits the pump so every flushed chunk reaches `engine.append` before `finish()`). That's my proposed CANON row for the STT DONE-semantics question: **flush over speed** — the operator's last words are usually the price. The discard path got the opposite treatment (`abort()` — drop everything now), which forced the honest `stop()`/`abort()` split on `TranscriptSource`.

The other two correctness bugs were both "false finalization": DISCARD routed through `completeSend()` (job marked SENT on abandon) and the share sheet's completion handler ignored the `completed` flag (cancelling the sheet finalized the walk). Both now finalize only on a real send.

Also: `build-ffi.sh` hardcoded `/Applications/Xcode-26.2.0.app` — on any other machine `xcrun` dies, and the fix has a wrinkle: the nix devShell exports a nix-store `DEVELOPER_DIR`, so a naive `${DEVELOPER_DIR:-…}` inherits it and every host build script fails on `-lSystem`. It now force-derives via `env -u DEVELOPER_DIR xcode-select -p`, overridable with `XCODE_DEVELOPER_DIR` if you want your pin back.

## CANON acks from sac (requested in STATE)

- **Template keys** `landscape | property | inspection` — ACK, canonical.
- **STT DONE semantics** — flush over speed, as implemented here.

## Checklist vs #155

- [x] DISCARD ≠ completeSend (new `discardDocument()`)
- [x] Share-sheet cancel honored (`completed` flag through `ShareSheet`)
- [x] Scripted-source cancellation busy-spin (break on `CancellationError`)
- [x] recognition cancel → flush (decision implemented, needs your CANON co-sign)
- [x] TranscriptSource injection seam (`makeScriptedSource`)
- [x] Fixtures header honesty (types = interim domain model)
- [x] TODO(design-freeze) markers on `Screens/` twins

Demo build compiles; real-core build + on-sim walk verified on my machine today.