### PR TITLE
photo_count fast-follow: wire real per-item counts into the board snapshot

### DIFF
--- a/crates/ffi/src/convert.rs
+++ b/crates/ffi/src/convert.rs
@@ -1,20 +1,26 @@
 //! Domain -> FFI dictionary projections. Every mapping across the FFI
 //! boundary lives here (plus the records themselves) — nowhere else.
 
+use std::collections::HashMap;
+
 use murmur_core::{Artifact, CapturedItem};
 
 use crate::document::{DocLine, DocumentPayload};
 use crate::events::BoardItem;
 
-/// `CapturedItem` -> `BoardItem`. `right`/`photo_count` have no core
-/// equivalent yet (see `events.rs` doc comment) and default to empty/zero.
-pub fn board_item(item: &CapturedItem) -> BoardItem {
+/// `CapturedItem` -> `BoardItem`. `right` has no core equivalent yet (board
+/// chrome text the Swift layer owns) and stays empty. `photo_count` is looked
+/// up from a batched per-session map (`Store::count_live_photos_by_item_for_session`,
+/// the photo_count fast-follow) — a missing key (no live photos attached to
+/// this item) defaults to `0`. Callers load the map ONCE per snapshot, never
+/// per item (no N+1 query per board item).
+pub fn board_item(item: &CapturedItem, photo_counts: &HashMap<String, u32>) -> BoardItem {
     BoardItem {
         id: item.id.clone(),
         kind: item.kind.clone(),
         text: item.text.clone(),
         right: String::new(),
-        photo_count: 0,
+        photo_count: photo_counts.get(&item.id).copied().unwrap_or(0),
     }
 }
 
@@ -120,10 +126,25 @@ mod tests {
         let item = store
             .add_item_with_source(&session.id, "todo", "order lumber", ItemSource::Live)
             .unwrap();
-        let board = board_item(&item);
+        let board = board_item(&item, &HashMap::new());
         assert_eq!(board.id, item.id);
         assert_eq!(board.kind, "todo");
         assert_eq!(board.text, "order lumber");
+        assert_eq!(board.photo_count, 0, "no entry in the counts map defaults to 0");
+    }
+
+    #[test]
+    fn board_item_photo_count_comes_from_the_batched_map() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let item = store
+            .add_item_with_source(&session.id, "todo", "order lumber", ItemSource::Live)
+            .unwrap();
+        store.add_photo(&session.id, Some(&item.id), "a.jpg", None).unwrap();
+        store.add_photo(&session.id, Some(&item.id), "b.jpg", None).unwrap();
+        let counts = store.count_live_photos_by_item_for_session(&session.id).unwrap();
+        let board = board_item(&item, &counts);
+        assert_eq!(board.photo_count, 2);
     }
 
     #[test]

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -356,24 +356,46 @@ impl WalkSession {
 
     /// Re-queries the board and emits exactly one `BoardUpdated` snapshot —
     /// the shared tail of both a live-pass tick and the finish-time swap (D3).
+    ///
+    /// Photo counts (photo_count fast-follow, Plan 11 D6) are loaded with ONE
+    /// batched `GROUP BY item_id` query per snapshot
+    /// (`count_live_photos_by_item_for_session`) and threaded into every
+    /// `convert::board_item` call below — never a per-item query (no N+1 on
+    /// the hot board path). NOTE (staleness): this snapshot only fires on a
+    /// live-extraction tick or the finish-time swap. `add_photo`/`remove_photo`
+    /// (engine-keyed, `crates/ffi/src/photos.rs`) do NOT themselves trigger a
+    /// re-emission — `MurmurEngine` holds no registry of live `WalkSession`s to
+    /// call back into, so there is no cheap existing emission path to hook.
+    /// A photo attached mid-walk therefore shows a stale (possibly 0) count on
+    /// the live board until the NEXT tick or the finish swap re-queries it;
+    /// the capture UI's own local confirmation is the immediate feedback (D6).
     fn emit_board_snapshot(&self) {
         let Some(listener) = self.listener.lock().unwrap().clone() else { return };
         // Don't panic across FFI on a poisoned lock (this is also called from
         // finish()): count the degradation and skip the snapshot instead.
-        let items = match self.store.lock() {
-            Ok(store) => match store.list_items_for_session(&self.session_id) {
-                Ok(items) => items,
-                Err(e) => {
-                    self.record_tick_fault(&format!("list_items_for_session: {e}"));
-                    return;
-                }
-            },
+        let (items, photo_counts) = match self.store.lock() {
+            Ok(store) => {
+                let items = match store.list_items_for_session(&self.session_id) {
+                    Ok(items) => items,
+                    Err(e) => {
+                        self.record_tick_fault(&format!("list_items_for_session: {e}"));
+                        return;
+                    }
+                };
+                // A photo-count query fault degrades to "no counts" (all zero)
+                // rather than dropping the whole snapshot — items are the
+                // load-bearing content; counts are best-effort enrichment.
+                let counts = store
+                    .count_live_photos_by_item_for_session(&self.session_id)
+                    .unwrap_or_default();
+                (items, counts)
+            }
             Err(_) => {
                 self.record_tick_fault("store lock poisoned");
                 return;
             }
         };
-        let board_items = items.iter().map(convert::board_item).collect();
+        let board_items = items.iter().map(|item| convert::board_item(item, &photo_counts)).collect();
         listener.on_event(WalkEvent::BoardUpdated { items: board_items });
     }
 
@@ -813,6 +835,60 @@ mod tests {
         };
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].text, "order lumber");
+    }
+
+    /// photo_count fast-follow (Plan 11 D6): a photo attached to a pre-existing
+    /// item shows up in the NEXT `BoardUpdated` snapshot, batched (one
+    /// `count_live_photos_by_item_for_session` query for the whole board, not
+    /// one per item) rather than defaulted to `0`.
+    #[tokio::test]
+    async fn board_snapshot_carries_batched_photo_counts() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let sid = store.start_session(None).unwrap().id;
+        let pre_item = store
+            .add_item_with_source(&sid, "todo", "existing item", ItemSource::Live)
+            .unwrap();
+        store.add_photo(&sid, Some(&pre_item.id), "a.jpg", None).unwrap();
+        store.add_photo(&sid, Some(&pre_item.id), "b.jpg", None).unwrap();
+        let store = Arc::new(StdMutex::new(store));
+        let memory = Arc::new(StdMutex::new(Memory::default()));
+
+        let mut extractor = LiveExtractor::new(
+            Arc::new(MockProvider::new(vec![
+                tool_use("add_item", serde_json::json!({"kind": "todo", "text": "order lumber"})),
+                end_turn("captured"),
+            ])),
+            store.clone(),
+            memory.clone(),
+            &sid,
+        );
+        extractor.min_new_chars = 1;
+
+        let session = test_session(
+            sid.clone(),
+            store.clone(),
+            extractor,
+            Arc::new(MockProvider::new(vec![])),
+            memory,
+        );
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        session.clone().set_event_listener(Arc::new(ChannelListener(tx)));
+
+        session.clone().append_transcript("order twelve two by tens for the deck".into());
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("tick did not fire in time")
+            .expect("channel closed without an event");
+        let WalkEvent::BoardUpdated { items } = event else {
+            panic!("expected BoardUpdated, got {event:?}");
+        };
+        assert_eq!(items.len(), 2, "the pre-existing item + the newly extracted item");
+        let pre = items.iter().find(|i| i.id == pre_item.id).expect("pre-existing item present");
+        assert_eq!(pre.photo_count, 2, "batched per-item photo count wired into the snapshot");
+        let new_item = items.iter().find(|i| i.text == "order lumber").expect("new item present");
+        assert_eq!(new_item.photo_count, 0, "no photos attached to the freshly extracted item");
     }
 
     #[tokio::test]

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -385,9 +385,18 @@ impl WalkSession {
                 // A photo-count query fault degrades to "no counts" (all zero)
                 // rather than dropping the whole snapshot — items are the
                 // load-bearing content; counts are best-effort enrichment.
-                let counts = store
-                    .count_live_photos_by_item_for_session(&self.session_id)
-                    .unwrap_or_default();
+                // The fault is still SURFACED via the tick counter (carry-note
+                // 4 posture, matching the item-list fault above; lock-safe:
+                // record_tick_fault is atomic + eprintln, no store re-lock).
+                let counts = match store.count_live_photos_by_item_for_session(&self.session_id) {
+                    Ok(counts) => counts,
+                    Err(e) => {
+                        self.record_tick_fault(&format!(
+                            "count_live_photos_by_item_for_session: {e}"
+                        ));
+                        std::collections::HashMap::new()
+                    }
+                };
                 (items, counts)
             }
             Err(_) => {

--- a/crates/murmur-core/src/store/photos.rs
+++ b/crates/murmur-core/src/store/photos.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use rusqlite::Row;
 
 use crate::domain::Photo;
@@ -133,6 +135,31 @@ impl Store {
             .map_err(CoreError::Sqlite)
     }
 
+    /// Batched per-item live-photo counts for a session (photo_count
+    /// fast-follow, Plan 11 D6): one `GROUP BY item_id` query, never an N+1
+    /// per board item. Only photos attached to a specific item are counted
+    /// (`item_id IS NOT NULL`); session-level photos don't count for any item.
+    /// An item with no live photos is simply ABSENT from the map — callers
+    /// treat a missing key as `0` (see `convert::board_item`).
+    pub fn count_live_photos_by_item_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<HashMap<String, u32>, CoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT item_id, COUNT(*) FROM photos
+             WHERE session_id = ?1 AND deleted_at IS NULL AND item_id IS NOT NULL
+             GROUP BY item_id",
+        )?;
+        let mut rows = stmt.query([session_id])?;
+        let mut counts = HashMap::new();
+        while let Some(row) = rows.next()? {
+            let item_id: String = row.get(0)?;
+            let count: i64 = row.get(1)?;
+            counts.insert(item_id, count as u32);
+        }
+        Ok(counts)
+    }
+
     /// Demote live photos whose `item_id` references a now-tombstoned item in
     /// `session_id` to session-level (`item_id := NULL`). Runs INSIDE the
     /// caller's transaction, AFTER the item tombstone. Order-independent: it
