### PR TITLE
sac: walk-time photo capture + photo/vocab design pass

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -535,6 +535,16 @@ fileprivate struct FfiConverterString: FfiConverter {
 public protocol MurmurEngineProtocol : AnyObject {
     
     /**
+     * Attaches a photo to a session, optionally to a specific captured item.
+     * The shell writes the bytes FIRST (Plan 11 D4 write order), then calls
+     * this with the resulting filename. `captured_at` is `None` → core
+     * stamps `now()`. Errors: missing/tombstoned session or item -> `Photo`;
+     * an `item_id` not in `session_id` -> `Photo` (InvalidState); a poisoned
+     * lock or persistence failure -> `Photo`.
+     */
+    func addPhoto(sessionId: String, itemId: String?, filename: String, capturedAt: UInt64?) throws  -> PhotoRef
+    
+    /**
      * Add one user vocabulary term (`FactSource::Stated`, D3). Idempotent
      * (case-insensitive). Errors: `Full` at 100 terms, `Empty` for blank input,
      * a poisoned lock, or a persistence failure. Returns the resulting list so
@@ -551,10 +561,28 @@ public protocol MurmurEngineProtocol : AnyObject {
     func beginWalk(jobId: String?, template: String) throws  -> WalkSession
     
     /**
+     * Core's entire file contract (Plan 11 D4): every live photo filename,
+     * across all sessions. The shell sweep deletes any file on disk not in
+     * this set.
+     */
+    func listLivePhotoFilenames() throws  -> [String]
+    
+    /**
+     * Photos attached to a session, insertion order.
+     */
+    func listPhotos(sessionId: String) throws  -> [PhotoRef]
+    
+    /**
      * The user's vocabulary terms, insertion order. Read-only — no lock held
      * across FFI beyond the clone.
      */
     func listVocabulary() throws  -> [String]
+    
+    /**
+     * Tombstones a photo's metadata row. The bytes are reclaimed by the
+     * shell's reconciling sweep (Plan 11 D4), not deleted here.
+     */
+    func removePhoto(photoId: String) throws 
     
     /**
      * Remove one vocabulary term (case-insensitive). Returns the resulting list.
@@ -632,6 +660,25 @@ public convenience init(config: EngineConfig)throws  {
 
     
     /**
+     * Attaches a photo to a session, optionally to a specific captured item.
+     * The shell writes the bytes FIRST (Plan 11 D4 write order), then calls
+     * this with the resulting filename. `captured_at` is `None` → core
+     * stamps `now()`. Errors: missing/tombstoned session or item -> `Photo`;
+     * an `item_id` not in `session_id` -> `Photo` (InvalidState); a poisoned
+     * lock or persistence failure -> `Photo`.
+     */
+open func addPhoto(sessionId: String, itemId: String?, filename: String, capturedAt: UInt64?)throws  -> PhotoRef {
+    return try  FfiConverterTypePhotoRef.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_add_photo(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),
+        FfiConverterOptionString.lower(itemId),
+        FfiConverterString.lower(filename),
+        FfiConverterOptionUInt64.lower(capturedAt),$0
+    )
+})
+}
+    
+    /**
      * Add one user vocabulary term (`FactSource::Stated`, D3). Idempotent
      * (case-insensitive). Errors: `Full` at 100 terms, `Empty` for blank input,
      * a poisoned lock, or a persistence failure. Returns the resulting list so
@@ -661,6 +708,29 @@ open func beginWalk(jobId: String?, template: String)throws  -> WalkSession {
 }
     
     /**
+     * Core's entire file contract (Plan 11 D4): every live photo filename,
+     * across all sessions. The shell sweep deletes any file on disk not in
+     * this set.
+     */
+open func listLivePhotoFilenames()throws  -> [String] {
+    return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_list_live_photo_filenames(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Photos attached to a session, insertion order.
+     */
+open func listPhotos(sessionId: String)throws  -> [PhotoRef] {
+    return try  FfiConverterSequenceTypePhotoRef.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_list_photos(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),$0
+    )
+})
+}
+    
+    /**
      * The user's vocabulary terms, insertion order. Read-only — no lock held
      * across FFI beyond the clone.
      */
