### PR TITLE
Whisper model download flow + small.en promotion (revertible)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@
 # simulator/QA capture evidence
 /screenshots/
 
-# On-device whisper model (large binary, provisioned locally — see apps/ios/build-ffi.sh)
+# On-device whisper model (large binary, provisioned locally — see
+# apps/ios/fetch-whisper-model.sh). Both the shipped default (small.en) and
+# the revertible fallback (base.en) are gitignored; either or both may be
+# present on disk depending on which models you've fetched.
 apps/ios/Sources/Resources/ggml-base.en-q5_1.bin
+apps/ios/Sources/Resources/ggml-small.en-q5_1.bin

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -44,7 +44,10 @@ the first fetch): default **small.en** (~190 MB), with a one-arg revert to
 **base.en** (~60 MB) via `STT_MODEL=base.en ./generate.sh` or the runtime
 `sttmodel=base.en` launch arg. small.en's promotion is Mac-proxy evidence only
 — see `fetch-whisper-model.sh`'s header and `spikes/stt-whisper/RESULTS.md`
-(iPhone T5 device tier still PENDING).
+(iPhone T5 device tier still PENDING). After a successful fetch `generate.sh`
+deletes the non-selected model from `Sources/Resources/` — `project.yml` globs
+`Sources/` wholesale, so leaving both bins on disk would silently bundle both
+(+250 MB total). Exactly one model is ever bundled.
 
 > Switching modes in an existing checkout can leave a stale SwiftPM package graph
 > in DerivedData — if a build errors with `Unable to find module dependency:

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -38,6 +38,14 @@ gitignored `project.local.yml` and the generated (gitignored) `.xcodeproj`;
 xcodebuild expands `$(PPQ_API_KEY)` into the built app's Info.plist at build
 time. No tracked file ever holds the secret.
 
+`./generate.sh` also fetches the on-device whisper model via
+`./fetch-whisper-model.sh` (gitignored binary, sha256-verified, cached after
+the first fetch): default **small.en** (~190 MB), with a one-arg revert to
+**base.en** (~60 MB) via `STT_MODEL=base.en ./generate.sh` or the runtime
+`sttmodel=base.en` launch arg. small.en's promotion is Mac-proxy evidence only
+— see `fetch-whisper-model.sh`'s header and `spikes/stt-whisper/RESULTS.md`
+(iPhone T5 device tier still PENDING).
+
 > Switching modes in an existing checkout can leave a stale SwiftPM package graph
 > in DerivedData — if a build errors with `Unable to find module dependency:
 > 'ffiFFI'`, delete DerivedData and rebuild. A clean checkout is unaffected.
@@ -54,4 +62,6 @@ Design source of truth: `../../docs/design/BRIEF.md` (rationale) and
 `../../docs/design/mockup.html` (visual reference, open in a browser).
 
 Launch args: `autoflow=1` (scripted walk plays itself), `autopdf=1` (+ PDF),
-`live=1` (real mic + on-device STT), `screen=<page>` (design gallery).
+`live=1` (real mic + on-device STT), `screen=<page>` (design gallery),
+`sttmodel=base.en|small.en` (which bundled whisper model to load; default
+small.en).

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -23,6 +23,14 @@ private let engineLog = Logger(subsystem: "com.damsac.sitewalk", category: "engi
 //                                              (default 0.0; ~0.01 cuts noise)
 //   sttnsp=<float>                           → STT no_speech_prob drop
 //                                              threshold (default 0.6)
+//   sttmodel=base.en|small.en                → which bundled whisper model to
+//                                              load (default small.en — see
+//                                              resolveSttModelPath). One-arg
+//                                              revert to base.en: small.en's
+//                                              on-device RTF is Mac-proxy
+//                                              evidence only — the iPhone T5
+//                                              tier is still PENDING in
+//                                              spikes/stt-whisper/RESULTS.md.
 
 /// Engine selection (Plan 07 D10/Task 11): real `MurmurEngine` when an API
 /// key + config resolve, `DemoWalkEngine` when launched with `demo=1` OR
@@ -75,6 +83,40 @@ private func resolveSttKnobs(_ args: [String]) -> SttKnobs {
     return SttKnobs(useGpu: useGpu, vadRms: vadRms, noSpeechProb: noSpeechProb)
 }
 
+/// Resolves the bundled whisper model path from the `sttmodel=base.en|small.en`
+/// launch arg (default **small.en** — the spike-validated upgrade over
+/// base.en on every measured WER/hallucination axis, `spikes/stt-whisper/
+/// RESULTS.md`). This is the one-arg revert surface: the iPhone T5 device
+/// tier in that same doc is still PENDING, so small.en's on-device RTF is
+/// unproven — launching with `sttmodel=base.en` (or setting
+/// `STT_MODEL=base.en` before `./generate.sh`/`./fetch-whisper-model.sh`)
+/// falls straight back to the previously-shipped default with no code change.
+///
+/// Falls back to whichever model IS bundled if the requested one isn't
+/// present (e.g. only base.en was fetched) — same "degrade, never crash"
+/// posture as the rest of engine resolution. Returns `nil` (text-only) only
+/// if neither model is bundled.
+private func resolveSttModelPath(_ args: [String]) -> String? {
+    let requested = args
+        .first(where: { $0.hasPrefix("sttmodel=") })
+        .map { String($0.dropFirst("sttmodel=".count)) } ?? "small.en"
+    let fallback = requested == "base.en" ? "small.en" : "base.en"
+    for name in [requested, fallback] {
+        if let path = Bundle.main.path(forResource: "ggml-\(name)-q5_1", ofType: "bin") {
+            if name != requested {
+                engineLog.notice(
+                    "sttmodel=\(requested, privacy: .public) requested but not bundled"
+                )
+                engineLog.notice("using \(name, privacy: .public) instead")
+            } else {
+                engineLog.notice("stt model=\(name, privacy: .public)")
+            }
+            return path
+        }
+    }
+    return nil
+}
+
 @MainActor
 private func resolveEngine(demo: Bool) -> WalkEngine? {
     if demo {
@@ -103,14 +145,17 @@ private func resolveEngine(demo: Bool) -> WalkEngine? {
     let dbPath = appSupport
         .appendingPathComponent("murmur.sqlite3")
         .path
-    // Bundled whisper model (Plan 08 D5) — resolved from the app bundle. If the
-    // resource is missing the walk degrades to text-only (no crash): the Rust
-    // side treats a nil path as a text-only session.
-    let sttModelPath = Bundle.main.path(forResource: "ggml-base.en-q5_1", ofType: "bin")
+    // Bundled whisper model (Plan 08 D5; sttmodel= knob added in the
+    // model-download PR) — resolved from the app bundle via
+    // resolveSttModelPath, which also handles the base.en/small.en fallback
+    // and revert. If neither model is bundled the walk degrades to text-only
+    // (no crash): the Rust side treats a nil path as a text-only session.
+    let args = ProcessInfo.processInfo.arguments
+    let sttModelPath = resolveSttModelPath(args)
     if sttModelPath == nil {
         engineLog.notice("stt model not bundled — live walk will run text-only")
     }
-    let stt = resolveSttKnobs(ProcessInfo.processInfo.arguments)
+    let stt = resolveSttKnobs(args)
     let config = EngineConfig(
         dbPath: dbPath,
         deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "unknown-device",

--- a/apps/ios/build-ffi.sh
+++ b/apps/ios/build-ffi.sh
@@ -95,25 +95,29 @@ xcodebuild -create-xcframework \
 # Whisper model provisioning (Plan 08 D5/Task 8)
 # ---------------------------------------------------------------------------
 # The FFI libs are now built WITH the `whisper` feature, so the app can run
-# on-device STT. It needs the GGML model bundled as an APP-TARGET resource:
+# on-device STT. It needs a GGML model bundled as an APP-TARGET resource:
 #
-#   ggml-base.en-q5_1.bin  (~60 MB, MIT, huggingface.co/ggerganov/whisper.cpp)
+#   ggml-small.en-q5_1.bin  (~190 MB, MIT, huggingface.co/ggerganov/whisper.cpp)
+#     — the default (small.en promotion; see fetch-whisper-model.sh header for
+#     the RTF/WER rationale and the iPhone-T5-unproven caveat)
+#   ggml-base.en-q5_1.bin   (~60 MB) — the one-arg revert (STT_MODEL=base.en)
 #
-# This binary is GITIGNORED (large — like the xcframework). Fetch it into the
-# app target's Sources/Resources once:
+# Both binaries are GITIGNORED (large — like the xcframework), sha256-pinned,
+# and fetched/cache-verified by ./fetch-whisper-model.sh (called automatically
+# from ./generate.sh, which runs after this script). Manual fetch:
 #
-#   curl -L -o apps/ios/Sources/Resources/ggml-base.en-q5_1.bin \
-#     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en-q5_1.bin
+#   ./fetch-whisper-model.sh            # default: small.en
+#   ./fetch-whisper-model.sh base.en    # revert
 #
 # WHY Sources/Resources and NOT Packages/MurmurCoreFFI/Resources: SwiftPM
 # package resources land in `Bundle.module` (the package's resource bundle),
-# but GalleryApp.resolveEngine reads `Bundle.main.path(forResource:
-# "ggml-base.en-q5_1", ofType: "bin")` — the APP bundle. A model placed in the
-# package would silently never resolve. The app-target `Sources` glob (picked
-# up by both project.yml and project-real.yml) is the mechanism that actually
-# works — verified on the simulator. If the model is absent the live walk
-# degrades to text-only — no crash (the Rust side treats a nil path as
-# text-only); ./generate.sh prints a NOTE when it's missing. Keep
+# but GalleryApp.resolveEngine resolves the model via `Bundle.main.path(
+# forResource: "ggml-<model>-q5_1", ofType: "bin")` — the APP bundle. A model
+# placed in the package would silently never resolve. The app-target `Sources`
+# glob (picked up by both project.yml and project-real.yml) is the mechanism
+# that actually works — verified on the simulator. If neither model is present
+# the live walk degrades to text-only — no crash (the Rust side treats a nil
+# path as text-only); ./generate.sh prints a NOTE when the fetch fails. Keep
 # CODE_SIGNING_ALLOWED: NO for the simulator.
 #
 # NOTE: the tracked demo spec (project.yml) deliberately does NOT bundle the

--- a/apps/ios/fetch-whisper-model.sh
+++ b/apps/ios/fetch-whisper-model.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Downloads a ggml whisper model into apps/ios/Sources/Resources/ as an
+# APP-TARGET resource (Bundle.main — see GalleryApp.resolveEngine and
+# build-ffi.sh's Whisper model provisioning note for why it must live there
+# and not under a SwiftPM package's Resources).
+#
+# Usage:
+#   ./fetch-whisper-model.sh [base.en|small.en] [--force]
+#   MODEL=base.en ./fetch-whisper-model.sh          # env var form
+#
+# Default model: small.en (Plan 08 spike RESULTS.md: strictly better than
+# base.en on every measured axis — 4.7% vs 5.8% WER clean, 2-4pp better under
+# noise, 0 vs 4 hallucinated tokens on jackhammer noise-only audio — at ~free
+# RTF headroom on the Mac proxy). See the CAVEAT below before trusting this on
+# a device.
+#
+# Both models' sha256 digests are hardcoded below (not just the default's) so
+# reverting the *download* to base.en never needs a source change beyond the
+# one launch arg documented in GalleryApp.swift (`sttmodel=base.en`) — this
+# script fetches whichever model you ask it for, verifying against a pinned
+# digest either way.
+#
+# CAVEAT (carried into the PR description, not just here): the small.en
+# promotion is decided on Mac-proxy RTF numbers only (spike RESULTS.md Table
+# 1: RTF 0.021 on an M4 Max). The iPhone T5 device tier in that same doc is
+# still marked PENDING — small.en's on-device RTF is UNPROVEN. That is why
+# this is a one-arg revert (`sttmodel=base.en`) and not a hard swap: if a
+# device sweep shows small.en missing the RTF<1.0 bar, flip the arg back
+# without touching this script or GalleryApp.swift's resolution logic.
+#
+# Caching: if the target file exists and its sha256 already matches the
+# pinned digest, the download is skipped. --force re-fetches regardless.
+# On a digest mismatch (corrupt/partial download, or an upstream file change)
+# the bad file is deleted and the script fails loudly — it never leaves a
+# silently-wrong model behind for whisper.cpp to load.
+set -euo pipefail
+cd "$(dirname "$0")"   # apps/ios
+DEST_DIR="Sources/Resources"
+BASE_URL="https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
+
+MODEL="${MODEL:-small.en}"
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    base.en|small.en) MODEL="$arg" ;;
+    --force) FORCE=1 ;;
+    *)
+      echo "usage: $0 [base.en|small.en] [--force]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Pinned sha256 digests (verified against a real download of both files,
+# 2026-07 — see the PR that introduced this script). Keep BOTH here even
+# though only one is fetched by default: the whole point of the revert path
+# is that base.en's digest is always available, no source change needed.
+case "$MODEL" in
+  base.en)
+    FILENAME="ggml-base.en-q5_1.bin"
+    SHA256="4baf70dd0d7c4247ba2b81fafd9c01005ac77c2f9ef064e00dcf195d0e2fdd2f"
+    ;;
+  small.en)
+    FILENAME="ggml-small.en-q5_1.bin"
+    SHA256="bfdff4894dcb76bbf647d56263ea2a96645423f1669176f4844a1bf8e478ad30"
+    ;;
+  *)
+    echo "unknown model '$MODEL' (expected base.en or small.en)" >&2
+    exit 1
+    ;;
+esac
+
+DEST="$DEST_DIR/$FILENAME"
+mkdir -p "$DEST_DIR"
+
+sha256_of() {
+  # shasum ships on macOS by default; sha256sum on most Linux dev boxes.
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    sha256sum "$1" | cut -d' ' -f1
+  fi
+}
+
+if [ -f "$DEST" ] && [ "$FORCE" -ne 1 ]; then
+  EXISTING_SHA="$(sha256_of "$DEST")"
+  if [ "$EXISTING_SHA" = "$SHA256" ]; then
+    echo "==> $DEST already present and verified (sha256 matches) — skipping download."
+    exit 0
+  fi
+  echo "NOTE: $DEST exists but its sha256 doesn't match the pinned digest — re-fetching." >&2
+fi
+
+echo "==> downloading $FILENAME (~$([ "$MODEL" = small.en ] && echo 190 || echo 60) MB) from $BASE_URL"
+curl -L --fail -o "$DEST.part" "$BASE_URL/$FILENAME"
+
+ACTUAL_SHA="$(sha256_of "$DEST.part")"
+if [ "$ACTUAL_SHA" != "$SHA256" ]; then
+  echo "ERROR: sha256 mismatch for $FILENAME" >&2
+  echo "       expected $SHA256" >&2
+  echo "       got      $ACTUAL_SHA" >&2
+  rm -f "$DEST.part"
+  exit 1
+fi
+
+mv "$DEST.part" "$DEST"
+echo "==> $DEST downloaded and verified (sha256 matches)."