@@ -257,6 +284,24 @@ mod tests {
         let g = s.add_photo(&sid, None, "b.jpg", None).unwrap();
         s.remove_photo(&g.id).unwrap();
         assert_eq!(s.count_photos_for_session(&sid).unwrap(), 1);
+    }
+
+    #[test]
+    fn count_live_photos_by_item_for_session_batches_and_skips_session_level() {
+        let (s, sid) = store_with_session();
+        let i1 = s.add_item(&sid, "todo", "I1").unwrap();
+        let i2 = s.add_item(&sid, "todo", "I2").unwrap();
+        s.add_photo(&sid, Some(&i1.id), "a.jpg", None).unwrap();
+        s.add_photo(&sid, Some(&i1.id), "b.jpg", None).unwrap();
+        s.add_photo(&sid, Some(&i2.id), "c.jpg", None).unwrap();
+        s.add_photo(&sid, None, "d.jpg", None).unwrap(); // session-level, not counted
+        let gone = s.add_photo(&sid, Some(&i2.id), "e.jpg", None).unwrap();
+        s.remove_photo(&gone.id).unwrap(); // tombstoned, not counted
+
+        let counts = s.count_live_photos_by_item_for_session(&sid).unwrap();
+        assert_eq!(counts.get(i1.id.as_str()), Some(&2));
+        assert_eq!(counts.get(i2.id.as_str()), Some(&1));
+        assert_eq!(counts.len(), 2, "items with zero live photos are absent, not zero-valued");
     }
 
     #[test]