@@ -669,6 +739,17 @@ open func listVocabulary()throws  -> [String] {
     uniffi_ffi_fn_method_murmurengine_list_vocabulary(self.uniffiClonePointer(),$0
     )
 })
+}
+    
+    /**
+     * Tombstones a photo's metadata row. The bytes are reclaimed by the
+     * shell's reconciling sweep (Plan 11 D4), not deleted here.
+     */
+open func removePhoto(photoId: String)throws  {try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_remove_photo(self.uniffiClonePointer(),
+        FfiConverterString.lower(photoId),$0
+    )
+}
 }
     
     /**
@@ -977,6 +1058,12 @@ public protocol WalkSessionProtocol : AnyObject {
     func pushAudio(samples: [Float]) 
     
     /**
+     * The store id of this walk's session — so the capture UI can call
+     * `engine.add_photo(session_id, …)` during and after the walk (Plan 11 D7).
+     */
+    func sessionId()  -> String
+    
+    /**
      * Stores the listener (fresh per session — D3/HANDOFF per-session
      * streams).
      */
@@ -1133,6 +1220,17 @@ open func pushAudio(samples: [Float]) {try! rustCall() {
         FfiConverterSequenceFloat.lower(samples),$0
     )
 }
+}
+    
+    /**
+     * The store id of this walk's session — so the capture UI can call
+     * `engine.add_photo(session_id, …)` during and after the walk (Plan 11 D7).
+     */
+open func sessionId() -> String {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_ffi_fn_method_walksession_session_id(self.uniffiClonePointer(),$0
+    )
+})
 }
     
     /**
@@ -1753,6 +1851,101 @@ public func FfiConverterTypeEngineConfig_lower(_ value: EngineConfig) -> RustBuf
 
 
 /**
+ * A display-copy-free projection of `murmur_core::Photo` (D-Plan07 posture):
+ * the shell resolves `filename` to a real file URL under its own
+ * `<Documents>/photos/` directory (Plan 11 D4) — core never touches bytes.
+ */
+public struct PhotoRef {
+    public var id: String
+    public var sessionId: String
+    public var itemId: String?
+    public var filename: String
+    public var capturedAt: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, sessionId: String, itemId: String?, filename: String, capturedAt: UInt64) {
+        self.id = id
+        self.sessionId = sessionId
+        self.itemId = itemId
+        self.filename = filename
+        self.capturedAt = capturedAt
+    }
+}
+
+
+
+extension PhotoRef: Equatable, Hashable {
+    public static func ==(lhs: PhotoRef, rhs: PhotoRef) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.sessionId != rhs.sessionId {
+            return false
+        }
+        if lhs.itemId != rhs.itemId {
+            return false
+        }
+        if lhs.filename != rhs.filename {
+            return false
+        }
+        if lhs.capturedAt != rhs.capturedAt {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(sessionId)
+        hasher.combine(itemId)
+        hasher.combine(filename)
+        hasher.combine(capturedAt)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePhotoRef: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PhotoRef {
+        return
+            try PhotoRef(
+                id: FfiConverterString.read(from: &buf), 
+                sessionId: FfiConverterString.read(from: &buf), 
+                itemId: FfiConverterOptionString.read(from: &buf), 
+                filename: FfiConverterString.read(from: &buf), 
+                capturedAt: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PhotoRef, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.sessionId, into: &buf)
+        FfiConverterOptionString.write(value.itemId, into: &buf)
+        FfiConverterString.write(value.filename, into: &buf)
+        FfiConverterUInt64.write(value.capturedAt, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePhotoRef_lift(_ buf: RustBuffer) throws -> PhotoRef {
+    return try FfiConverterTypePhotoRef.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePhotoRef_lower(_ value: PhotoRef) -> RustBuffer {
+    return FfiConverterTypePhotoRef.lower(value)
+}
+
+
+/**
  * Fallible-path errors that cross the FFI boundary as a thrown error rather
  * than a panic (Plan 07 CANON: no panics across FFI). `flat_error` means the
  * Swift side receives the variant plus its `Display` message — no api key is
@@ -1784,6 +1977,14 @@ public enum EngineError {
      * contains an api key (memory/vocab strings only).
      */
     case Memory(message: String)
+    
+    /**
+     * A photo attachment operation failed (missing/tombstoned session, an
+     * item_id not in the session, an empty/duplicate filename, a poisoned lock,
+     * or a persistence failure). Recoverable — surface, don't crash. Contains
+     * store/validation strings only (never an api key).
+     */
+    case Photo(message: String)
     
 }
 
@@ -1817,6 +2018,10 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 5: return .Photo(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -1836,6 +2041,8 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(3))
         case .Memory(_ /* message is ignored*/):
             writeInt(&buf, Int32(4))
+        case .Photo(_ /* message is ignored*/):
+            writeInt(&buf, Int32(5))
 
         
         }
@@ -1944,6 +2151,30 @@ public func FfiConverterTypeWalkEvent_lower(_ value: WalkEvent) -> RustBuffer {
 extension WalkEvent: Equatable, Hashable {}
 
 
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
+    typealias SwiftType = UInt64?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterUInt64.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterUInt64.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2092,6 +2323,31 @@ fileprivate struct FfiConverterSequenceTypeDocLine: FfiConverterRustBuffer {
         return seq
     }
 }
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypePhotoRef: FfiConverterRustBuffer {
+    typealias SwiftType = [PhotoRef]
+
+    public static func write(_ value: [PhotoRef], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypePhotoRef.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [PhotoRef] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [PhotoRef]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypePhotoRef.read(from: &buf))
+        }
+        return seq
+    }
+}
 private let UNIFFI_RUST_FUTURE_POLL_READY: Int8 = 0
 private let UNIFFI_RUST_FUTURE_POLL_MAYBE_READY: Int8 = 1
 
@@ -2154,13 +2410,25 @@ private var initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_add_photo() != 53149) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_add_vocabulary_term() != 28855) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_begin_walk() != 41375) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_list_live_photo_filenames() != 39240) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_list_photos() != 9711) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_list_vocabulary() != 10809) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_remove_photo() != 8364) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_remove_vocabulary_term() != 40682) {
@@ -2179,6 +2447,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_walksession_push_audio() != 33536) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_walksession_session_id() != 15531) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_walksession_set_event_listener() != 4564) {

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -216,8 +216,17 @@ final class AppModel {
         }
     }
 