--- a/apps/ios/generate.sh
+++ b/apps/ios/generate.sh
@@ -69,17 +69,25 @@ settings:
     ANTHROPIC_BASE_URL: "$BASE_URL"
 EOF
 
-# Whisper model check (Plan 08 D5): the model must be an APP-TARGET resource
-# under Sources/Resources (Bundle.main — a package resource would land in
-# Bundle.module and never resolve). Absent model = the live walk silently runs
-# text-only, so say it loudly here instead.
-MODEL="Sources/Resources/ggml-base.en-q5_1.bin"
-if [ ! -f "$MODEL" ]; then
-  echo "NOTE: $MODEL not found — live walks will run TEXT-ONLY (no on-device STT)." >&2
-  echo "      Fetch it (gitignored, ~60 MB):" >&2
-  echo "      curl -L -o apps/ios/$MODEL \\" >&2
-  echo "        https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en-q5_1.bin" >&2
-fi
+# Whisper model fetch (Plan 08 D5, model-download PR): the model must be an
+# APP-TARGET resource under Sources/Resources (Bundle.main — a package
+# resource would land in Bundle.module and never resolve). Default model is
+# small.en (spike RESULTS.md: strictly better WER/hallucination than base.en
+# at every measured SNR, ~free RTF headroom on the Mac proxy) — override with
+# STT_MODEL=base.en for the one-arg revert (matches the `sttmodel=` runtime
+# launch arg in GalleryApp.swift). fetch-whisper-model.sh caches on sha256, so
+# repeat runs of generate.sh don't re-download once the file is verified
+# present.
+#
+# CAVEAT: small.en's promotion is decided on Mac-proxy RTF only — the iPhone
+# T5 device tier (spikes/stt-whisper/RESULTS.md Table 4) is still PENDING, so
+# small.en's on-device RTF is unproven. That's why this stays a one-var
+# revert (STT_MODEL=base.en / sttmodel=base.en) rather than a hard swap.
+STT_MODEL="${STT_MODEL:-small.en}"
+./fetch-whisper-model.sh "$STT_MODEL" || {
+  echo "NOTE: whisper model fetch failed — live walks will run TEXT-ONLY (no on-device STT)." >&2
+  echo "      Retry manually: apps/ios/fetch-whisper-model.sh $STT_MODEL" >&2
+}
 
 xcodegen generate --spec project-real.yml
 echo "==> generated SitewalkGallery.xcodeproj (REAL murmur-core engine active when a key was found)"

