### PR TITLE
CI: fail on stale committed UniFFI Swift bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,45 @@ jobs:
       - name: cargo clippy --workspace --all-targets -- -D warnings
         run: nix develop -c cargo clippy --workspace --all-targets -- -D warnings
 
+  ffi-bindings-drift:
+    name: FFI bindings drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+
+      # Same cache key as the `rust` job — this job builds `ffi` (release,
+      # host target, no `whisper` feature) via the same workspace, so it can
+      # reuse those artifacts instead of recompiling from scratch.
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      # Regenerates apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+      # from the current crates/ffi Rust source (host build only — no iOS
+      # cross-compilation; uniffi's proc-macro metadata is platform-independent,
+      # see apps/ios/check-bindings.sh for the full argument) and fails if it
+      # differs from the committed copy. Catches the drift that shipped stale
+      # in PR #176 (regenerated late) and PR #179 (caught only at final review).
+      - name: Check committed Swift bindings are up to date
+        run: ./apps/ios/check-bindings.sh
+
   ios-demo:
     name: iOS demo build (simulator)
     runs-on: macos-latest

--- a/apps/ios/check-bindings.sh
+++ b/apps/ios/check-bindings.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fails if the committed Swift bindings (Sources/MurmurCoreFFI/ffi.swift) are
+# stale relative to the current crates/ffi Rust source.
+#
+# Unlike build-ffi.sh, this does NOT cross-compile for iOS. uniffi's
+# proc-macro mode (uniffi::setup_scaffolding!) embeds the interface metadata
+# that uniffi-bindgen reads directly into the compiled library at a fixed
+# link-time section, regardless of target platform — the Swift *source* that
+# comes out is a function of the Rust interface surface only, not of the host
+# triple. So a plain host build (`cargo build -p ffi --release`, whisper
+# feature OFF — same hermetic/no-model build already exercised by
+# `cargo test --workspace`) is enough to regenerate ffi.swift and compare it
+# byte-for-byte against the committed copy. This runs on Linux CI (cheap) as
+# well as macOS dev machines; see the CI workflow's "FFI bindings drift" job.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."   # repo root
+FFI_SWIFT="apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift"
+OUT_DIR="$(mktemp -d)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+echo "==> building crates/ffi (host, release, no whisper feature)"
+nix develop -c cargo build -p ffi --release
+
+LIBDIR="target/release"
+if [ -f "$LIBDIR/libffi.dylib" ]; then
+  LIB="$LIBDIR/libffi.dylib"
+elif [ -f "$LIBDIR/libffi.so" ]; then
+  LIB="$LIBDIR/libffi.so"
+else
+  echo "error: no libffi.{dylib,so} found in $LIBDIR after build" >&2
+  exit 1
+fi
+
+echo "==> generating Swift bindings from $LIB"
+nix develop -c cargo run -p ffi --features uniffi-bindgen-cli --bin uniffi-bindgen -- \
+  generate --library "$LIB" --language swift --out-dir "$OUT_DIR"
+
+if ! diff -u "$FFI_SWIFT" "$OUT_DIR/ffi.swift" > "$OUT_DIR/diff.txt"; then
+  echo ""
+  echo "error: committed Swift bindings are STALE." >&2
+  echo "The Rust FFI surface (crates/ffi) has changed but $FFI_SWIFT was not regenerated." >&2
+  echo "Fix: run ./apps/ios/build-ffi.sh and commit the updated ffi.swift." >&2
+  echo ""
+  echo "diff (committed vs freshly generated):" >&2
+  cat "$OUT_DIR/diff.txt" >&2
+  exit 1
+fi
+
+echo "==> ffi.swift is up to date."


### PR DESCRIPTION
## Thinking

**The bug pattern.** `apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift` is committed (it's Swift source consumers of the package need; the xcframework binary is gitignored). CI's `ios-demo` job only builds the demo Xcode project (`project.yml`, no `MurmurCoreFFI` dependency — `#if canImport(MurmurCoreFFI)` compiles out real-core code), so nothing in CI ever notices when `crates/ffi`'s Rust surface changes but `ffi.swift` doesn't get regenerated. That's exactly what happened twice: PR #176 regenerated bindings late in review, and PR #179 shipped with stale bindings until the final human review caught it. Both times the fix existed (`./apps/ios/build-ffi.sh`); the failure was that nothing *forced* it to run.

**The host-dylib mechanism.** `crates/ffi` uses uniffi 0.28 in proc-macro mode (`uniffi::setup_scaffolding!()` + `#[derive(uniffi::...)]`/`#[uniffi::export]`, no UDL, no build.rs). The interface metadata `uniffi-bindgen` reads to produce `ffi.swift` is embedded by the proc macros into a fixed link section of the compiled library at *compile time* — it describes the Rust interface surface, not the target triple. `build-ffi.sh` builds `crates/ffi` for `aarch64-apple-ios-sim`/`aarch64-apple-ios` only because it *also* needs the `.xcframework` binary slices; the Swift bindings step in that script is separable and only needs *some* compiled `libffi.{dylib,so,a}` to read metadata from — any host build works.

I verified this directly: `nix develop -c cargo build -p ffi --release` (host target, `whisper` feature off — same hermetic build `cargo test --workspace` already exercises) produces `target/release/libffi.dylib`; running `uniffi-bindgen generate --library target/release/libffi.dylib --language swift` against it produced a `ffi.swift` byte-identical to the committed one (`diff` exit 0). No iOS cross-compilation, no Xcode toolchain, no `xcodebuild -create-xcframework` needed for this check.

**Platform determinism.** `crates/ffi` is already a normal workspace member (`Cargo.toml` `members`) built and tested by the existing `rust` CI job on `ubuntu-latest` — so the host build path is proven to work on Linux already, no macOS runner required for this new job. The committed `ffi.swift` header has no timestamps or absolute paths baked in (checked), and the devShell pins the Rust/uniffi toolchain via `flake.lock`, so CI and any dev machine on the same lockfile produce byte-identical output. This is why the new "FFI bindings drift" job runs on `ubuntu-latest`, reusing the same Nix + cargo caches as the `rust` job, instead of paying for a `macos-latest` runner.

**Both-ways proof** (run in-worktree before opening this PR):
- Clean state: `./apps/ios/check-bindings.sh` → exit 0, "ffi.swift is up to date."
- Drift: added a dummy `Option<String>` field to `ffi::photos::PhotoRef` (and its one constructor site) → `./apps/ios/check-bindings.sh` → exit 1, printed `error: committed Swift bindings are STALE. ... Fix: run ./apps/ios/build-ffi.sh and commit the updated ffi.swift.` plus the actual Swift diff. Reverted the dummy field before committing this PR (not part of the diff).

## What changed

- `apps/ios/check-bindings.sh` (new): host-builds `crates/ffi` (release, no `whisper` feature), runs `uniffi-bindgen` against the resulting dylib/so, diffs against the committed `ffi.swift`, exits nonzero with a fix-it message on drift. Runnable locally too.
- `.github/workflows/ci.yml`: new `ffi-bindings-drift` job (`ubuntu-latest`, same Nix/cargo cache keys as `rust`) that runs the script.

## Test plan

- [x] `nix develop -c cargo test --workspace` — exit 0
- [x] `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `./apps/ios/check-bindings.sh` on clean tree — exit 0
- [x] `./apps/ios/check-bindings.sh` with a deliberately-added Rust field — exit 1, correct message
- [ ] New CI job runs and passes on this PR itself