-    func addPhoto() {
-        guard let id = lastCapturedID,
+    /// Walk-time capture (Plan 11 D7 / sac design pass): one tap, zero
+    /// confirm — the shot pins to the item being spoken (`lastCapturedID`,
+    /// dam's D3 rule) or attaches session-level when the board is still
+    /// empty. Core ids are canonical-lowercase UUIDv7; `UUID.uuidString`
+    /// is uppercase, so lowercase across the seam. The chip bump is
+    /// optimistic — the next `boardUpdated` carries the core's
+    /// `photoCount` and self-corrects.
+    func addPhoto(_ data: Data) {
+        capturePhoto(image: data, itemId: lastCapturedID?.uuidString.lowercased())
+        guard photoError == nil,
+              let id = lastCapturedID,
               let idx = items.firstIndex(where: { $0.id == id }) else { return }
         items[idx].photos += 1
     }

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import os
 #if canImport(MurmurCoreFFI)
 import MurmurCoreFFI
@@ -271,7 +272,23 @@ struct AppRoot: View {
                 try? await Task.sleep(for: .seconds(1))
                 model.startWalk()
                 // Let the scripted walk play out, then finish it.
-                try? await Task.sleep(for: .seconds(16))
+                try? await Task.sleep(for: .seconds(8))
+                // Screenshot-automation hook: exercise the walk-time photo
+                // path (button → capturePhoto → FFI → gallery) unattended.
+                if ProcessInfo.processInfo.arguments.contains("autophoto=1"),
+                   model.phase == .walking {
+                    let renderer = UIGraphicsImageRenderer(size: CGSize(width: 320, height: 240))
+                    let image = renderer.image { ctx in
+                        UIColor(red: 0.91, green: 0.33, blue: 0.12, alpha: 1).setFill()
+                        ctx.fill(CGRect(x: 0, y: 0, width: 320, height: 240))
+                        UIColor.white.setFill()
+                        ctx.fill(CGRect(x: 24, y: 100, width: 272, height: 40))
+                    }
+                    if let data = image.jpegData(compressionQuality: 0.8) {
+                        model.addPhoto(data)
+                    }
+                }
+                try? await Task.sleep(for: .seconds(8))
                 if model.phase == .walking {
                     model.finishWalk()
                 }
@@ -292,7 +309,7 @@ struct AppRoot: View {
 
 struct GalleryRoot: View {
     enum Dest: String, Hashable, CaseIterable {
-        case components, jobs, capture, document
+        case components, jobs, capture, document, vocab
 
         var title: String {
             switch self {
@@ -300,6 +317,7 @@ struct GalleryRoot: View {
             case .jobs: return "01 · JOBS BOARD"
             case .capture: return "02 · CAPTURE"
             case .document: return "04 · DOCUMENT REVIEW"
+            case .vocab: return "05 · FIELD VOCABULARY"
             }
         }
     }
@@ -360,6 +378,7 @@ struct GalleryRoot: View {
                 case .jobs: JobsBoardScreen(trade: Fixtures.landscape)
                 case .capture: CaptureScreen(trade: Fixtures.landscape)
                 case .document: DocumentReviewScreen(trade: Fixtures.landscape)
+                case .vocab: VocabularyView(model: AppModel())
                 }
             }
         }

--- a/apps/ios/Sources/App/Info.plist
+++ b/apps/ios/Sources/App/Info.plist
@@ -22,6 +22,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Photos you take during a walk pin to the item you're describing and land in the finished document.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Sitewalk records your walk-and-talk so it can turn it into paperwork.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -18,13 +18,23 @@ struct BoardView: View {
                         .tracking(2.0)
                         .foregroundStyle(Theme.C.orangeDeep)
                     Spacer()
-                    // sac: placement/glyph/affordance for the vocabulary editor
-                    // entry point is yours — this gear is a functional default.
+                    // Vocabulary entry: a stamped chip in the tag grammar —
+                    // this is a field tool, not settings, so no gear. Padding
+                    // widens the tap target without growing the stamp.
                     Button { showVocabulary = true } label: {
-                        Image(systemName: "gearshape")
+                        Text("VOCAB")
+                            .font(Theme.F.mono(8, .semibold))
+                            .tracking(1.0)
                             .foregroundStyle(Theme.C.ink60)
+                            .padding(.horizontal, 6)
+                            .padding(.top, 3)
+                            .padding(.bottom, 2)
+                            .background(Theme.C.paperDeep)
+                            .padding(6)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .padding(-6)
                 }
                 Text(model.trade.countTitle)
                     .font(Theme.F.ui(26, .bold))
@@ -74,9 +84,11 @@ struct BoardView: View {
         }
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
-        // sac: sheet vs. push, chrome, and dismissal affordance are yours.
         .sheet(isPresented: $showVocabulary) {
             VocabularyView(model: model)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+                .presentationBackground(Theme.C.paper)
         }
     }
 }

--- a/apps/ios/Sources/Flow/PhotoCapture.swift
+++ b/apps/ios/Sources/Flow/PhotoCapture.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import PhotosUI
+import UIKit
+
+// One-tap field capture. Device = the camera directly (zero chrome, zero
+// confirm — gloves and speed rule out anything else); simulator / no-camera
+// = PhotosPicker fallback so the flow stays exercisable everywhere.
+
+struct CameraCapture: UIViewControllerRepresentable {
+    var onImage: (Data) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    static var isAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ vc: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let parent: CameraCapture
+        init(_ parent: CameraCapture) { self.parent = parent }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let image = info[.originalImage] as? UIImage,
+               let data = image.jpegData(compressionQuality: 0.85) {
+                parent.onImage(data)
+            }
+            parent.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.dismiss()
+        }
+    }
+}

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -128,58 +128,111 @@ struct ReviewView: View {
         }
     }
 