--- a/apps/ios/generate.sh
+++ b/apps/ios/generate.sh
@@ -84,10 +84,23 @@ EOF
 # small.en's on-device RTF is unproven. That's why this stays a one-var
 # revert (STT_MODEL=base.en / sttmodel=base.en) rather than a hard swap.
 STT_MODEL="${STT_MODEL:-small.en}"
-./fetch-whisper-model.sh "$STT_MODEL" || {
+if ./fetch-whisper-model.sh "$STT_MODEL"; then
+  # Exactly ONE model may be bundled: project.yml globs Sources/ wholesale, so
+  # if both ggml bins are on disk (e.g. a default small.en run followed by a
+  # STT_MODEL=base.en revert) xcodegen would bundle both and silently fatten
+  # the app by the other model's size. generate.sh owns the bundle contents,
+  # so prune the non-selected model here (fetch-whisper-model.sh stays
+  # single-purpose: fetch + verify only).
+  if [ "$STT_MODEL" = "base.en" ]; then OTHER="small.en"; else OTHER="base.en"; fi
+  OTHER_FILE="Sources/Resources/ggml-$OTHER-q5_1.bin"
+  if [ -f "$OTHER_FILE" ]; then
+    rm -f "$OTHER_FILE"
+    echo "==> removed $OTHER_FILE (only the selected model — $STT_MODEL — is bundled)"
+  fi
+else
   echo "NOTE: whisper model fetch failed — live walks will run TEXT-ONLY (no on-device STT)." >&2
   echo "      Retry manually: apps/ios/fetch-whisper-model.sh $STT_MODEL" >&2
-}
+fi
 
 xcodegen generate --spec project-real.yml
 echo "==> generated SitewalkGallery.xcodeproj (REAL murmur-core engine active when a key was found)"


