### PR TITLE
sac: bake ANTHROPIC_BASE_URL into Info.plist (missed the #167 merge window)

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -89,7 +89,11 @@ private func resolveEngine(demo: Bool) -> WalkEngine? {
         engineLog.notice("engine=demo (no PPQ_API_KEY configured)")
         return nil // no key configured -> demo path (D10)
     }
+    // Env var wins (ad-hoc override via SIMCTL_CHILD_…), else the value baked
+    // into Info.plist by generate.sh — so icon-tap launches hit the right
+    // provider without any environment plumbing.
     let baseURL = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"]
+        ?? (Bundle.main.object(forInfoDictionaryKey: "ANTHROPIC_BASE_URL") as? String)
     // iOS does not pre-create Application Support; murmur-core opens its SQLite
     // store at dbPath and panics if the parent directory is missing. Ensure it
     // exists before handing the path to the engine.

--- a/apps/ios/generate.sh
+++ b/apps/ios/generate.sh
@@ -43,6 +43,16 @@ elif [ -f "$ENV_FILE" ] && grep -qE '^ANTHROPIC_API_KEY=' "$ENV_FILE"; then
   KEY="$(grep -E '^ANTHROPIC_API_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
 fi
 
+# Resolve the provider base URL the same way (PPQ et al). Baked into the built
+# app's Info.plist so icon-tap launches work — a SIMCTL_CHILD_ env var only
+# reaches the app when launched via `simctl launch`, which nobody does twice.
+BASE_URL=""
+if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+  BASE_URL="$ANTHROPIC_BASE_URL"
+elif [ -f "$ENV_FILE" ] && grep -qE '^ANTHROPIC_BASE_URL=' "$ENV_FILE"; then
+  BASE_URL="$(grep -E '^ANTHROPIC_BASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+fi
+
 if [ -z "$KEY" ]; then
   echo "WARN: no ANTHROPIC_API_KEY in env or $ENV_FILE." >&2
   echo "      The real core is linked but will fall back to the DEMO engine at" >&2
@@ -56,6 +66,7 @@ cat > "$LOCAL" <<EOF
 settings:
   base:
     PPQ_API_KEY: "$KEY"
+    ANTHROPIC_BASE_URL: "$BASE_URL"
 EOF
 
 # Whisper model check (Plan 08 D5): the model must be an APP-TARGET resource

--- a/apps/ios/project.local.yml.template
+++ b/apps/ios/project.local.yml.template
@@ -9,3 +9,7 @@ settings:
     # engine (no real LLM). ./generate.sh populates this from ANTHROPIC_API_KEY
     # in the repo-root .env.
     PPQ_API_KEY: ""
+    # Provider base URL (e.g. https://api.ppq.ai for PPQ). Empty => provider
+    # default (api.anthropic.com). ./generate.sh populates this from
+    # ANTHROPIC_BASE_URL in the repo-root .env.
+    ANTHROPIC_BASE_URL: ""

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -29,6 +29,9 @@ targets:
         # supplied by the gitignored project.local.yml and expanded by xcodebuild
         # into the built app's Info.plist. This tracked value never holds a secret.
         PPQ_API_KEY: "$(PPQ_API_KEY)"
+        # Provider base URL (e.g. https://api.ppq.ai). Same injection flow as
+        # the key; empty => provider default (api.anthropic.com).
+        ANTHROPIC_BASE_URL: "$(ANTHROPIC_BASE_URL)"
         CFBundleDisplayName: Sitewalk
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: "Sitewalk records your walk-and-talk so it can turn it into paperwork."


### PR DESCRIPTION
## Thinking

One commit that landed on `pr/sac/review-followups` ~an hour after you merged #167, so main never got it. Real-world failure it fixes: launching the app by TAPPING THE ICON gets no environment variables, so `resolveEngine`'s env-only `ANTHROPIC_BASE_URL` came back nil → real engine pointed at api.anthropic.com with a PPQ key → every LLM call 401'd silently → walks finish empty and the app *looks* like the demo. sac hit exactly this on first hands-on test.

Fix mirrors your PPQ_API_KEY flow one-for-one: generate.sh bridges `ANTHROPIC_BASE_URL` from the repo-root `.env` into the gitignored `project.local.yml`, project.yml carries the `$(ANTHROPIC_BASE_URL)` literal, resolveEngine falls back env → Info.plist → provider default. Env var still wins for ad-hoc overrides. Verified: env-free autoflow walk on sim extracts a real document (4 rows, $1,200 total from speech, +4 GAP).