-    // sac: functional-plain — capture button + bare grid, no thumbnails/empty
-    // state polish. Restyle freely; the wiring (PhotosPicker → capturePhoto,
-    // Image(contentsOfFile:) → removePhoto) is what matters here.
+    // The gallery reads as a contact sheet ON the paper, not an iOS grid:
+    // stamped label, ink-bordered thumbnails with PH-nn index stamps, square
+    // ink ✕ remove, dashed empty state, errors in the red note bar.
     private var photoGallery: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("PHOTOS")
-                    .font(Theme.F.mono(11, .medium))
-                    .tracking(1.2)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                SectionLabel("PHOTOS")
+                Text("× \(model.photos.count)")
+                    .font(Theme.F.mono(9, .semibold))
                     .foregroundStyle(Theme.C.ink60)
                 Spacer()
                 PhotosPicker(selection: $photoPickerItem, matching: .images) {
-                    Text("+ ADD PHOTO")
-                        .font(Theme.F.mono(11, .medium))
+                    Text("+ ADD")
+                        .font(Theme.F.mono(9, .semibold))
+                        .tracking(1.2)
                         .foregroundStyle(Theme.C.orangeDeep)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Theme.C.orangeDeep, lineWidth: 1.5)
+                        )
                 }
+                .buttonStyle(.plain)
             }
