### PR TITLE
TestFlight release pipeline (rebuild era) — ARMS auto-publish on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,79 @@
-# ⚠️ ERA-I PIPELINE — builds the retired Swift app (project.yml/Makefile removed in
-# the 2026-07-05 re-unification). It will NOT succeed against the current Rust +
-# apps/ios tree. Trigger reduced to manual-only (workflow_dispatch) so it never
-# auto-fires; kept as reference. A rebuild-era TestFlight pipeline (apps/ios via
-# xcodegen/build-ffi.sh) must replace this before the next external build.
+# TestFlight release pipeline — REBUILD ERA (Rust core + apps/ios shell).
 #
-# TestFlight release pipeline.
+# This file was rewritten in place on 2026-07-05 for the rebuilt app. The Era-I
+# version (Swift-era app, project.yml/Makefile) is preserved in git history —
+# `git log --follow .github/workflows/release.yml`. It is REWRITTEN IN PLACE (not
+# a new file) on purpose: `github.run_number` is per-workflow-file, so reusing
+# this file keeps the build-number counter monotonic vs the Era-I builds already
+# on App Store Connect. A fresh workflow file would restart run_number at 1 and
+# collide with existing (MARKETING_VERSION, build) pairs in TestFlight.
+#
+# WHAT'S IDENTICAL to Era-I (the proven signing blueprint):
+#   - archive with AUTOMATIC signing (CODE_SIGN_STYLE=Automatic +
+#     -allowProvisioningUpdates + ASC API key -> Apple cloud-generates the
+#     Distribution cert & profile)
+#   - export with MANUAL signing (ExportOptions signingStyle=manual, explicit
+#     provisioningProfiles dict, cert imported via import-codesign-certs, profile
+#     via download-provisioning-profiles, NO -allowProvisioningUpdates on export —
+#     cloud signing fails there under an App Manager key)
+#   - bundle id com.isaacwm.murmur + "Murmur App Store" profile (reused)
+#   - build number = github.run_number; tag v* overrides MARKETING_VERSION
+#   - the brew install||true / brew link --overwrite pattern; XcodeGen #691 guard
+#
+# WHAT CHANGED for the rebuild:
+#   - builds the REAL Rust core: apps/ios/build-ffi.sh --features whisper
+#     --device-only produces the MurmurCoreFFI xcframework on the runner (no nix;
+#     rustup cargo + system Xcode toolchain). Device-only halves the whisper.cpp
+#     compile — a TestFlight archive is device-only anyway.
+#   - provisions the on-device whisper model via apps/ios/fetch-whisper-model.sh
+#     (sha256-pinned, small.en default, ~190 MB) cached with actions/cache.
+#   - project-release.yml (xcodegen) replaces the removed project.yml/Makefile.
+#   - export uses destination=export (produces a signed .ipa artifact); the ASC
+#     upload is a SEPARATE, conditional altool step so a dry-run can verify the
+#     whole chain through signing without publishing.
+#   - NO App Group, NO entitlements, NO analytics injection: apps/ios uses none
+#     (it reads only PPQ_API_KEY from Info.plist) — simpler than Era-I.
 #
 # Two release lanes:
-#   - Push to main         → internal TestFlight (continuous; team dogfoods)
-#   - Push tag (v1.2.3)    → external TestFlight (requires manual ASC submission)
-#
-# Both lanes upload to the same TestFlight via the same job. Internal vs external
-# is configured ONCE in App Store Connect (auto-distribute new builds to internal
-# group; external assignment + beta review stays manual after a tag build lands).
+#   - Push to main         -> internal TestFlight (continuous; team dogfoods)
+#   - Push tag (v1.2.3)     -> external candidate (MARKETING_VERSION from the tag)
+#   - workflow_dispatch     -> dry-run by default (upload=false): builds, signs,
+#                              exports the .ipa artifact, SKIPS the ASC upload.
+#                              Set upload=true to publish a manual build.
 #
 # Setup steps (one-time, outside CI) are documented in meta/TESTFLIGHT_CI_SETUP.md.
 #
 # Required GitHub secrets:
