### PR TITLE
Move photo capture off the main actor (PR #176 should-fix)

### DIFF
--- a/apps/ios/Sources/App/AppModel+Photos.swift
+++ b/apps/ios/Sources/App/AppModel+Photos.swift
@@ -14,21 +14,63 @@ extension AppModel {
 
     /// sac: the capture UX (camera vs picker, confirm, where the button
     /// lives) is yours. This just wires bytes → FFI.
-    func capturePhoto(image: Data, itemId: String?) {
+    ///
+    /// Off-main (PR #176 should-fix): both the disk write and the FFI
+    /// `attachPhoto` call used to run synchronously on the main actor, and
+    /// the FFI call blocks on a store lock shared with the Rust pump thread —
+    /// enough to stall a tap during live extraction. The call itself stays a
+    /// plain, non-async, fire-and-forget entry point (no call site changes),
+    /// but the body now runs on a chained background `Task` (see
+    /// `photoCaptureChain`): bytes-write and attach happen off the main
+    /// actor, then the tail of the task hops back (implicitly — `AppModel`
+    /// is `@MainActor`) to mutate `photos`/`photoError` and fire
+    /// `onComplete`.
+    ///
+    /// `onComplete` is how `addPhoto` (AppModel.swift, sac's walk-time
+    /// caller) applies its optimistic chip bump AFTER the attach actually
+    /// succeeds, instead of racing it synchronously the way the old code
+    /// implicitly could.
+    ///
+    /// Ordering under rapid taps: captures are chained onto
+    /// `photoCaptureChain` (await the previous capture's Task before
+    /// starting this one), so two quick taps run their bytes-write +
+    /// attach + state mutation sequentially, in tap order — never
+    /// interleaved. (Each capture's own UUID filename is independent either
+    /// way, but chaining also keeps `photos` append order matching capture
+    /// order, which is the nicer UX and avoids relitigating "is
+    /// interleaving actually safe" every time this code changes.)
+    func capturePhoto(image: Data, itemId: String?, onComplete: (@MainActor (Bool) -> Void)? = nil) {
         guard let sessionId = currentSessionId else {
             photoError = "no active session to attach a photo to"
+            onComplete?(false)
             return
         }
         let name = "\(UUID().uuidString).jpg"
-        do {
-            try writePhotoBytes(image, name: name) // bytes FIRST (Plan 11 D4)
-            let photo = try engine.attachPhoto(sessionId: sessionId, itemId: itemId, filename: name, capturedAt: nil)
-            photos.append(photo)
-            photoError = nil
-        } catch {
-            photoLogger.error("capturePhoto failed: \(error, privacy: .public)")
-            // sac: how errors surface is a design call.
-            photoError = "\(error)"
+        let dir = photosDirectory // cheap URL/mkdir; fine on the main actor
+        let engine = self.engine
+        let previous = photoCaptureChain
+        photoCaptureChain = Task { [weak self] in
+            await previous?.value
+            guard let self else { return }
+            do {
+                // bytes FIRST (Plan 11 D4) — off-main disk write.
+                try await Task.detached(priority: .userInitiated) {
+                    try image.write(to: dir.appendingPathComponent(name))
+                }.value
+                // attachPhoto is `async` (WalkEngine seam) so the FFI's
+                // store-lock wait doesn't block the main actor either.
+                let photo = try await engine.attachPhoto(
+                    sessionId: sessionId, itemId: itemId, filename: name, capturedAt: nil
+                )
+                self.photos.append(photo)
+                self.photoError = nil
+                onComplete?(true)
+            } catch {
+                self.photoLogger.error("capturePhoto failed: \(error, privacy: .public)")
+                // sac: how errors surface is a design call.
+                self.photoError = "\(error)"
+                onComplete?(false)
+            }
         }
     }
 
@@ -70,10 +112,6 @@ extension AppModel {
         let dir = docs.appendingPathComponent("photos", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
-    }
-
-    private func writePhotoBytes(_ data: Data, name: String) throws {
-        try data.write(to: photosDirectory.appendingPathComponent(name))
     }
 
     private func photoDirContents() -> [String] {

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -58,6 +58,12 @@ final class AppModel {
     // extension in a different file — Swift's `private` is file-scoped.)
     var photos: [PhotoModel] = []
     var photoError: String?
+    /// Chains capture calls (PR #176 should-fix, AppModel+Photos.swift) so
+    /// rapid taps run their off-main bytes-write + attach sequentially, in
+    /// tap order, rather than interleaving. Not `private`: mutated from
+    /// AppModel+Photos.swift, a same-module extension in a different file —
+    /// Swift's `private` is file-scoped (same pattern as `photos` above).
+    var photoCaptureChain: Task<Void, Never>?
     /// Snapshotted when a walk successfully begins and kept through review
     /// (Plan 11 D7): the real `MurmurEngine` drops its live `WalkSession` once
     /// `finish()` returns, so `engine.currentSessionId` alone would go nil
@@ -223,12 +229,24 @@ final class AppModel {
     /// is uppercase, so lowercase across the seam. The chip bump is
     /// optimistic — the next `boardUpdated` carries the core's
     /// `photoCount` and self-corrects.
+    ///
+    /// PR #176 should-fix: `capturePhoto` now runs its bytes-write + FFI
+    /// attach off the main actor and reports back via `onComplete` instead
+    /// of finishing synchronously. `pinnedID` is snapshotted HERE, before
+    /// the async work starts — matching the old code's implicit behavior
+    /// (it read `lastCapturedID` right after a fully synchronous
+    /// `capturePhoto` call, so it always saw the same value it captured
+    /// with). Re-reading `lastCapturedID` from the completion closure
+    /// instead would risk bumping the WRONG item if a `boardUpdated` lands
+    /// while the attach is in flight.
     func addPhoto(_ data: Data) {
-        capturePhoto(image: data, itemId: lastCapturedID?.uuidString.lowercased())
-        guard photoError == nil,
-              let id = lastCapturedID,
-              let idx = items.firstIndex(where: { $0.id == id }) else { return }
-        items[idx].photos += 1
+        let pinnedID = lastCapturedID
+        capturePhoto(image: data, itemId: pinnedID?.uuidString.lowercased()) { [weak self] success in
+            guard success, let self,
+                  let id = pinnedID,
+                  let idx = self.items.firstIndex(where: { $0.id == id }) else { return }
+            self.items[idx].photos += 1
+        }
     }
 
     func discardWalk() {

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -227,8 +227,21 @@ final class MurmurEngine: WalkEngine {
         session?.sessionId()
     }
 
-    func attachPhoto(sessionId: String, itemId: String?, filename: String, capturedAt: UInt64?) throws -> PhotoModel {
-        let ref = try engine.addPhoto(sessionId: sessionId, itemId: itemId, filename: filename, capturedAt: capturedAt)
+    // Off-main (PR #176 should-fix): `engine.addPhoto` blocks on the same
+    // `std::Mutex` store lock the Rust pump thread holds during live-extraction
+    // commits. Capture the (Sendable, thread-safe-by-design FFI handle)
+    // `engine` reference on the main actor, then run the actual blocking call
+    // on `Task.detached` so the main thread is never held hostage by the lock.
+    // The `await` below is the only suspension point — callers (AppModel,
+    // already `@MainActor`) resume on the main actor exactly where they left
+    // off, no extra hop needed on their end.
+    func attachPhoto(
+        sessionId: String, itemId: String?, filename: String, capturedAt: UInt64?
+    ) async throws -> PhotoModel {
+        let engine = self.engine
+        let ref = try await Task.detached {
+            try engine.addPhoto(sessionId: sessionId, itemId: itemId, filename: filename, capturedAt: capturedAt)
+        }.value
         return Self.photo(ref)
     }
 

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -110,7 +110,18 @@ protocol WalkEngine: AnyObject {
     // its relative filename. Deletion is the reconciling sweep — see
     // sweepPhotoBytes() on AppModel. Throwing: the FFI methods are fallible
     // (missing session, bad item_id, persistence).
-    func attachPhoto(sessionId: String, itemId: String?, filename: String, capturedAt: UInt64?) throws -> PhotoModel
+    //
+    // `attachPhoto` is `async` (PR #176 should-fix): the real implementation's
+    // FFI call takes the same `std::Mutex` store lock the Rust pump thread
+    // contends for during live-extraction commits, so it can block for a
+    // while. `async` lets `MurmurEngine` hop the actual call off the main
+    // actor (`Task.detached`) while the app-facing call site stays a normal
+    // `await` that never blocks the UI thread. `DemoWalkEngine` needs no
+    // change — a synchronous function already satisfies an `async` protocol
+    // requirement.
+    func attachPhoto(
+        sessionId: String, itemId: String?, filename: String, capturedAt: UInt64?
+    ) async throws -> PhotoModel
     func listPhotos(sessionId: String) throws -> [PhotoModel]
     func removePhoto(photoId: String) throws
     func liveLivePhotoFilenames() throws -> [String]   // for the sweep


### PR DESCRIPTION
## Thinking

**Problem:** `capturePhoto` (AppModel+Photos.swift) wrote the JPEG to disk
and called `engine.attachPhoto` synchronously on the main actor. The real
FFI `attachPhoto` takes the same `std::Mutex` store lock the Rust pump
thread contends for during live-extraction commits — a capture mid-walk
could stall the tap while that lock is held.

**Actor-hop design:** rather than making `capturePhoto`/`addPhoto` `async`
(which would ripple into every call site — WalkView's `CameraCapture`
closure, the `PhotosPicker` `onChange` handlers, ReviewView, GalleryApp's
autoflow hook), I kept both entry points **synchronous, fire-and-forget**
and moved the work inside into a background `Task`:

- `WalkEngine.attachPhoto` becomes `async throws` at the protocol level.
  `MurmurEngine.attachPhoto` captures the FFI `engine` handle and runs the
  actual blocking call inside `Task.detached`, `await`-ing the result — the
  suspension point is where the main actor gets freed up.
  `DemoWalkEngine` needs zero changes: a synchronous function already
  satisfies an `async` protocol requirement in Swift.
- `capturePhoto` now chains its body onto a new `photoCaptureChain: Task<Void, Never>?`
  on `AppModel`. Inside that chained task: the disk write runs on
  `Task.detached`, the (now-async) `attachPhoto` call is `await`-ed off the
  main actor, and only the tail — appending to `photos`, clearing/setting
  `photoError`, and firing a new `onComplete` callback — touches
  `@MainActor` state (implicitly, since `AppModel` is `@MainActor` and the
  task inherits that isolation).
- `addPhoto` (sac's walk-time caller, #176) moves its optimistic chip-bump
  into `onComplete`.

**Rapid-tap ordering — chose serialization over "prove independence":**
each capture's UUID filename is independent end-to-end, so two concurrent
captures technically can't corrupt each other's bytes/photo pairing. But I
chained captures onto `photoCaptureChain` anyway (`await previous?.value`
before starting) rather than leaning purely on that independence argument:
it keeps `photos` append order matching tap order (nicer UX — a contact
sheet where photos jump out of order on rapid taps would be confusing),
and it means nobody has to re-litigate "is interleaving actually safe"
every time this code changes. The cost is small (one extra `await` per
capture, still off the main thread).

**Invariants preserved:**
- **Bytes-first-then-attach ordering:** unchanged — the disk write still
  happens before `attachPhoto` is called, inside the same chained task, so
  a crash between the two still leaves an orphan file the app-open sweep
  reaps, never a DB row without bytes.
- **Lowercased item-id at the seam:** `addPhoto` still passes
  `lastCapturedID?.uuidString.lowercased()` unchanged.
- **Optimistic chip-bump semantics:** still applies only on a successful
  attach (now signaled via `onComplete(true)` instead of a synchronous
  `photoError == nil` check), still self-corrects on the next
  `boardUpdated`. One subtlety: the target item id (`pinnedID`) is now
  snapshotted from `lastCapturedID` **before** the async work starts and
  reused in the completion closure, rather than re-reading
  `lastCapturedID` after the fact. This matches the *old* code's implicit
  behavior (which was fully synchronous, so it always saw the same value)
  and avoids a new failure mode where a `boardUpdated` landing mid-capture
  could bump the wrong item.
- **Error path:** `photoError` is still set on the main actor in the catch
  branch; `onComplete(false)` fires so `addPhoto` skips the bump.

**No Rust changes:** the FFI methods stay synchronous `&self` — they just
run on a background executor (`Task.detached`) from the Swift side now.

## Test plan
- [x] `cargo test --workspace` — all pass (untouched, ran anyway)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `xcodegen generate` (demo project) — succeeds
- [x] `xcodebuild ... build` (demo scheme, iPhone 17 sim, outside nix shell) — `BUILD SUCCEEDED`
- [x] `swiftlint lint` on all changed files — clean
- [x] `MurmurEngine.swift` (compiled out of the demo build via
      `#if canImport(MurmurCoreFFI)`) syntax-checked with `swiftc -parse`
      since the FFI xcframework isn't built in this environment