+
             if let error = model.photoError {
-                Text(error)
-                    .font(Theme.F.mono(10))
-                    .foregroundStyle(.red)
+                HStack(spacing: 0) {
+                    Theme.C.redTag.frame(width: 3)
+                    Text(error.uppercased())
+                        .font(Theme.F.mono(8))
+                        .tracking(0.4)
+                        .foregroundStyle(Theme.C.redTag)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 6)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(Theme.C.redTint)
             }
-            if !model.photos.isEmpty {
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 72))], spacing: 8) {
-                    ForEach(model.photos) { photo in
-                        photoThumbnail(photo)
+
+            if model.photos.isEmpty {
+                Text("NO PHOTOS — USE THE PHOTO BUTTON DURING A WALK, OR ADD HERE")
+                    .font(Theme.F.mono(8))
+                    .tracking(0.6)
+                    .foregroundStyle(Theme.C.ink35)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .padding(.horizontal, 10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                            .foregroundStyle(Theme.C.ink35)
+                    )
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 76), spacing: 10)], alignment: .leading, spacing: 10) {
+                    ForEach(Array(model.photos.enumerated()), id: \.element.id) { index, photo in
+                        photoThumbnail(photo, index: index)
                     }
                 }
             }
         }
     }
 
-    private func photoThumbnail(_ photo: PhotoModel) -> some View {
+    private func photoThumbnail(_ photo: PhotoModel, index: Int) -> some View {
         let url = FileManager.default
             .urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("photos")
             .appendingPathComponent(photo.filename)
-        return ZStack(alignment: .topTrailing) {
-            if let uiImage = UIImage(contentsOfFile: url.path) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 72, height: 72)
-                    .clipped()
-            } else {
-                Rectangle().fill(Theme.C.ink.opacity(0.08)).frame(width: 72, height: 72)
+        return VStack(alignment: .leading, spacing: 3) {
+            ZStack(alignment: .topTrailing) {
+                Group {
+                    if let uiImage = UIImage(contentsOfFile: url.path) {
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
+                    } else {
+                        Rectangle().fill(Theme.C.paperDeep)
+                    }
+                }
+                .frame(width: 76, height: 76)
+                .clipped()
+                .overlay(Rectangle().stroke(Theme.C.ink, lineWidth: 1.5))
+
+                Button { model.removePhoto(photo) } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(Theme.C.paper)
+                        .frame(width: 18, height: 18)
+                        .background(Theme.C.ink)
+                }
+                .buttonStyle(.plain)
             }
-            Button { model.removePhoto(photo) } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.white, .black.opacity(0.6))
+            HStack(spacing: 4) {
+                Text(String(format: "PH-%02d", index + 1))
+                    .font(Theme.F.mono(7, .semibold))
+                    .tracking(0.8)
+                    .foregroundStyle(Theme.C.ink60)
+                if photo.itemId != nil {
+                    // pinned to a spoken item during the walk
+                    Image(systemName: "link")
+                        .font(.system(size: 6, weight: .bold))
+                        .foregroundStyle(Theme.C.orangeDeep)
+                }
             }
-            .padding(2)
         }
     }
 

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -1,47 +1,137 @@
 import SwiftUI
 
-// Vocabulary editor (Plan 10, write half of the vocabulary → STT biasing loop).
+// Field vocabulary (Plan 10, write half of the vocabulary → STT biasing loop).
 //