### PR DESCRIPTION
## Thinking

**Problem.** `generate.sh` printed a curl hint when the whisper model was
missing instead of fetching it, and the bundled default (`base.en`) was
already the *worse* model per the spike's own evidence
(`spikes/stt-whisper/RESULTS.md` Table 4: small.en is 4.7% vs 5.8% WER clean,
2-4pp better under every synthesized noise profile, and 0 vs 4 hallucinated
tokens on jackhammer noise-only audio — at RTF headroom the Mac proxy calls
"~free"). RESULTS.md's own recommendation names small.en "the validated
upgrade" but held the default at base.en pending an ODR/download path — this
PR is that path landing, so the promotion follows.

**Download/verify/cache design.** `apps/ios/fetch-whisper-model.sh`:
- Fetches from the ggerganov HF mirror (the plan's `ggml-org` mirror 401s
  today per the spike's own attribution note — ggerganov serves the same MIT
  weights and is what the spike actually used).
- Both models' sha256 digests are hardcoded (verified against real downloads
  of both files during this PR — see below), not just the default's, so the
  revert path never needs a script change.
- Cache-by-verification, not cache-by-presence: an existing file is
  re-hashed and compared to the pinned digest before being trusted. A stale
  or half-written file gets silently re-fetched rather than silently trusted.
