### PR TITLE
brand: product name is Sitewalk, not Murmur

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# Murmur
+# Sitewalk
 
 Field-work voice agent. Speak through a site walk; an on-device agent turns it
 into a structured document (landscape / property / inspection report). Audio never
 leaves the device — local-first, sync-ready.
 
-A Rust core workspace with a native SwiftUI iOS shell. (Murmur began as a
-Swift/SwiftUI second-brain app, pivoted to field work on 2026-07-01, and was
+A Rust core workspace with a native SwiftUI iOS shell. (Sitewalk began as Murmur,
+a Swift/SwiftUI second-brain app, pivoted to field work on 2026-07-01, and was
 rebuilt on Rust — the full arc lives in this one repo; see `docs/HISTORY.md`.)
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Murmur
+# Sitewalk
 
-**Speak through a site walk, get a structured document.** Murmur is a field-work
+**Speak through a site walk, get a structured document.** Sitewalk is a field-work
 voice agent for general contractors, inspectors, and trades: talk your way through
 a walk-through and an on-device agent turns it into an organized report — a
 landscape, property, or inspection document — without you touching the phone.
 
 Audio never leaves the device. Local-first, sync-ready.
 
-> Murmur began life as a general-purpose voice-to-second-brain iOS app. On
-> 2026-07-01 it pivoted to field work and was rebuilt on a Rust core. The whole
+> Sitewalk began life as Murmur, a general-purpose voice-to-second-brain iOS app.
+> On 2026-07-01 it pivoted to field work and was rebuilt on a Rust core. The whole
 > arc lives in this one repository — see **[docs/HISTORY.md](docs/HISTORY.md)**.
 
 ## Workspace layout
 
-Murmur is a Rust workspace with native shells:
+Sitewalk is a Rust workspace with native shells:
 
 ```
 crates/
@@ -81,6 +81,6 @@ thinking first, code second.
 ## History
 
 This repo tells the whole story: the Swift/SwiftUI Murmur (Era I), the 2026-07-01
-field-work pivot, the Rust rebuild (Era II, formerly `damsac/sitewalk`), and the
-2026-07-04 re-unification. Start at **[docs/HISTORY.md](docs/HISTORY.md)** for how to
-browse each era in git history.
+field-work pivot, the Rust rebuild (Era II, formerly `damsac/sitewalk`, now
+branded **Sitewalk**), and the 2026-07-04 re-unification. Start at
+**[docs/HISTORY.md](docs/HISTORY.md)** for how to browse each era in git history.

--- a/docs/specs/2026-07-01-murmur-rebuild-vision-design.md
+++ b/docs/specs/2026-07-01-murmur-rebuild-vision-design.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-07-01 (Rev 2, same day — post sac mock review)
 **Status:** Approved by dam (this session). Pending sac review.
+**Brand note (2026-07-06):** the product is now branded **Sitewalk**; this document is a historical snapshot from the 2026-07-01 rebuild decision and retains "Murmur" throughout — see `meta/CANON.md` for the rename.
 **Supersedes:** the current Swift/SwiftUI codebase. This is a ground-up rebuild in a fresh repo under the Murmur brand (working title in sac's design study: SITEWALK).
 
 ## Rev 2 amendments (sac's design study, `SITEWALK — DS-01`)

--- a/docs/superpowers/specs/2026-07-01-murmur-rebuild-vision-design.md
+++ b/docs/superpowers/specs/2026-07-01-murmur-rebuild-vision-design.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-07-01 (Rev 2, same day — post sac mock review)
 **Status:** Approved by dam (this session). Pending sac review.
+**Brand note (2026-07-06):** the product is now branded **Sitewalk**; this document is a historical snapshot from the 2026-07-01 rebuild decision and retains "Murmur" throughout — see `meta/CANON.md` for the rename.
 **Supersedes:** the current Swift/SwiftUI codebase. This is a ground-up rebuild in a fresh repo under the Murmur brand (working title in sac's design study: SITEWALK).
 
 ## Rev 2 amendments (sac's design study, `SITEWALK — DS-01`)

--- a/meta/CANON.md
+++ b/meta/CANON.md
@@ -10,7 +10,7 @@ Pre-pivot canon (the old voice-notes app) lives in `damsac/Murmur` `meta/CANON.m
 
 ## Product
 
-- **What Murmur is now:** AI meeting notes for blue-collar field work. One button; record an hour-long site walk with the phone in your pocket; on-device transcription; an agent turns it into structured items, documents, and todos. Brand: Murmur. Repo/working title: sitewalk.
+- **What Sitewalk is now:** AI meeting notes for blue-collar field work. One button; record an hour-long site walk with the phone in your pocket; on-device transcription; an agent turns it into structured items, documents, and todos. Brand: Sitewalk (formerly Murmur — see Decisions Log, 2026-07-06). Repo: `damsac/sitewalk`.
 - **Capture-first:** artifacts are a pluggable seam; live in-session extraction onto a board; jobs-board home with `Job` as first-class.
 - **Privacy:** audio never leaves the device; on-device STT; local-first storage.
 
@@ -43,6 +43,7 @@ Centers of gravity, not hard boundaries.
 | 2026-07-01 | Native shells over Tauri (background audio, feel) | dam | pending sac's spec review |
 | 2026-07-01 | Product rules R1–R9 (hidden transcript, deliberate stop, under-extraction bias R6, spend meter R9, …) | dam | pending sac's spec review |
 | 2026-07-03 | Repo `damsac/sitewalk`; brand stays Murmur | dam | sac PR'd into it |
+| 2026-07-06 | **Product name is Sitewalk** — supersedes the 2026-07-03 "repo = sitewalk, brand stays Murmur" split. Sitewalk is now both the repo and the brand; Murmur remains the historical name for the pre-pivot app (`docs/HISTORY.md`). Follow-ups owned elsewhere, not part of this sweep: TestFlight/App Store Connect listing name, and the app display name in the unmerged TestFlight branch's `project-release.yml` | dam | brand decision sweep |
 | 2026-07-04 | Swap-contract fix: items get `source` (live/authoritative/manual); process() clears live items only AFTER successful extraction | dam | core-side; informs sac's board UX |
 | 2026-07-04 | STT: benchmark-first — whisper.cpp Rust-side preferred, 06-spike confirms or kills. Driver: vocabulary→STT biasing; iOS 26 SpeechAnalyzer dropped custom vocabulary | dam | supersedes HANDOFF's "STT stays in Swift"; flagged in PR #1 review |
 | 2026-07-04 | `WalkEngine` seam + `AppModel.init(engine:)` swap point | sac | dam's PR #1 review endorses |

--- a/meta/dam/STATE.md
+++ b/meta/dam/STATE.md
@@ -6,7 +6,7 @@ What dam is working on right now. Updated with every PR.
 
 ## Current focus
 
-**The rebuild — this repo.** Murmur pivoted 2026-07-01 to AI meeting notes for blue-collar field work (GC site walks, inspections). Rust core + native shells, built here in `damsac/sitewalk`. Specs, plans, research, and mocks all live HERE now (`docs/`); `damsac/Murmur` is archive-only.
+**The rebuild — this repo.** Murmur pivoted 2026-07-01 to AI meeting notes for blue-collar field work (GC site walks, inspections); as of 2026-07-06 the product is branded **Sitewalk** (CANON). Rust core + native shells, built here in `damsac/sitewalk`. Specs, plans, research, and mocks all live HERE now (`docs/`); `damsac/Murmur` is archive-only.
 
 dam owns: harness / murmur-core / STT / FFI. sac owns: renderers / component library / visual direction (`apps/ios/`).
 


### PR DESCRIPTION
## Thinking

dam decided 2026-07-06 that the product name is **Sitewalk**, superseding the 2026-07-03 CANON entry ("repo=sitewalk, brand stays Murmur"). This PR is a narrow brand sweep, not a rename of anything structural.

**The scope line I drew:** forward-looking, user-facing brand text moves to Sitewalk. Everything that is either (a) a code/package identifier, (b) an actual git repo name, or (c) a historical record of what the product was called at a point in time, stays as Murmur.

Concretely:
- **Changed** — root `CLAUDE.md` intro, `README.md` (title, tagline, workspace-layout line, history footer), `meta/CANON.md` (added a Decisions Log row + updated the "What Sitewalk is now" line), `meta/dam/STATE.md` (current-focus line).
- **Annotated, not rewritten** — the frozen 2026-07-01 vision spec (`docs/specs/...` and its duplicate under `docs/superpowers/specs/...`) is a dated, approved snapshot full of "Murmur" prose (pillars, product rules, "Murmur v1" comparisons). Rewriting that prose would falsify a historical record, so I added one line under its Status field pointing to the CANON rename instead of touching the body.
- **Left alone by design** — `docs/HISTORY.md`, all dated plan/research/brainstorm docs, `docs/CORE.md` and `docs/design/BRIEF.md`'s "Murmur's engine, carried over" attributions (these correctly describe the *legacy Era-I app* being reused, not the current product name), crate names (`murmur-core`), code identifiers (`MurmurEngine`, `MurmurCoreFFI`), the `com.isaacwm.murmur` bundle id, and `meta/ROADMAP.md` / `meta/sac/STATE.md` (their only "Murmur" mentions are the `damsac/Murmur` repo name or the `MurmurEngine` FFI type — not brand prose).
- `apps/ios/` needed **no changes** — `project.yml` already sets `name: SitewalkGallery` and `CFBundleDisplayName: Sitewalk`; I grepped Swift sources and plists for user-facing "Murmur" strings and found none (only `MurmurCoreFFI`/`MurmurEngine` code identifiers and log lines).
- Two follow-ups are explicitly out of scope and called out in the new CANON row: the TestFlight/App Store Connect listing name, and the app display name in the unmerged TestFlight branch's `project-release.yml` (not touched — that branch wasn't checked out).

## Test plan

- [x] `nix develop -c cargo test --workspace` — exit 0
- [x] `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] No `apps/ios` files changed, so xcodegen/xcodebuild regeneration wasn't needed