-// sac: This whole screen is a functional placeholder — visual design is yours.
-// A bare List is used only because the app has none yet; restyle to the Theme
-// (Theme.C / Theme.F / Theme.S) or hand-roll rows like the rest of the app.
-// The onboarding interview (which SEEDS this vocabulary) is out of scope here.
+// Designed as a field tool, not a settings page: the operator teaches the mic
+// the words crews actually say — plant names, part numbers, client names —
+// and whisper biases toward hearing them. Hand-rolled to the Theme; the
+// onboarding interview that SEEDS this list is out of scope (Plan 10 note).
+
 struct VocabularyView: View {
     @Bindable var model: AppModel
     @State private var newTerm = ""
+    @FocusState private var fieldFocused: Bool
+
+    private let cap = 100
 
     var body: some View {
-        List {
-            Section {                                    // sac: header/empty-state design
-                ForEach(model.vocabulary, id: \.self) { term in
-                    Text(term)
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            VStack(alignment: .leading, spacing: 4) {
+                SectionLabel("FIELD VOCABULARY", color: Theme.C.orangeDeep)
+                Text("Teach the mic your jargon")
+                    .font(Theme.F.ui(22, .bold))
+                Text("NAMES, PLANTS, PART NUMBERS — WALKS HEAR THEM BETTER")
+                    .font(Theme.F.mono(8.5))
+                    .tracking(0.8)
+                    .foregroundStyle(Theme.C.ink60)
+                    .padding(.top, 1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Theme.S.screenPad)
+            .padding(.top, 18)
+            .padding(.bottom, 14)
+
+            MetaStrip(
+                left: "TERMS \(model.vocabulary.count) / \(cap)",
+                right: model.vocabulary.count >= cap ? "FULL — REMOVE TO ADD" : "BIASES ON-DEVICE STT",
+                warn: model.vocabulary.count >= cap
+            )
+
+            if let error = model.vocabularyError {
+                HStack(spacing: 0) {
+                    Theme.C.yellowTag.frame(width: 3)
+                    Text(error.uppercased())
+                        .font(Theme.F.mono(8))
+                        .tracking(0.4)
+                        .foregroundStyle(Theme.C.ink60)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 6)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .onDelete { idx in
-                    idx.map { model.vocabulary[$0] }.forEach(model.removeVocabulary)
-                }
+                .background(Theme.C.yellowTint)
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.top, 10)
             }
 
-            Section {                                    // sac: add affordance design (this is placeholder)
-                HStack {
-                    TextField("Add a term", text: $newTerm) // sac: styling / focus / placeholder copy
-                    Button("Add") {
-                        let term = newTerm
-                        newTerm = ""
-                        if !term.trimmingCharacters(in: .whitespaces).isEmpty {
-                            model.addVocabulary(term)
+            // Terms
+            if model.vocabulary.isEmpty {
+                Text("NO TERMS YET — ADD THE WORDS CREWS ACTUALLY SAY.\n\u{201C}BOXWOOD\u{201D} · \u{201C}GFCI\u{201D} · \u{201C}HOLLIS\u{201D}")
+                    .font(Theme.F.mono(8.5))
+                    .tracking(0.6)
+                    .foregroundStyle(Theme.C.ink35)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(5)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 26)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                            .foregroundStyle(Theme.C.ink35)
+                    )
+                    .padding(.horizontal, Theme.S.screenPad)
+                    .padding(.top, 16)
+            } else {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        ForEach(model.vocabulary, id: \.self) { term in
+                            HStack(spacing: 10) {
+                                Text(term)
+                                    .font(Theme.F.mono(12, .medium))
+                                Spacer()
+                                Button { model.removeVocabulary(term) } label: {
+                                    Image(systemName: "xmark")
+                                        .font(.system(size: 10, weight: .bold))
+                                        .foregroundStyle(Theme.C.ink60)
+                                        .frame(width: 30, height: 30)
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 6)
+                                                .stroke(Theme.C.hairline, lineWidth: 1)
+                                        )
+                                }
+                                .buttonStyle(.plain)
+                            }
+                            .padding(.horizontal, Theme.S.screenPad)
+                            .padding(.vertical, 9)
+                            .overlay(alignment: .bottom) { Theme.C.hairlineSoft.frame(height: 1) }
                         }
                     }
                 }
-                // sac: the thrown-error surface (full-at-100, empty, too-long) is
-                // yours to design; this is a bare placeholder.
-                if let error = model.vocabularyError {
-                    Text(error)
-                        .font(.footnote)
-                        .foregroundStyle(.red)
+            }
+
+            Spacer(minLength: 0)
+
+            // Add bar
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    TextField("boxwood, zone 2, Hollis…", text: $newTerm)
+                        .font(Theme.F.mono(14, .medium))
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .focused($fieldFocused)
+                        .padding(.bottom, 6)
+                        .overlay(alignment: .bottom) { Theme.C.orange.frame(height: 2) }
+                    Button {
+                        let term = newTerm.trimmingCharacters(in: .whitespaces)
+                        newTerm = ""
+                        if !term.isEmpty { model.addVocabulary(term) }
+                    } label: {
+                        Text("ADD")
+                            .font(Theme.F.ui(14, .bold))
+                            .tracking(1.4)
+                            .foregroundStyle(Theme.C.paper)
+                            .frame(width: 76, height: 48)
+                            .background(RoundedRectangle(cornerRadius: Theme.S.radius).fill(Theme.C.ink))
+                    }
+                    .buttonStyle(.plain)
                 }
             }
+            .padding(.horizontal, Theme.S.screenPad)
+            .padding(.top, 12)
+            .padding(.bottom, 12)
+            .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
         }
+        .background(Theme.C.paper.ignoresSafeArea())
         .onAppear { model.loadVocabulary() }
-        // sac: title, chrome, navigation style are yours.
     }
 }

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 // Live capture — the walk. Everything readable at arm's length; controls
 // glove-sized in the thumb zone.