- On a digest mismatch after download, the bad file is deleted and the
  script exits non-zero loudly — it never leaves a corrupt model for
  whisper.cpp to load silently.
- `--force` re-fetches unconditionally (for "I know the pin changed" cases).
- Downloads to a `.part` suffix and renames on success, so a killed download
  never masquerades as a complete file on the next run.

**The promotion-with-unproven-T5 caveat.** The whole small.en-vs-base.en
comparison in RESULTS.md Table 1/4A/4B is measured on an **Apple M4 Max Mac**
via the Metal backend — a proxy, not the target hardware. RESULTS.md Table 4
("iPhone tier") is explicitly marked **PENDING — not run**: small.en's actual
RTF on an iPhone T5-class device is unmeasured. Shipping small.en as the
default is a bet that a 3-5x pessimistic Mac→iPhone slowdown still clears
RTF<1.0 (small.en measured RTF 0.021 on the Mac, so even 10x leaves headroom)
— reasonable, but unproven, which is why this isn't a plain default swap.

**One-arg revert, by construction, not by promise:**
- `apps/ios/fetch-whisper-model.sh base.en` (or `STT_MODEL=base.en
  ./generate.sh`) re-fetches the previously-shipped model — its sha256 stays
  pinned in the script regardless of which one is the default.
