### PR TITLE
ios: default to live mic walk on physical devices

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -14,7 +14,7 @@ private let engineLog = Logger(subsystem: "com.damsac.sitewalk", category: "engi
 //
 // Launch arguments (used by design QA and screenshot automation):
 //   screen=components|jobs|capture|document  → static design gallery pages
-//   live=1                                   → real mic + on-device STT
+//   live=1 / live=0                          → force mic+STT / scripted (default: live on device, scripted on sim)
 //   autoflow=1                               → auto-starts a scripted walk and
 //                                              auto-finishes it (state machine demo)
 //   demo=1                                   → force DemoWalkEngine even if a
@@ -30,8 +30,7 @@ private let engineLog = Logger(subsystem: "com.damsac.sitewalk", category: "engi
 //                                              revert to base.en: small.en's
 //                                              on-device RTF is Mac-proxy
 //                                              evidence only — the iPhone T5
-//                                              tier is still PENDING in
-//                                              spikes/stt-whisper/RESULTS.md.
+//                                              tier is PENDING in spikes/stt-whisper/RESULTS.md.
 
 /// Engine selection (Plan 07 D10/Task 11): real `MurmurEngine` when an API
 /// key + config resolve, `DemoWalkEngine` when launched with `demo=1` OR
@@ -82,6 +81,20 @@ private func resolveSttKnobs(_ args: [String]) -> SttKnobs {
     engineLog.notice("stt gpu=\(useGpu, privacy: .public)")
     engineLog.notice("stt vad_rms=\(vadRms, privacy: .public) no_speech_prob=\(noSpeechProb, privacy: .public)")
     return SttKnobs(useGpu: useGpu, vadRms: vadRms, noSpeechProb: noSpeechProb)
+}
+
+/// Live-mic vs. scripted text walk. `live=1`/`live=0` always win. Default:
+/// scripted on sim (Metal STT SIGTRAPs on MTLSimDevice; QA assumes scripted),
+/// **live** on device. CAVEAT: small.en's on-device RTF is unmeasured (see
+/// resolveSttModelPath) — `sttmodel=base.en`/`live=0` reverts if too slow.
+private func resolveLive(_ args: [String]) -> Bool {
+    if args.contains("live=1") { return true }
+    if args.contains("live=0") { return false }
+    #if targetEnvironment(simulator)
+    return false
+    #else
+    return true
+    #endif
 }
 
 /// Resolves the bundled whisper model path from the `sttmodel=base.en|small.en`
@@ -200,7 +213,7 @@ struct RootRouter: View {
             GalleryRoot()
         } else {
             AppRoot(
-                live: Self.args.contains("live=1"),
+                live: resolveLive(Self.args),
                 wavwalk: Self.args.contains("wavwalk=1"),
                 demo: Self.args.contains("demo=1"),
                 voiceProcessing: Self.args.contains("voiceproc=1"),


### PR DESCRIPTION
## Thinking

**Problem.** `GalleryApp.swift` resolved `live` purely from the `live=1` launch
arg (`RootRouter.args.contains("live=1")`). Icon-tap launches (no args) always
got `live=false` → `scripted: true` in `AppModel`. On a real device with the
real `MurmurEngine`, that means a field-test launch silently runs the scripted
demo text — no mic, no STT — even though the whole point of a device build is
to exercise the live path.

**Why device-only.** Flipping the default everywhere would break the simulator:
Metal STT SIGTRAPs on `MTLSimDevice` (`ggml_metal_buffer_set_tensor`, see the
existing comment on `resolveSttKnobs`), and the screenshot/QA automation
(`autoflow=`, `autophoto=1`, CI's demo build check) is built around the
scripted flow — those must keep working unattended, with no explicit `live=`
arg, on the simulator. So the flip is gated on
`#if targetEnvironment(simulator)`: unchanged (scripted) on sim, live on a
physical device. Explicit `live=1`/`live=0` always win, on either platform —
nothing about existing QA/automation invocations changes.

**Precedence table** (`resolveLive`, called once in `RootRouter`):

| Launch args present                | Result                    | Notes |
|---|---|---|
| `live=1`                           | live (mic)                | explicit, wins everywhere |
| `live=0`                           | scripted                  | explicit, wins everywhere — the on-device escape hatch |
| `wavwalk=1` (no `live=`)           | non-scripted, WAV fixture | `wavwalk` is read independently of `live`/`resolveLive` in `RootRouter`; `whisperWalk = live || wavwalk` makes AppModel non-scripted either way, and `AppModel.startAudioSource` unconditionally prefers the WAV fixture over the mic whenever `wavFixture` is true — `wavwalk=1` always wins the *audio source* choice regardless of what `resolveLive` returns |
| `wavwalk=1` + `live=1`             | non-scripted, WAV fixture | same as above — `wavwalk` still wins the source pick |
| neither `live=` nor `wavwalk=`, simulator | scripted            | unchanged from before this PR |
| neither `live=` nor `wavwalk=`, device    | **live (mic)**      | the flip this PR makes |
| `screen=...`                       | n/a — `RootRouter` routes to `GalleryRoot` (static design gallery) before `resolveLive` is ever consulted | unaffected |
| `autoflow=N`                       | independent — drives `AppModel.startWalk()`/`finishWalk()` timing; does not touch `live`/`scripted` itself | on sim, still scripted by default as today; would only run live if someone *also* deliberately ran it on a device build with the new default (or `live=1`), which is out of scope for the existing screenshot automation (sim-only) |
| `autophoto=1`                      | independent — walk-time photo capture hook inside the `autoflow` loop | unaffected |

**T5 caveat.** `spikes/stt-whisper/RESULTS.md` validates small.en's WER/
hallucination advantage on Mac-proxy hardware only — the iPhone T5 on-device
RTF tier is still PENDING. Flipping the *default* to live on device means
dam's upcoming field test is the first real signal on that axis. Documented
at the flip (`resolveLive`'s doc comment) rather than buried in
`resolveSttModelPath`'s existing comment, since this is the new place where a
live walk actually starts by default: `sttmodel=base.en` is the one-arg
fallback, `live=0` is the full revert to scripted.

**Mic permission.** `apps/ios/project.yml` already sets
`NSMicrophoneUsageDescription` in the `Info.plist` template (unchanged) — a
device-default live launch prompts correctly instead of crashing on first
`AVAudioSession` access.

**Demo engine interaction.** Unaffected in the sense that no key → `demo`
regardless of `live`. But worth flagging: `DemoWalkEngine.pushAudio` is a
no-op (`// The scripted demo drives the board from TEXT (append), never
audio.`), so a demo+live combination (no API key, but `live` resolves true)
starts real mic capture and STT plumbing but the board never updates — same
pre-existing behavior as `live=1` today with no key, not something this PR
changes or needs to fix, just noting it since the new device default makes
that combination easier to hit accidentally (no key configured + real
device).

## Diff

Minimal: one new `resolveLive(_:)` helper (device/sim `#if`, `live=1`/`live=0`
override) called from `RootRouter`, plus a doc-comment update to the existing
launch-args block. No refactor.

## Gates

- `cargo test --workspace` (untouched by this change, ran anyway): exit 0, 34 unit tests + doctests pass
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0, clean
- `cd apps/ios && xcodegen generate`: succeeds
- `xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17' build` (outside the nix shell): `** BUILD SUCCEEDED **`, exit 0
- No device CI exists; the device branch of the `#if` was reviewed by eye (see below).

## Device branch (quoted in full, reviewed by eye — no CI covers this)

```swift
private func resolveLive(_ args: [String]) -> Bool {
    if args.contains("live=1") { return true }
    if args.contains("live=0") { return false }
    #if targetEnvironment(simulator)
    return false
    #else
    return true
    #endif
}
```

## Test plan

- [ ] dam: icon-tap launch on a physical iPhone starts a live mic walk (permission prompt appears, board updates from real speech)
- [ ] `live=0` on the same device build reverts to scripted
- [ ] Simulator icon-tap launch (no args) is still scripted, unchanged
- [ ] `autoflow=1 autophoto=1` screenshot automation on sim still completes unattended