-#   APPLE_TEAM_ID                       Apple Developer Team ID (10-char)
-#   ASC_API_KEY_ID                      App Store Connect API key ID
-#   ASC_API_ISSUER_ID                   App Store Connect issuer UUID
-#   ASC_API_KEY_P8                      Full contents of AuthKey_*.p8 (text)
-#   PPQ_API_KEY                         PPQ.ai API key (baked into Info.plist)
-#   STUDIO_ANALYTICS_API_KEY_RELEASE    Studio Analytics key for Release config
+#   APPLE_TEAM_ID          Apple Developer Team ID (98GXNZ6NKZ)
+#   ASC_API_KEY_ID         App Store Connect API key ID (App Manager role)
+#   ASC_API_ISSUER_ID      App Store Connect issuer UUID
+#   ASC_API_KEY_P8         Full contents of AuthKey_*.p8 (text, not base64)
+#   APPLE_CERT_P12         base64 Apple Distribution cert + private key (.p12)
+#   APPLE_CERT_PASSWORD    password for the .p12
+#   PPQ_API_KEY            LLM API key (expanded into Info.plist at build time)
 
 name: Release
 
 on:
-  workflow_dispatch:   # manual only — Era-I; see header. Was: push to main + v* tags.
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: 'Upload the signed build to TestFlight (false = dry-run: build + sign + export .ipa only)'
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
+
+env:
+  # Model choice + sha256 digests live in apps/ios/fetch-whisper-model.sh (the
+  # same script ./generate.sh uses locally) — this is the default it fetches.
+  WHISPER_MODEL: small.en
+  MODEL_FILENAME: ggml-small.en-q5_1.bin
 
 jobs:
   release:
@@ -50,14 +92,21 @@ jobs:
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/xcodegen
             /opt/homebrew/Cellar/xcbeautify
-          key: brew-${{ runner.os }}-xcodegen-xcbeautify
+          key: brew-${{ runner.os }}-xcodegen-xcbeautify-cmake
 
       - name: Install tools
         run: |
-          brew install xcodegen xcbeautify || true
+          brew install xcodegen xcbeautify cmake || true
           brew link --overwrite xcodegen xcbeautify || true
 
-      - name: Determine version
+      - name: Set up Rust (iOS device target)
+        run: |
+          rustup show active-toolchain || rustup default stable
+          # Device slice is what ships (the archive is device-only). build-ffi.sh
+          # runs --device-only in CI, so only the device target is required.
+          rustup target add aarch64-apple-ios
+
+      - name: Determine version, lane, and upload flag
         id: version
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
@@ -66,52 +115,60 @@ jobs:
               echo "::error::Tag '$TAG' does not match v<major>.<minor>.<patch>"
               exit 1
             fi
-            VERSION="${TAG#v}"
-            echo "marketing_version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "lane=external" >> "$GITHUB_OUTPUT"
-            echo "Release lane: external (tag $TAG → MARKETING_VERSION=$VERSION)"
+            MARKETING_VERSION="${TAG#v}"
+            LANE=external
+            UPLOAD=true
+            echo "Release lane: external (tag $TAG -> MARKETING_VERSION=$MARKETING_VERSION)"
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            MARKETING_VERSION=""
+            LANE=manual
+            UPLOAD="${{ github.event.inputs.upload }}"
+            echo "Release lane: manual (upload=$UPLOAD)"
           else
-            echo "marketing_version=" >> "$GITHUB_OUTPUT"
-            echo "lane=internal" >> "$GITHUB_OUTPUT"
-            echo "Release lane: internal (using MARKETING_VERSION from project.yml)"
+            MARKETING_VERSION=""
+            LANE=internal
+            UPLOAD=true
+            echo "Release lane: internal (MARKETING_VERSION from project-release.yml)"
           fi
+          {
+            echo "marketing_version=$MARKETING_VERSION"
+            echo "lane=$LANE"
+            echo "upload=$UPLOAD"
+          } >> "$GITHUB_OUTPUT"
           echo "Build number: ${{ github.run_number }}"
 
