### PR TITLE
Zombie-Recording sweep: fail crash-orphaned sessions on app open

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -590,6 +590,27 @@ public protocol MurmurEngineProtocol : AnyObject {
      */
     func removeVocabularyTerm(term: String) throws  -> [String]
     
+    /**
+     * App-open zombie sweep (carry-note, Plan 04): a `Recording` session left
+     * behind by a crash or force-quit mid-walk can never resume — there is no
+     * live `WalkSession`/STT pump for it after relaunch, `MurmurEngine::new`
+     * starts clean — so without this it would sit in `Recording` forever.
+     * The shell calls this once, at app open, the same way it calls
+     * `list_live_photo_filenames`/`sweepPhotoBytes` (Plan 11 D4): an explicit
+     * method the host invokes at a known quiescent point, not something
+     * hidden inside the constructor. Automatic-in-`new` would make sweep
+     * policy invisible and untestable from the shell side, and would run
+     * even for callers (tests, tooling) that open a store without ever
+     * wanting mutation as a side effect of construction.
+     *
+     * Transitions every `Recording` row to `Failed` — never deletes.
+     * Transcript and items survive (they're the crash-surviving record of
+     * real field data); `Failed -> Processed` is the existing retry path, so
+     * a future "recover this walk" UI can reprocess it. Idempotent: returns
+     * the number of sessions swept, `0` on a clean relaunch.
+     */
+    func sweepZombieSessions() throws  -> UInt64
+    
 }
 
 /**
@@ -760,6 +781,32 @@ open func removeVocabularyTerm(term: String)throws  -> [String] {
     return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
     uniffi_ffi_fn_method_murmurengine_remove_vocabulary_term(self.uniffiClonePointer(),
         FfiConverterString.lower(term),$0
+    )
+})
+}
+    
+    /**
+     * App-open zombie sweep (carry-note, Plan 04): a `Recording` session left
+     * behind by a crash or force-quit mid-walk can never resume — there is no
+     * live `WalkSession`/STT pump for it after relaunch, `MurmurEngine::new`
+     * starts clean — so without this it would sit in `Recording` forever.
+     * The shell calls this once, at app open, the same way it calls
+     * `list_live_photo_filenames`/`sweepPhotoBytes` (Plan 11 D4): an explicit
+     * method the host invokes at a known quiescent point, not something
+     * hidden inside the constructor. Automatic-in-`new` would make sweep
+     * policy invisible and untestable from the shell side, and would run
+     * even for callers (tests, tooling) that open a store without ever
+     * wanting mutation as a side effect of construction.
+     *
+     * Transitions every `Recording` row to `Failed` — never deletes.
+     * Transcript and items survive (they're the crash-surviving record of
+     * real field data); `Failed -> Processed` is the existing retry path, so
+     * a future "recover this walk" UI can reprocess it. Idempotent: returns
+     * the number of sessions swept, `0` on a clean relaunch.
+     */
+open func sweepZombieSessions()throws  -> UInt64 {
+    return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_sweep_zombie_sessions(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -2004,6 +2051,13 @@ public enum EngineError {
      */
     case Photo(message: String)
     
+    /**
+     * A session-lifecycle operation outside `begin_walk`/`WalkSession` failed
+     * (currently: the app-open zombie sweep). A poisoned store lock or a
+     * store error — recoverable, surface don't crash.
+     */
+    case Session(message: String)
+    
 }
 
 
@@ -2040,6 +2094,10 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 6: return .Session(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2061,6 +2119,8 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(4))
         case .Photo(_ /* message is ignored*/):
             writeInt(&buf, Int32(5))
+        case .Session(_ /* message is ignored*/):
+            writeInt(&buf, Int32(6))
 
         
         }
@@ -2450,6 +2510,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_remove_vocabulary_term() != 40682) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_sweep_zombie_sessions() != 29924) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_walkeventlistener_on_event() != 10314) {

--- a/apps/ios/Sources/App/AppModel+Photos.swift
+++ b/apps/ios/Sources/App/AppModel+Photos.swift
@@ -97,6 +97,18 @@ extension AppModel {
     /// (bytes written, row not yet committed) and delete a just-captured
     /// photo; app-open is the one quiescent point where neither a capture nor
     /// a walk can be mid-flight.
+    ///
+    /// INVARIANT (sweep-vs-live-walk race — closed by ORDERING alone, and
+    /// these three properties keep it closed):
+    ///   1. Fully SYNCHRONOUS: no `await` before this call in the `.task`,
+    ///      none inside it. A single suspension point could let a walk start
+    ///      first, and the resumed sweep would Fail the LIVE session — its
+    ///      next append/finish then throws InvalidState.
+    ///   2. Runs BEFORE any start-walk path: the user's tap and the autoflow
+    ///      script both come after the `.task` head has executed.
+    ///   3. NEVER re-fired on background→foreground while a `WalkSession` is
+    ///      live — `.task` runs once per view lifetime, and it must stay that
+    ///      way (no scenePhase re-trigger).
     func runAppOpenSweeps() {
         sweepPhotoBytes()
         sweepZombieSessions()

--- a/apps/ios/Sources/App/AppModel+Photos.swift
+++ b/apps/ios/Sources/App/AppModel+Photos.swift
@@ -90,17 +90,37 @@ extension AppModel {
         photos = (try? engine.listPhotos(sessionId: sessionId)) ?? []
     }
 
+    /// Both app-open sweeps, called together from `AppRoot.body`'s `.task`
+    /// (GalleryApp.swift): reconcile photo bytes (Plan 11 D4) and fail any
+    /// crash-orphaned `Recording` session. Both are app-open-ONLY, never
+    /// background — a concurrent photo sweep could race an in-flight capture
+    /// (bytes written, row not yet committed) and delete a just-captured
+    /// photo; app-open is the one quiescent point where neither a capture nor
+    /// a walk can be mid-flight.
+    func runAppOpenSweeps() {
+        sweepPhotoBytes()
+        sweepZombieSessions()
+    }
+
     /// Reconciling sweep (Plan 11 D4): delete every file in <Documents>/photos/
     /// whose name is NOT in the engine's live set. Idempotent, crash-safe;
     /// reaps tombstoned-row bytes AND never-committed capture orphans with one
-    /// rule. Call on app launch ONLY (v1): a concurrent/background sweep could
-    /// race an in-flight capture (bytes written, row not yet committed) and
-    /// delete a just-captured photo. App-open is a quiescent point (no capture
-    /// in flight).
+    /// rule.
     func sweepPhotoBytes() {
         guard let live = try? Set(engine.liveLivePhotoFilenames()) else { return }
         for file in photoDirContents() where !live.contains(file) {
             deletePhotoFile(file)
+        }
+    }
+
+    /// A crash/force-quit mid-walk leaves a `Recording` session that can
+    /// never resume (there is no live `WalkSession` for it after relaunch).
+    /// Best effort like the photo sweep — a failure here (e.g. store lock
+    /// contention) just means the zombie waits for the next app-open; it
+    /// never blocks launch or crashes the app.
+    func sweepZombieSessions() {
+        if let swept = try? engine.sweepZombieSessions(), swept > 0 {
+            photoLogger.notice("swept \(swept, privacy: .public) zombie session(s)")
         }
     }
 

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -269,8 +269,9 @@ struct AppRoot: View {
         }
         .tint(Theme.C.ink)
         .task {
-            // App-open sweeps (photo bytes + zombie sessions) — see
-            // AppModel.runAppOpenSweeps() for why these are app-open-only.
+            // INVARIANT: stays FIRST in this .task (no `await` before it) and
+            // is never re-fired while a walk is live — one suspension point
+            // ahead of it would Fail a live session. See runAppOpenSweeps().
             model.runAppOpenSweeps()
             if live {
                 _ = await SpeechSource.requestPermissions()

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -269,11 +269,9 @@ struct AppRoot: View {
         }
         .tint(Theme.C.ink)
         .task {
-            // Reconciling sweep (Plan 11 D4): app-open ONLY, never background —
-            // a concurrent sweep could race an in-flight capture (bytes written,
-            // row not yet committed) and delete a just-captured photo. App-open
-            // is a quiescent point (no capture in flight).
-            model.sweepPhotoBytes()
+            // App-open sweeps (photo bytes + zombie sessions) — see
+            // AppModel.runAppOpenSweeps() for why these are app-open-only.
+            model.runAppOpenSweeps()
             if live {
                 _ = await SpeechSource.requestPermissions()
             }

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -129,6 +129,12 @@ final class DemoWalkEngine: WalkEngine {
         demoPhotos.map(\.filename)
     }
 
+    // No Recording rows to leak in the scripted demo (no crash-orphaned
+    // sessions are possible here) — nothing to sweep.
+    func sweepZombieSessions() -> UInt64 {
+        0
+    }
+
     func finish() async -> DocumentModel {
         continuation?.finish()
         continuation = nil

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -257,6 +257,10 @@ final class MurmurEngine: WalkEngine {
         try engine.listLivePhotoFilenames()
     }
 
+    func sweepZombieSessions() throws -> UInt64 {
+        try engine.sweepZombieSessions()
+    }
+
     private nonisolated static func photo(_ ref: MurmurCoreFFI.PhotoRef) -> PhotoModel {
         PhotoModel(
             id: ref.id,

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -126,6 +126,17 @@ protocol WalkEngine: AnyObject {
     func removePhoto(photoId: String) throws
     func liveLivePhotoFilenames() throws -> [String]   // for the sweep
 
+    /// App-open zombie sweep: a `Recording` session left behind by a crash or
+    /// force-quit mid-walk can never resume (there is no live session for it
+    /// after relaunch) — this transitions every such row to `Failed` so it
+    /// stops sitting in `Recording` forever. Called once at app open,
+    /// alongside `sweepPhotoBytes()` (see `AppRoot.body`'s `.task`).
+    /// Transcript/items survive; `Failed -> Processed` remains the existing
+    /// retry path. Returns the number swept (`0` on a clean relaunch).
+    /// `DemoWalkEngine` no-ops (there is no Recording concept to leak in the
+    /// scripted demo).
+    func sweepZombieSessions() throws -> UInt64
+
     /// The active walk's session id, so the capture UI can call
     /// `attachPhoto(sessionId:...)` mid-walk (Plan 11 D7). `nil` when there is
     /// no live session (not walking, or the real engine has none yet).

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -36,6 +36,11 @@ pub enum EngineError {
     /// store/validation strings only (never an api key).
     #[error("photo error: {0}")]
     Photo(String),
+    /// A session-lifecycle operation outside `begin_walk`/`WalkSession` failed
+    /// (currently: the app-open zombie sweep). A poisoned store lock or a
+    /// store error — recoverable, surface don't crash.
+    #[error("session error: {0}")]
+    Session(String),
 }
 
 /// Config crossing the FFI boundary. `api_key` is an opaque `String` from the

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -502,6 +502,34 @@ impl MurmurEngine {
         session.start_pump();
         Ok(session)
     }
+
+    /// App-open zombie sweep (carry-note, Plan 04): a `Recording` session left
+    /// behind by a crash or force-quit mid-walk can never resume — there is no
+    /// live `WalkSession`/STT pump for it after relaunch, `MurmurEngine::new`
+    /// starts clean — so without this it would sit in `Recording` forever.
+    /// The shell calls this once, at app open, the same way it calls
+    /// `list_live_photo_filenames`/`sweepPhotoBytes` (Plan 11 D4): an explicit
+    /// method the host invokes at a known quiescent point, not something
+    /// hidden inside the constructor. Automatic-in-`new` would make sweep
+    /// policy invisible and untestable from the shell side, and would run
+    /// even for callers (tests, tooling) that open a store without ever
+    /// wanting mutation as a side effect of construction.
+    ///
+    /// Transitions every `Recording` row to `Failed` — never deletes.
+    /// Transcript and items survive (they're the crash-surviving record of
+    /// real field data); `Failed -> Processed` is the existing retry path, so
+    /// a future "recover this walk" UI can reprocess it. Idempotent: returns
+    /// the number of sessions swept, `0` on a clean relaunch.
+    pub fn sweep_zombie_sessions(&self) -> Result<u64, EngineError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|_| EngineError::Session("store lock poisoned".into()))?;
+        let swept = store
+            .sweep_zombie_sessions()
+            .map_err(|e| EngineError::Session(e.to_string()))?;
+        Ok(swept as u64)
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -844,6 +872,48 @@ mod tests {
         };
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].text, "order lumber");
+    }
+
+    fn no_op_providers() -> Providers {
+        Providers {
+            live: Arc::new(MockProvider::new(vec![])),
+            processing: Arc::new(MockProvider::new(vec![])),
+            reflection: Arc::new(MockProvider::new(vec![])),
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_zombie_sessions_is_exposed_and_transitions_recording_rows() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        // A zombie left behind by a "crash": Recording, never ended.
+        let zombie_id = store.start_session(None).unwrap().id;
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            no_op_providers(),
+        );
+
+        let swept = engine.sweep_zombie_sessions().unwrap();
+        assert_eq!(swept, 1);
+
+        // A fresh begin_walk still works after the sweep (engine stays usable).
+        let session = engine.begin_walk(None, "landscape".into()).unwrap();
+        assert_ne!(session.session_id(), zombie_id, "a new walk gets its own session");
+    }
+
+    #[tokio::test]
+    async fn sweep_zombie_sessions_is_idempotent_across_ffi() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        store.start_session(None).unwrap();
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            no_op_providers(),
+        );
+        assert_eq!(engine.sweep_zombie_sessions().unwrap(), 1);
+        assert_eq!(engine.sweep_zombie_sessions().unwrap(), 0);
     }
 
     /// photo_count fast-follow (Plan 11 D6): a photo attached to a pre-existing

--- a/crates/murmur-core/src/store/sessions.rs
+++ b/crates/murmur-core/src/store/sessions.rs
@@ -289,6 +289,34 @@ impl Store {
         Ok(sessions)
     }
 
+    /// App-open zombie sweep: a `Recording` session left behind by a crash or
+    /// force-quit mid-walk can never legally resume (there is no live
+    /// `WalkSession`/STT pump for it after relaunch — `MurmurEngine::new`
+    /// starts clean), so it is stuck in `Recording` forever unless something
+    /// moves it out. This transitions every `Recording` row to `Failed`:
+    /// transcript and items are left exactly as they were (they are the
+    /// crash-surviving record of real field data, not garbage) — only the
+    /// status changes, so `Failed -> Processed` (the existing retry path,
+    /// `transition_ended`) can recover the walk later. Deleting instead of
+    /// failing was considered and rejected: it would destroy data the field
+    /// worker actually said before the crash.
+    ///
+    /// Idempotent: a second call finds no `Recording` rows and sweeps zero.
+    /// Returns the number of sessions swept, so the shell can log/surface it.
+    pub fn sweep_zombie_sessions(&self) -> Result<usize, CoreError> {
+        let now = self.now() as i64;
+        let swept = self.conn.execute(
+            "UPDATE sessions SET status = ?1, updated_at = ?2
+             WHERE status = ?3 AND deleted_at IS NULL",
+            rusqlite::params![
+                SessionStatus::Failed.as_str(),
+                now,
+                SessionStatus::Recording.as_str(),
+            ],
+        )?;
+        Ok(swept)
+    }
+
     /// Tombstones a session AND cascades to its live items and artifacts in
     /// one transaction — deleting a session is a single logical delete
     /// operation (sync story: one op, never a half-cascaded state). Already
@@ -765,6 +793,66 @@ mod tests {
             })
             .unwrap();
         assert_eq!(raw_artifact, 1);
+    }
+
+    #[test]
+    fn sweep_zombie_sessions_fails_only_recording_rows() {
+        let s = store();
+        let recording_a = s.start_session(None).unwrap();
+        let recording_b = s.start_session(None).unwrap();
+        let awaiting = s.start_session(None).unwrap();
+        s.end_session(&awaiting.id).unwrap();
+        let processed = s.start_session(None).unwrap();
+        s.end_session(&processed.id).unwrap();
+        s.mark_session_processed(&processed.id, "done.").unwrap();
+
+        let swept = s.sweep_zombie_sessions().unwrap();
+        assert_eq!(swept, 2, "only the two Recording rows are zombies");
+
+        assert_eq!(s.get_session(&recording_a.id).unwrap().status, SessionStatus::Failed);
+        assert_eq!(s.get_session(&recording_b.id).unwrap().status, SessionStatus::Failed);
+        // untouched
+        assert_eq!(s.get_session(&awaiting.id).unwrap().status, SessionStatus::AwaitingProcessing);
+        assert_eq!(s.get_session(&processed.id).unwrap().status, SessionStatus::Processed);
+    }
+
+    #[test]
+    fn sweep_zombie_sessions_is_idempotent() {
+        let s = store();
+        s.start_session(None).unwrap();
+        assert_eq!(s.sweep_zombie_sessions().unwrap(), 1);
+        // second call: nothing left in Recording — zero, no error, no re-sweep
+        assert_eq!(s.sweep_zombie_sessions().unwrap(), 0);
+    }
+
+    #[test]
+    fn sweep_zombie_sessions_preserves_transcript_and_items() {
+        let s = store();
+        let session = s.start_session(None).unwrap();
+        s.append_transcript(&session.id, "we walked the yard").unwrap();
+        let item = s.add_item(&session.id, "todo", "order lumber").unwrap();
+
+        s.sweep_zombie_sessions().unwrap();
+
+        let failed = s.get_session(&session.id).unwrap();
+        assert_eq!(failed.status, SessionStatus::Failed);
+        assert_eq!(failed.transcript, "we walked the yard");
+        // items survive the sweep — they are the crash-surviving record
+        let items: Vec<_> = s.list_items_for_session(&session.id).unwrap().into_iter().map(|i| i.id).collect();
+        assert_eq!(items, vec![item.id]);
+    }
+
+    #[test]
+    fn failed_zombie_session_can_still_retry_to_processed() {
+        // Recording -> Failed (sweep) -> Processed must remain a legal retry
+        // path, same as the existing AwaitingProcessing/Failed -> Processed
+        // allowlist.
+        let s = store();
+        let session = s.start_session(None).unwrap();
+        s.sweep_zombie_sessions().unwrap();
+        assert_eq!(s.get_session(&session.id).unwrap().status, SessionStatus::Failed);
+        let done = s.mark_session_processed(&session.id, "recovered").unwrap();
+        assert_eq!(done.status, SessionStatus::Processed);
     }
 
     #[test]


### PR DESCRIPTION
## Thinking

**Investigation (Phase 1).** The Plan 04 carry-note was right: `Store::list_sessions_by_status(Recording)` existed, but nothing ever called it. Traced the actual crash → relaunch → new-walk path:

- `MurmurEngine::new` (`crates/ffi/src/engine.rs`) just opens the store — no sweep, no scan for stale `Recording` rows.
- `begin_walk` (`crates/ffi/src/session.rs`) always `start_session_with_template`s a brand-new row; it never checks for or touches an existing `Recording` session. So a zombie doesn't *block* a new walk — but it also never goes away. Multiple crashes accumulate multiple zombies.
- `apps/ios/Sources/App/GalleryApp.swift`'s `.task` already had exactly one app-open sweep: `model.sweepPhotoBytes()` (Plan 11 D4). No session-side counterpart.
- The zombie's blast radius: `list_sessions`/`list_session_summaries` show it forever as "still recording" in the session library, and the session can never legally transition out of `Recording` through the normal API — so it can never enter the Failed→Processed retry path either. Note on items: `list_open_todos()` (`crates/murmur-core/src/store/items.rs`) is **not** session-status-scoped, so pre-crash todos appear in the live todo list both before AND after this sweep — the sweep deliberately preserves them (they are real field data). Clearing or resolving leaked todos waits on the future recover/reprocess UI; what this PR fixes is the "recording forever" library state and unblocking the retry path. Photos stay session-scoped and just sit there; `sweepPhotoBytes()` treats them as live (correctly, since nothing tombstoned them) so no photo-byte leak, just an orphaned metadata row.

So: real, live gap. Fixed it.

**Placement.** Added an explicit `sweep_zombie_sessions` FFI method (`crates/ffi/src/session.rs`) that the shell calls once at app open, right alongside `sweepPhotoBytes()` — not something automatic inside `MurmurEngine::new`. Same reasoning as the existing photo-sweep precedent: constructor-side sweeping would make the mutation invisible/untestable from the shell, and would fire even for callers (tests, tooling) that open a store without wanting a side-effecting scan on construction. An explicit method the host calls at a known quiescent point keeps the policy visible and matches the pattern already established for photos.

**Sweep-vs-live-walk race.** Closed by ordering: `runAppOpenSweeps()` runs synchronously at the head of `AppRoot`'s `.task`, before any start-walk path (manual tap or autoflow), and is never re-fired while a `WalkSession` is live. This invariant is now pinned in comments at both the call site (`GalleryApp.swift`) and the method (`AppModel+Photos.swift`): one `await` ahead of the sweep would let a walk start first and the resumed sweep would Fail the live session (its next append/finish throws InvalidState).

**Failed, not deleted.** `sweep_zombie_sessions` (`crates/murmur-core/src/store/sessions.rs`) transitions every `Recording` row to `Failed` via a raw UPDATE — never touches the transcript or items. Deletion was considered and rejected: the transcript/items captured before a crash are real field data, and `Failed -> Processed` is already a legal retry path (`transition_ended`'s existing allowlist), so a future "recover this walk" UI can reprocess a swept zombie without any further schema work. I did not loosen `transition_ended`'s guard on direct `mark_session_failed`/`mark_session_processed` calls against a `Recording` session (that stays illegal, correctly — only the sweep's raw SQL performs this specific transition, and only for genuinely orphaned rows). A test (`failed_zombie_session_can_still_retry_to_processed`) pins that the sweep's output feeds straight into the existing retry path.

## What changed

- `crates/murmur-core`: `Store::sweep_zombie_sessions()` — transitions all `Recording` rows to `Failed`, idempotent, returns the count swept. Transcript/items untouched.
- `crates/ffi`: `MurmurEngine::sweep_zombie_sessions()` exposed via UniFFI (new `EngineError::Session` variant); bindings regenerated (`ffi.swift`).
- `apps/ios`: `WalkEngine.sweepZombieSessions()` protocol method; `MurmurEngine` forwards to FFI, `DemoWalkEngine` no-ops (no Recording concept in the scripted demo — nothing to leak). `AppModel.runAppOpenSweeps()` now calls both the photo sweep and the zombie sweep from `GalleryApp`'s single `.task` (consolidated to keep `GalleryApp.swift` under the file-length lint budget), with the ordering invariant documented at both sites.
- No UI for recovered/failed-from-crash sessions — future work, same posture as the existing Failed-retry surface.

## Test plan

- [x] `nix develop -c cargo test --workspace` — all green (161 murmur-core, 36 ffi, full workspace) including 6 new sweep tests (3 core, 2 ffi, 1 retry-path pin)
- [x] `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `xcodegen generate` (demo) + `xcodebuild ... build` — BUILD SUCCEEDED
- [x] `./build-ffi.sh` + `./generate.sh` (real-core) + `xcodebuild ... build` — BUILD SUCCEEDED, confirms `sweepZombieSessions()` compiles end-to-end against the regenerated bindings
- [x] Regenerated demo project committed state restored (xcodeproj/xcframework are gitignored, no diff there)