### PR DESCRIPTION
## Thinking

**What this is.** The Plan 11 D6 fast-follow: `BoardItem.photo_count` existed in the FFI events but `convert::board_item` hardcoded it to `0`. This wires it to real counts. No new event types, no schema change, no binding-surface change (`photoCount` was already in the generated Swift record).

**Batching decision.** One new Store query, `count_live_photos_by_item_for_session`: `SELECT item_id, COUNT(*) FROM photos WHERE session_id=? AND deleted_at IS NULL AND item_id IS NOT NULL GROUP BY item_id` → `HashMap<String, u32>`. `emit_board_snapshot` loads this map ONCE per snapshot (under the same store-lock scope as the item list) and threads it into every `convert::board_item` call — never a per-item count query, so the hot board path stays O(2 queries) per snapshot regardless of board size. Items absent from the map render `0`; session-level photos (`item_id NULL`) and tombstoned photos count for no item — the demotion rule (D3) means a demoted photo's count honestly disappears from the item it used to hang on.

**Re-emission decision: NOT implemented, deliberately.** `add_photo`/`remove_photo` are engine-keyed (`crates/ffi/src/photos.rs`, the vocabulary precedent) — `MurmurEngine` holds no registry of live `WalkSession`s, so there is no existing emission path a photo mutation could cheaply call into. Building one (a session registry, or a new event type) is exactly the scope this fast-follow shouldn't take on. **Staleness semantics:** a photo attached mid-walk shows its real count at the NEXT board snapshot — i.e., the next live-extraction tick or the finish-time swap. Until then the live board may show a stale (possibly 0) count; the capture UI's own local confirmation is the immediate feedback (the D6 argument, unchanged). This is documented in a code-adjacent comment on `emit_board_snapshot`.

**Degradation.** A count-query fault degrades to an all-zero map rather than dropping the snapshot — items are the load-bearing content, counts are enrichment. (A `list_items_for_session` fault still skips the snapshot and records a tick fault, unchanged.)

**Swift side.** Zero changes needed: `MurmurEngine.swift` already maps `item.photoCount → CapturedFixture(photos:)`, so real counts flow through as soon as the xcframework is rebuilt. The demo engine fabricates `CapturedFixture`s whose `photos` field defaults to `0` — parity kept, nothing wired (demo photos live in a separate in-memory list keyed to a fake session).

## Changes

- `crates/murmur-core/src/store/photos.rs` — `count_live_photos_by_item_for_session` (batched GROUP BY) + test
- `crates/ffi/src/convert.rs` — `board_item(item, photo_counts)` map lookup, default 0 + tests
- `crates/ffi/src/session.rs` — `emit_board_snapshot` loads the map once per snapshot; staleness comment + end-to-end tick test (pre-attached photos surface `photo_count: 2` in the next `BoardUpdated`)

## Tests

+3 tests (1 core, 2 ffi convert, 1 ffi session — 4 new asserts total across 3 new test fns + 1 extended). `cargo test --workspace` exit 0; `cargo clippy --workspace --all-targets -- -D warnings` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)