-      - name: Configure project.local.yml
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PPQ_API_KEY: ${{ secrets.PPQ_API_KEY }}
-          STUDIO_ANALYTICS_API_KEY_RELEASE: ${{ secrets.STUDIO_ANALYTICS_API_KEY_RELEASE }}
+      - name: Cache whisper model
+        id: model-cache
+        uses: actions/cache@v4
+        with:
+          path: apps/ios/Sources/Resources/${{ env.MODEL_FILENAME }}
+          # Keyed on the fetch script itself (not a duplicated sha literal here)
+          # so a digest/model bump in the script busts the cache automatically.
+          key: whisper-model-${{ env.WHISPER_MODEL }}-${{ hashFiles('apps/ios/fetch-whisper-model.sh') }}
+
+      - name: Download and verify whisper model
         run: |
-          if [ -z "$APPLE_TEAM_ID" ]; then
-            echo "::error::APPLE_TEAM_ID secret not set"
-            exit 1
-          fi
-          cat > project.local.yml << EOF
-          settings:
-            base:
-              DEVELOPMENT_TEAM: $APPLE_TEAM_ID
-              PRODUCT_BUNDLE_IDENTIFIER_MURMUR: com.isaacwm.murmur
-              PRODUCT_BUNDLE_IDENTIFIER_TESTS: com.isaacwm.murmur.tests
-              APP_GROUP_IDENTIFIER: group.com.isaacwm.murmur.shared
-              PPQ_API_KEY: "$PPQ_API_KEY"
-            configs:
-              Release:
-                STUDIO_ANALYTICS_ENDPOINT: "https://damsac.studio"
-                STUDIO_ANALYTICS_API_KEY: "$STUDIO_ANALYTICS_API_KEY_RELEASE"
-          EOF
+          cd apps/ios
+          ./fetch-whisper-model.sh "$WHISPER_MODEL"
 
       - name: Materialize ASC API key
         env:
           ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
         run: |
           if [ -z "$ASC_API_KEY_P8" ]; then
             echo "::error::ASC_API_KEY_P8 secret not set"
             exit 1
           fi
+          # For xcodebuild -authenticationKeyPath (archive step).
           mkdir -p "$RUNNER_TEMP/private_keys"
           printf '%s' "$ASC_API_KEY_P8" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
           chmod 600 "$RUNNER_TEMP/private_keys/AuthKey.p8"
+          # For `xcrun altool --upload-app`, which auto-discovers the key by ID
+          # from ~/.appstoreconnect/private_keys/AuthKey_<KEYID>.p8.
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$ASC_API_KEY_P8" > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8"
 
       - name: Import Apple Distribution certificate
         uses: Apple-Actions/import-codesign-certs@v3
@@ -128,12 +185,20 @@ jobs:
           api-key-id: ${{ secrets.ASC_API_KEY_ID }}
           api-private-key: ${{ secrets.ASC_API_KEY_P8 }}
 
-      - name: Generate Xcode project
-        run: make generate
+      - name: Build MurmurCoreFFI xcframework (real core)
+        run: |
+          cd apps/ios
+          ./build-ffi.sh --features whisper --device-only
+
+      - name: Generate Xcode project (release spec)
+        run: |
+          cd apps/ios
+          xcodegen generate --spec project-release.yml
 
       - name: Debug build settings
         run: |
-          xcodebuild -project Murmur.xcodeproj -scheme Murmur -showBuildSettings -configuration Release 2>/dev/null \
+          xcodebuild -project apps/ios/SitewalkGallery.xcodeproj -scheme SitewalkGallery \
+            -showBuildSettings -configuration Release 2>/dev/null \
             | grep -E "^\s+(CODE_SIGN|DEVELOPMENT_TEAM|PROVISIONING|PRODUCT_BUNDLE_ID|MARKETING_VERSION|CURRENT_PROJECT_VERSION)" \
             | sort -u
 
@@ -149,7 +214,7 @@ jobs:
             <key>method</key>
             <string>app-store-connect</string>
             <key>destination</key>
-            <string>upload</string>
+            <string>export</string>
             <key>signingStyle</key>
             <string>manual</string>
             <key>teamID</key>