@@ -6,6 +7,8 @@ import SwiftUI
 struct WalkView: View {
     @Bindable var model: AppModel
     var scriptedLabel: Bool
+    @State private var showCamera = false
+    @State private var pickerItem: PhotosPickerItem?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -61,8 +64,17 @@ struct WalkView: View {
                     Waveform()
                 }
                 HStack(spacing: 9) {
-                    Button { model.addPhoto() } label: { PhotoSquareButton() }
+                    // One tap, zero confirm: camera on device, picker on sim.
+                    // The shot pins to the item being spoken (see addPhoto).
+                    if CameraCapture.isAvailable {
+                        Button { showCamera = true } label: { PhotoSquareButton() }
+                            .buttonStyle(.plain)
+                    } else {
+                        PhotosPicker(selection: $pickerItem, matching: .images) {
+                            PhotoSquareButton()
+                        }
                         .buttonStyle(.plain)
+                    }
                     Button { model.togglePause() } label: {
                         Text(model.isPaused ? "RESUME" : "PAUSE")
                             .font(Theme.F.ui(13.5, .bold))
@@ -91,5 +103,18 @@ struct WalkView: View {
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
+        .fullScreenCover(isPresented: $showCamera) {
+            CameraCapture { data in model.addPhoto(data) }
+                .ignoresSafeArea()
+        }
+        .onChange(of: pickerItem) { _, newValue in
+            guard let newValue else { return }
+            Task {
+                if let data = try? await newValue.loadTransferable(type: Data.self) {
+                    model.addPhoto(data)
+                }
+                pickerItem = nil
+            }
+        }
     }
 }

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -36,6 +36,7 @@ targets:
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: "Sitewalk records your walk-and-talk so it can turn it into paperwork."
         NSSpeechRecognitionUsageDescription: "Sitewalk transcribes your walk on-device to build your document."
+        NSCameraUsageDescription: "Photos you take during a walk pin to the item you're describing and land in the finished document."
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
         UIAppFonts:

--- a/docs/superpowers/plans/2026-07-06-sac-photo-vocab-design-pass.md
+++ b/docs/superpowers/plans/2026-07-06-sac-photo-vocab-design-pass.md
@@ -1,0 +1,52 @@
+# Plan (sac): photo capture during the walk + photo/vocab design pass
+
+Takes the two `sac:` handoffs from Plans 10/11 (vocabulary editor visuals,
+photo gallery visuals) and closes the walk-time capture gap: the walk screen's
+PHOTO button still runs the pre-Plan-11 fake counter (`items[idx].photos += 1`,
+never touches the engine). The mockup's promise — *photos pin to the item
+being spoken* — becomes real.
+
+## Design decisions
+
+1. **Walk-time capture is one tap, zero confirm.** Gloves and speed rule out a
+   confirm step; the operator taps PHOTO, the camera fires, the shot pins to
+   `lastCapturedID` (the item being spoken — dam's D3 rule), a chip appears.
+   Device = camera (`UIImagePickerController`, the only zero-chrome path);
+   simulator = PhotosPicker fallback. Item id goes across the seam lowercased
+   (core ids are canonical-lowercase UUIDv7; `UUID.uuidString` is uppercase).
+2. **No items yet → session-level photo** (`itemId: nil`). The gallery shows
+   it at review; nothing is refused mid-walk. Chip bump is optimistic; the
+   next `boardUpdated` carries the core's `photoCount` and self-corrects.
+3. **Gallery reads as a contact sheet on the paper**, not an iOS grid: stamped
+   `PHOTOS` label, ink-bordered thumbnails with `PH-01` index stamps, square
+   ink ✕ remove (no `xmark.circle.fill`), dashed empty-state box, errors in
+   the red-tint note bar (same grammar as the yellow RevNote).
+4. **Vocabulary editor is a field tool, not a settings page.** Hand-rolled
+   sheet: title + mono explainer ("names, plants, part numbers — the mic
+   learns them"), `TERMS n / 100` counter, hairline rows with ✕, underlined
+   mono add-field + block ADD button, yellow note bar for engine errors
+   (full-at-100, dup, too-long), dashed empty state. Board entry point:
+   the placeholder gear becomes a stamped `VOCAB` chip (design-language
+   consistent; gear said "settings", this is a tool).
+
+## Tasks
+
+1. `AppModel.addPhoto()` → real: route through `capturePhoto(image:itemId:)`
+   with optimistic chip bump; keep working on the demo engine (it has a
+   session id + photo stubs).
+2. `WalkView`: PHOTO button presents camera (device) / PhotosPicker (sim);
+   `NSCameraUsageDescription` added to project.yml.
+3. `ReviewView.photoGallery` restyle per decision 3.
+4. `VocabularyView` rebuild per decision 4; `BoardView` gear → `VOCAB` chip.
+5. Verification hooks: `autophoto=1` (autoflow injects a generated JPEG
+   mid-walk — proves button-path → FFI → gallery headlessly) and
+   `screen=vocab` (design-QA route). Screenshots: walk chip, review gallery,
+   vocab editor.
+
+## Out of scope (queued)
+
+- Per-item photo grouping on the review document (needs core item ids on
+  `DocRowFixture` rows — seam question for dam).
+- Photos in the PDF (CORE.md v1.1 note).
+- #168 DONE gating (awaiting dam's call on UI-side vs engine signal).
+- Onboarding interview that seeds vocabulary (dam's note in Plan 10).


### PR DESCRIPTION
## Thinking

Closes both Plan 10/11 `sac:` handoffs and the gap the mockup always promised: **photos pin to the item being spoken, captured mid-walk**. Design plan at `docs/superpowers/plans/2026-07-06-sac-photo-vocab-design-pass.md`.

Decisions worth your review: (1) walk-time capture is one tap, zero confirm — camera directly on device, PhotosPicker on sim; item id crosses the seam lowercased (`UUID.uuidString` is uppercase, core ids are canonical-lowercase — silent photoCount mismatch otherwise). (2) Board empty → session-level attach, nothing refused mid-walk; the chip bump is optimistic and self-corrects on the next boardUpdated. (3) The gallery reads as a contact sheet ON the paper (PH-nn stamps, ink borders, square ✕) — not an iOS grid. (4) The vocabulary entry is a stamped VOCAB chip, not a gear: it's a field tool, not settings.

**Note:** stacked on #173 (base-URL plist injection) — that commit is included here; merging this merges both. Verified headlessly via the new `autophoto=1` hook: generated JPEG → `capturePhoto` → FFI → `Documents/photos/` → PH-01 thumbnail in review, on the real engine. `screen=vocab` added as a design-QA route.

## Not in this PR (queued in the plan doc)

Per-item photo grouping on the document (needs core item ids on doc rows — seam question), photos in the PDF, #168 DONE gating (awaiting your call).