- `GalleryApp.swift`'s new `sttmodel=base.en|small.en` launch arg
  (`resolveSttModelPath`) picks which bundled model to load at runtime, with
  fallback to whichever model IS present and a further fallback to
  text-only — never a crash.
- If a device sweep shows small.en missing its RTF bar, reverting is one
  launch arg / one env var, not a source change.

**Rust side:** checked `crates/stt`/`crates/ffi` — `SttConfig`/
`EngineConfig.stt_model_path` are caller-provided (`Option<String>`); no
hardcoded model name or path in Rust. No Rust changes in this PR.

**Scope boundaries respected:** `.github/workflows/release.yml` untouched
(owned by an unmerged branch's CI model-download work, per instructions).
No model binary committed; both filenames stay gitignored (`.gitignore`
now covers `ggml-base.en-q5_1.bin` and `ggml-small.en-q5_1.bin`).

## What changed

- `apps/ios/fetch-whisper-model.sh` (new): sha256-verified, cache-aware
  model downloader; `[base.en|small.en]` positional arg or `MODEL=` env var,
  `--force` to re-fetch.
- `apps/ios/generate.sh`: replaced the curl-hint NOTE with an actual fetch
  call (`STT_MODEL` env var, default `small.en`); a fetch failure degrades
  to a NOTE (text-only walk) rather than aborting generation.
- `apps/ios/build-ffi.sh`: updated the whisper-provisioning comment block to
  match (both models, new script, no more copy-pasted curl command).
- `apps/ios/Sources/App/GalleryApp.swift`: new `sttmodel=` launch arg +
  `resolveSttModelPath` (requested → bundled-fallback → text-only chain).
- `apps/ios/README.md`: documents the fetch step and the `sttmodel=` arg.
- `.gitignore`: added `ggml-small.en-q5_1.bin` alongside the existing
  `ggml-base.en-q5_1.bin` entry.

## Verification

- **Real download ran**: both `ggml-base.en-q5_1.bin` (57 MB) and
  `ggml-small.en-q5_1.bin` (190 MB) were fetched end-to-end from the
  ggerganov HF mirror during this work and their sha256 digests captured
  and pinned into the script:
  - `base.en`: `4baf70dd0d7c4247ba2b81fafd9c01005ac77c2f9ef064e00dcf195d0e2fdd2f`
  - `small.en`: `bfdff4894dcb76bbf647d56263ea2a96645423f1669176f4844a1bf8e478ad30`
- Script logic exercised with fixtures: cache-hit skip (matching sha → no
  re-download), stale-file detection (mismatched sha → automatic
  re-fetch), and corrupt-download handling (mismatch after download →
  file deleted, non-zero exit) — all verified working.
- `nix develop -c cargo test --workspace` — exit 0.
- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` —
  exit 0.
- `cd apps/ios && nix develop -c xcodegen generate` — exit 0 (demo project,
  no xcframework in this worktree).
- `xcodebuild ... build` (outside nix, iPhone 17 sim) — **BUILD SUCCEEDED**.

## Test plan

- [ ] On a machine with the real-core xcframework built, run `./generate.sh`
      and confirm the small.en model downloads and the live walk transcribes.
- [ ] Confirm `sttmodel=base.en` reverts to the base.en model at runtime
      (after `./fetch-whisper-model.sh base.en`).
- [ ] Run the iPhone T5 device sweep (spike RESULTS.md's still-PENDING item)
      before treating small.en as fully validated in production.