@@ -170,19 +235,25 @@ jobs:
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
           ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PPQ_API_KEY: ${{ secrets.PPQ_API_KEY }}
           MARKETING_VERSION_OVERRIDE: ${{ steps.version.outputs.marketing_version }}
         run: |
+          if [ -z "$APPLE_TEAM_ID" ]; then
+            echo "::error::APPLE_TEAM_ID secret not set"
+            exit 1
+          fi
           BUILD_SETTINGS=(
             "CODE_SIGN_STYLE=Automatic"
             "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
             "CURRENT_PROJECT_VERSION=${{ github.run_number }}"
+            "PPQ_API_KEY=$PPQ_API_KEY"
           )
           if [ -n "$MARKETING_VERSION_OVERRIDE" ]; then
             BUILD_SETTINGS+=("MARKETING_VERSION=$MARKETING_VERSION_OVERRIDE")
           fi
           set -o pipefail && xcodebuild archive \
-            -project Murmur.xcodeproj \
-            -scheme Murmur \
+            -project apps/ios/SitewalkGallery.xcodeproj \
+            -scheme SitewalkGallery \
             -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/Murmur.xcarchive" \
             -allowProvisioningUpdates \
@@ -192,28 +263,41 @@ jobs:
             "${BUILD_SETTINGS[@]}" \
             | xcbeautify
 
-      - name: Export and upload to TestFlight
-        env:
-          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+      - name: Export signed .ipa
         run: |
           set -o pipefail && xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/Murmur.xcarchive" \
             -exportPath "$RUNNER_TEMP/export" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
-            -authenticationKeyID "$ASC_API_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_API_ISSUER_ID" \
-            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey.p8" \
             | xcbeautify
 
-      - name: Upload archive artifact
+      - name: Upload .ipa artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Murmur-${{ steps.version.outputs.lane }}-${{ github.run_number }}
-          path: ${{ runner.temp }}/Murmur.xcarchive
+          name: Murmur-${{ steps.version.outputs.lane }}-${{ github.run_number }}-ipa
+          path: ${{ runner.temp }}/export/*.ipa
           retention-days: 30
+          if-no-files-found: warn
 
-      - name: Clean up API key
+      - name: Upload to TestFlight
+        if: ${{ steps.version.outputs.upload == 'true' }}
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: |
+          IPA=$(find "$RUNNER_TEMP/export" -maxdepth 1 -name '*.ipa' | head -1)
+          echo "Uploading $IPA to TestFlight"
+          xcrun altool --upload-app --type ios --file "$IPA" \
+            --apiKey "$ASC_API_KEY_ID" --apiIssuer "$ASC_API_ISSUER_ID"
+
+      - name: Dry-run notice
+        if: ${{ steps.version.outputs.upload != 'true' }}
+        run: |
+          echo "::notice::Dry-run (upload=false): built, signed, and exported the .ipa artifact but did NOT upload to TestFlight. Re-run with upload=true, or push to main / a v* tag, to publish."
+
+      - name: Clean up API keys
         if: ${{ always() }}
-        run: rm -f "$RUNNER_TEMP/private_keys/AuthKey.p8"
+        run: |
+          rm -f "$RUNNER_TEMP/private_keys/AuthKey.p8"
+          rm -f "$HOME"/.appstoreconnect/private_keys/AuthKey_*.p8

--- a/apps/ios/build-ffi.sh
+++ b/apps/ios/build-ffi.sh
@@ -22,15 +22,56 @@
 # iphoneos/iphonesimulator SDK via `xcrun`. This is the "system Xcode
 # fallback" path referenced in the Plan 07 Task 9 report — the pure-nix path
 # (unset SDKROOT/NIX_*FLAGS only) still fails on SDK linkage.
+#
+# ---------------------------------------------------------------------------
+# Options
+#   --features "<list>"  cargo features for crates/ffi (default: "whisper").
+#   --device-only        build only the aarch64-apple-ios (device) slice and a
+#                        device-only xcframework. Skips the simulator slice —
+#                        halves the expensive whisper.cpp/Metal compile. Use in
+#                        CI (a TestFlight archive is device-only anyway). Local
+#                        default builds BOTH slices so the simulator still runs.
+#
+# Nix vs no-nix: the cross-build blocks below point CC/AR/linker at the *system*
+# Xcode toolchain and unset the nix cc-wrapper flags, so the exact same commands
+# work whether or not nix is present. On a machine WITH nix (nous) they run
+# inside `nix develop` (pinned rust toolchain, cmake); on a GitHub runner WITHOUT
+# nix they run against rustup's cargo + brew's cmake directly. `dev` picks the
+# right wrapper.
 set -euo pipefail
+
+FEATURES="whisper"
+DEVICE_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --features) FEATURES="$2"; shift 2 ;;
+    --features=*) FEATURES="${1#*=}"; shift ;;
+    --device-only) DEVICE_ONLY=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Run a command inside the nix dev shell when nix is available (nous), or
+# directly otherwise (GitHub runner: rustup cargo + brew cmake on PATH).
+dev() {
+  if command -v nix >/dev/null 2>&1; then
+    nix develop -c "$@"
+  else
+    "$@"
+  fi
+}
 
 cd "$(dirname "$0")/../.."   # repo root
 FFI_DIR="apps/ios/Packages/MurmurCoreFFI"
 BINDINGS_DIR="$(mktemp -d)"
 trap 'rm -rf "$BINDINGS_DIR"' EXIT
 
+# Cross-build env is passed through to the inner shell via the environment.
+export FEATURES
+
+if [ "$DEVICE_ONLY" -eq 0 ]; then
 echo "==> building crates/ffi for aarch64-apple-ios-sim"
-nix develop -c bash -c '
+dev bash -c '
   set -euo pipefail
   export DEVELOPER_DIR="${XCODE_DEVELOPER_DIR:-$(env -u DEVELOPER_DIR /usr/bin/xcode-select -p)}"
   export SDKROOT=$(/usr/bin/xcrun --sdk iphonesimulator --show-sdk-path)
@@ -49,11 +90,12 @@ nix develop -c bash -c '
   # whisper.cpp Metal shaders compile against the iphonesimulator SDK via the
   # SDKROOT/system-clang cross-link set above. `cargo test --workspace` never
   # sees this feature — it stays hermetic (no model, no cmake, no Metal).
-  cargo build -p ffi --release --target aarch64-apple-ios-sim --features whisper
+  cargo build -p ffi --release --target aarch64-apple-ios-sim --features "$FEATURES"
 '
+fi
 
 echo "==> building crates/ffi for aarch64-apple-ios (device)"
-nix develop -c bash -c '
+dev bash -c '
   set -euo pipefail
   export DEVELOPER_DIR="${XCODE_DEVELOPER_DIR:-$(env -u DEVELOPER_DIR /usr/bin/xcode-select -p)}"
   export SDKROOT=$(/usr/bin/xcrun --sdk iphoneos --show-sdk-path)
@@ -67,28 +109,43 @@ nix develop -c bash -c '
   export CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=/usr/bin/clang
   unset NIX_CFLAGS_COMPILE NIX_LDFLAGS NIX_CFLAGS_COMPILE_FOR_BUILD NIX_LDFLAGS_FOR_BUILD
   # --features whisper (device slice) — see the sim invocation above.
-  cargo build -p ffi --release --target aarch64-apple-ios --features whisper
+  cargo build -p ffi --release --target aarch64-apple-ios --features "$FEATURES"
 '
 
+# Bindgen reads symbols from a built static lib; either slice works. Prefer the
+# sim slice when it exists, else the device slice (--device-only).
+BINDGEN_LIB="target/aarch64-apple-ios-sim/release/libffi.a"
+[ -f "$BINDGEN_LIB" ] || BINDGEN_LIB="target/aarch64-apple-ios/release/libffi.a"
+
 echo "==> generating Swift bindings (uniffi-bindgen, host build)"
-nix develop -c cargo run -p ffi --features uniffi-bindgen-cli --bin uniffi-bindgen -- \
-  generate --library target/aarch64-apple-ios-sim/release/libffi.a \
+dev cargo run -p ffi --features uniffi-bindgen-cli --bin uniffi-bindgen -- \
+  generate --library "$BINDGEN_LIB" \
   --language swift --out-dir "$BINDINGS_DIR"
 
 cp "$BINDINGS_DIR/ffi.swift" "$FFI_DIR/Sources/MurmurCoreFFI/ffi.swift"
 
 echo "==> assembling ffiFFI.xcframework"
 rm -rf "$FFI_DIR/Frameworks/ffiFFI.xcframework"
-for slice in sim device; do
+
+# Slices to include: always device; sim too unless --device-only.
+SLICES=(device)
+[ "$DEVICE_ONLY" -eq 0 ] && SLICES=(sim device)
+
+XCF_ARGS=()
+for slice in "${SLICES[@]}"; do
   hdir="$BINDINGS_DIR/headers-$slice"
   mkdir -p "$hdir"
   cp "$BINDINGS_DIR/ffiFFI.h" "$hdir/"
   cp "$BINDINGS_DIR/ffiFFI.modulemap" "$hdir/module.modulemap"
+  case "$slice" in
+    sim)    lib="target/aarch64-apple-ios-sim/release/libffi.a" ;;
+    device) lib="target/aarch64-apple-ios/release/libffi.a" ;;
+  esac
+  XCF_ARGS+=(-library "$lib" -headers "$hdir")
 done
 
 xcodebuild -create-xcframework \
-  -library target/aarch64-apple-ios-sim/release/libffi.a -headers "$BINDINGS_DIR/headers-sim" \
-  -library target/aarch64-apple-ios/release/libffi.a -headers "$BINDINGS_DIR/headers-device" \
+  "${XCF_ARGS[@]}" \
   -output "$FFI_DIR/Frameworks/ffiFFI.xcframework"
 
 # ---------------------------------------------------------------------------

--- a/apps/ios/project-release.yml
+++ b/apps/ios/project-release.yml
@@ -1,0 +1,60 @@
+# RELEASE spec — signed TestFlight distribution build (rebuild-era pipeline).
+#
+# Used ONLY by .github/workflows/release.yml. It leaves the dev/demo/clean-checkout
+# flows untouched:
+#   xcodegen generate                 -> DEMO app        (project.yml alone)
+#   ./generate.sh                     -> REAL-core DEV   (project-real.yml + local)
+#   xcodegen generate -s project-release.yml -> REAL-core DISTRIBUTION (this file)
+#
+# It layers on the demo base (project.yml) + the MurmurCoreFFI package (the real
+# murmur-core engine, same dependency project-real.yml adds) and overrides the
+# SitewalkGallery target for App Store distribution:
+#   - bundle id com.isaacwm.murmur, display name "Sitewalk" (bundle id/profile
+#     reused for TestFlight continuity — see CANON 2026-07-06 brand rename;
+#     the ASC/TestFlight listing rename itself is coordinated at first publish,
+#     but the shipped app already shows the new name)
+#   - signing enabled, Automatic style (archive uses -allowProvisioningUpdates;
+#     export uses manual signing via ExportOptions.plist — see release.yml)
+#   - CFBundleShortVersionString / CFBundleVersion reference MARKETING_VERSION /
+#     CURRENT_PROJECT_VERSION so CI can override them per lane (tag -> marketing
+#     version, github.run_number -> build number)
+#
+# xcodegen deep-merges includes (this file wins on conflicts), so the target keeps
+# its type/sources/fonts/usage-strings from project.yml and only the keys below change.
+#
+# SECRET FLOW (no secret ever in a tracked file): Info.plist keeps the literal
+# "$(PPQ_API_KEY)"; CI passes PPQ_API_KEY=<secret> as an xcodebuild build setting
+# on the archive command, which xcodebuild expands into the built Info.plist —
+# identical mechanism to the dev path (project.local.yml), just supplied on the
+# command line instead of a gitignored file. apps/ios uses no App Group, no
+# entitlements, and no analytics SDK, so the profile is a plain App Store profile.
+include:
+  - path: project.yml
+name: SitewalkGallery
+packages:
+  MurmurCoreFFI:
+    path: Packages/MurmurCoreFFI
+targets:
+  SitewalkGallery:
+    dependencies:
+      - package: MurmurCoreFFI
+    info:
+      path: Sources/App/Info.plist
+      properties:
+        CFBundleDisplayName: Sitewalk
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.isaacwm.murmur
+        MARKETING_VERSION: "1.0"
+        CURRENT_PROJECT_VERSION: "1"
+        # Distribution build is signed. Automatic style lets the archive step
+        # cloud-generate the Distribution cert + profile with -allowProvisioningUpdates
+        # (App Manager ASC key). CODE_SIGN_IDENTITY MUST stay empty: XcodeGen #691
+        # otherwise emits "iPhone Developer" per config, which breaks Automatic
+        # signing. Never set it explicitly under Automatic.
+        CODE_SIGNING_ALLOWED: "YES"
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGN_IDENTITY: ""
+        TARGETED_DEVICE_FAMILY: "1"

--- a/meta/TESTFLIGHT_CI_SETUP.md
+++ b/meta/TESTFLIGHT_CI_SETUP.md
@@ -4,6 +4,93 @@ One-time prerequisites for the `Release` workflow (`.github/workflows/release.ym
 Once these are done, pushing to `main` ships an internal TestFlight build and
 pushing a `v*` tag ships a build that's ready for external beta review.
 
+---
+
+## Rebuild-era update (2026-07-05)
+
+`release.yml` was rewritten in place for the rebuilt app (Rust core + `apps/ios`
+SwiftUI shell). Rewritten *in place* on purpose: `github.run_number` is
+per-workflow-file, so keeping the same file keeps the build-number counter
+monotonic vs the Era-I builds already on App Store Connect.
+
+**Identical to Era-I (the proven signing blueprint, unchanged):**
+
+- **Archive with automatic signing** — `CODE_SIGN_STYLE=Automatic` +
+  `-allowProvisioningUpdates` + the ASC API key. Apple cloud-generates the
+  Distribution cert and profile.
+- **Export with manual signing** — `ExportOptions.plist` `signingStyle=manual`,
+  explicit `provisioningProfiles` dict (`com.isaacwm.murmur` → `Murmur App
+  Store`), cert imported via `Apple-Actions/import-codesign-certs@v3`, profile
+  via `Apple-Actions/download-provisioning-profiles@v3`, **no**
+  `-allowProvisioningUpdates` on export (cloud signing fails there under an App
+  Manager key).
+- **Bundle id `com.isaacwm.murmur`** and the **`Murmur App Store`** profile are
+  reused (the TestFlight app + ASC build history are bound to that id/team
+  `98GXNZ6NKZ`).
+- Build number = `github.run_number`; a `v*` tag overrides `MARKETING_VERSION`.
+- The `brew install … || true` / `brew link --overwrite` pattern; the XcodeGen
+  #691 guard (`CODE_SIGN_IDENTITY: ""` in the spec, never set explicitly under
+  Automatic).
+
+**What changed for the rebuild:**
+
+- **Ships the real Rust core.** A new step runs
+  `apps/ios/build-ffi.sh --features whisper --device-only` on the macOS runner to
+  produce the `MurmurCoreFFI` xcframework. No nix on the runner — `build-ffi.sh`
+  now auto-detects nix and, when absent, runs against rustup's cargo + the system
+  Xcode toolchain directly (the nix path is unchanged for local `nous` builds).
+  `--device-only` builds only the `aarch64-apple-ios` slice (a TestFlight archive
+  is device-only anyway), halving the whisper.cpp/Metal compile.
+- **On-device model provisioning.** The workflow runs
+  `apps/ios/fetch-whisper-model.sh` (the same script `./generate.sh` uses
+  locally) to download the sha256-pinned `small.en` model (~190 MB, the
+  default; `base.en` is a one-arg revert) from the ggerganov Hugging Face
+  mirror into `apps/ios/Sources/Resources/`, cached via `actions/cache` keyed
+  on the model name + the script's own hash (so a digest/model bump busts the
+  cache automatically). The app-target `Sources` glob bundles it
+  (`Bundle.main`); absent, live walks degrade to text-only.
+- **Release xcodegen spec.** The Era-I `project.yml`/`Makefile` were removed in
+  the re-unification; the release build now generates from
+  `apps/ios/project-release.yml` (demo base + `MurmurCoreFFI` package + signed
+  distribution overrides: bundle id, display name `Sitewalk`, version vars).
+- **Dry-run capable.** Export uses `destination=export` (produces a signed `.ipa`
+  artifact); the ASC upload is a **separate, conditional** `xcrun altool
+  --upload-app` step. `workflow_dispatch` has an `upload` input (default
+  `false`): a dry-run builds → signs → exports the `.ipa` but does **not**
+  publish. Pushes to `main` / `v*` tags always upload.
+- **No App Group, no entitlements, no analytics.** `apps/ios` uses none — it
+  reads only `PPQ_API_KEY` from `Info.plist`. So **step 1 below (App Group
+  registration) is NOT required** for the rebuilt app, and the profile is a plain
+  App Store profile. `STUDIO_ANALYTICS_API_KEY_RELEASE` is no longer injected
+  (there is no analytics SDK in the rebuild).
+
+**Required secrets (rebuild):** `APPLE_TEAM_ID`, `ASC_API_KEY_ID`,
+`ASC_API_ISSUER_ID`, `ASC_API_KEY_P8`, `APPLE_CERT_P12`, `APPLE_CERT_PASSWORD`,
+`PPQ_API_KEY`. (All verified present in the repo's secrets.)
+
+**One-time steps you may still need before the first real upload:**
+
+1. **Re-save / confirm the `Murmur App Store` profile matches the new app
+   shape.** The rebuilt app has *fewer* capabilities than Era-I (no App Group).
+   If the existing profile was created with the App Group entitlement, it should
+   still work (it's a superset), but if provisioning errors on
+   entitlement mismatch, edit the App ID `com.isaacwm.murmur` to remove the App
+   Group capability (or leave it — the app simply won't request it) and
+   regenerate/re-save the `Murmur App Store` profile. The
+   `download-provisioning-profiles` step fetches the latest by bundle-id + type,
+   so re-saving in the portal is all that's needed.
+2. Everything in the Era-I steps below that concerns the **ASC API key (App
+   Manager role)**, **auto-distribution to internal testers**, and the
+   **repository secrets** still applies unchanged.
+
+**Dry-run before publishing:** Actions → Release → *Run workflow* on this branch
+with `upload=false`. It exercises the full chain — real-core FFI build, model
+fetch, archive (automatic signing), export (manual signing) — and uploads the
+signed `.ipa` as a build artifact **without** touching App Store Connect. Flip
+`upload=true` (or merge to `main`) when the dry-run is green.
+
+---
+
 > **Note on bundle ID:** the bundle ID is `com.isaacwm.murmur` (registered
 > under the damsac Apple Developer team). The `damsac` namespace is the
 > GitHub org and the team in App Store Connect; the bundle ID prefix


### PR DESCRIPTION
## Thinking

This is the reconciled TestFlight pipeline (rebased onto main 9aec626 on 2026-07-07; dry-run 28900094459 green END-TO-END including a signed .ipa artifact after sac signed the Apple agreement). Merging this ARMS the pipeline: push to main → lane=internal, upload=true → every merge to main builds, signs, and auto-distributes the rebuild to internal TestFlight testers, replacing the Era-I Murmur builds in the same TestFlight app (bundle com.isaacwm.murmur kept deliberately — build numbers stay monotonic via github.run_number on the rewritten-in-place workflow file). Tags v* = external candidate (manual Beta App Review still required). workflow_dispatch upload=false remains the dry-run path.

Reconciliation decisions (from the branch rebase): sac's env-u DEVELOPER_DIR form wins in build-ffi.sh; the bespoke model download was replaced by fetch-whisper-model.sh (small.en, cache keyed on script hash); display name is Sitewalk (ASC listing rename happens at first publish); the proven Era-I signing blueprint (automatic-sign archive, manual-sign export, no -allowProvisioningUpdates on export) is unchanged.

Known standing decisions, accepted for this merge: release builds bake no API key/base-url → testers get the DEMO engine (safe first beta; real-engine beta is a follow-up decision); artifact naming still says Murmur internally (cosmetic).

Merge = first publish. dam authorized 2026-07-08 after the dry-run went green.