### PR TITLE
sac: voice-first input mode — user choice in the UI, demo demoted to a chip

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -89,7 +89,26 @@ final class AppModel {
     private var audioSource: (any PCMAudioSource)?
     private var pumpTask: Task<Void, Never>?
     private var eventTask: Task<Void, Never>?
-    private let scripted: Bool
+
+    /// The walk's input mode — a USER choice now, not a launch condition.
+    /// `.voice` = mic → on-device whisper (the product). `.demo` = the canned
+    /// scripted walk (kept for showing the moment; graduates into onboarding).
+    /// Persisted across launches; launch args (`live=`, `demo=1`, autoflow)
+    /// still force a mode for QA — forced modes lock the toggle and don't
+    /// persist (D10: every existing launch arg keeps working).
+    enum WalkMode: String { case voice, demo }
+    var walkMode: WalkMode {
+        didSet {
+            guard !modeLocked else { return }
+            UserDefaults.standard.set(walkMode.rawValue, forKey: Self.walkModeKey)
+        }
+    }
+    let modeLocked: Bool
+    private static let walkModeKey = "sitewalk.walkMode"
+    /// Set when the user tries a voice walk with mic permission denied —
+    /// BoardView surfaces it with an "open Settings" affordance.
+    var micDenied = false
+
     /// When live, drive the STT path from a bundled fixture WAV instead of the
     /// mic (`wavwalk=1`, D7) — a mic-free way to exercise real whisper.
     private let wavFixture: Bool
@@ -104,12 +123,25 @@ final class AppModel {
     @ObservationIgnored
     var makeScriptedSource: (TradeFixture) -> TranscriptSource = { ScriptedSource(trade: $0) }
 
-    init(engine: WalkEngine? = nil, scripted: Bool = true, wavFixture: Bool = false,
+    init(engine: WalkEngine? = nil, forcedMode: WalkMode? = nil, wavFixture: Bool = false,
          voiceProcessing: Bool = false) {
         self.engine = engine ?? DemoWalkEngine()
-        self.scripted = scripted
+        if let forcedMode {
+            self.walkMode = forcedMode
+            self.modeLocked = true
+        } else {
+            self.walkMode = UserDefaults.standard.string(forKey: Self.walkModeKey)
+                .flatMap(WalkMode.init(rawValue:)) ?? .voice
+            self.modeLocked = false
+        }
         self.wavFixture = wavFixture
         self.voiceProcessing = voiceProcessing
+    }
+
+    func toggleMode() {
+        guard !modeLocked else { return }
+        walkMode = walkMode == .voice ? .demo : .voice
+        if walkMode == .demo { micDenied = false }
     }
 
     // MARK: Trade switching (validation strategy: same bones, swappable template)
@@ -121,7 +153,27 @@ final class AppModel {
 
     // MARK: Walk lifecycle
 
+    /// Voice walks gate on mic permission BEFORE the session starts — a walk
+    /// that can't hear must never begin (same posture as throwing begin()).
+    /// Returns immediately when already authorized; first-ever tap shows the
+    /// system prompt. Denied → `micDenied` surfaces on the board.
     func startWalk() {
+        if walkMode == .voice && !wavFixture {
+            Task { [weak self] in
+                guard let self else { return }
+                if await AudioCaptureSource.requestPermissions() {
+                    self.micDenied = false
+                    self.beginWalk()
+                } else {
+                    self.micDenied = true
+                }
+            }
+        } else {
+            beginWalk()
+        }
+    }
+
+    private func beginWalk() {
         pumpTask?.cancel()
         eventTask?.cancel()
 
@@ -173,7 +225,7 @@ final class AppModel {
 
         phase = .walking
         path = [.walking]
-        if scripted {
+        if walkMode == .demo {
             startScriptedSource()
         } else {
             startAudioSource()

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -84,17 +84,15 @@ private func resolveSttKnobs(_ args: [String]) -> SttKnobs {
 }
 
 /// Live-mic vs. scripted text walk. `live=1`/`live=0` always win. Default:
+/// (superseded by the in-app mode chip — this now only reports an EXPLICIT
+/// arg; absent args defer to the user's persisted choice in AppModel.)
 /// scripted on sim (Metal STT SIGTRAPs on MTLSimDevice; QA assumes scripted),
 /// **live** on device. CAVEAT: small.en's on-device RTF is unmeasured (see
 /// resolveSttModelPath) — `sttmodel=base.en`/`live=0` reverts if too slow.
-private func resolveLive(_ args: [String]) -> Bool {
+private func resolveLive(_ args: [String]) -> Bool? {
     if args.contains("live=1") { return true }
     if args.contains("live=0") { return false }
-    #if targetEnvironment(simulator)
-    return false
-    #else
-    return true
-    #endif
+    return nil
 }
 
 /// Resolves the bundled whisper model path from the `sttmodel=base.en|small.en`
@@ -227,24 +225,34 @@ struct RootRouter: View {
 
 struct AppRoot: View {
     @State private var model: AppModel
-    private let live: Bool
+    private let live: Bool?
     private let wavwalk: Bool
     private let autoflowRounds: Int
 
     @MainActor
-    init(live: Bool, wavwalk: Bool = false, demo: Bool, voiceProcessing: Bool = false,
+    init(live: Bool?, wavwalk: Bool = false, demo: Bool, voiceProcessing: Bool = false,
          autoflowRounds: Int) {
         self.live = live
         self.wavwalk = wavwalk
         self.autoflowRounds = autoflowRounds
-        // Both live (mic) and wavwalk (fixture) are real whisper walks — neither
-        // is the scripted text path. wavwalk drives the STT path from a bundled
-        // WAV instead of the mic (Plan 08 D7).
-        let whisperWalk = live || wavwalk
+        // Mode is a USER choice (persisted, board chip) unless a launch arg
+        // forces it: wavwalk/live=1 → voice; demo=1/live=0 → demo; autoflow
+        // without an explicit voice arg → demo (scripted determinism for
+        // screenshots/CI). Forced modes lock the chip and never persist.
+        let forcedMode: AppModel.WalkMode?
+        if wavwalk || live == true {
+            forcedMode = .voice
+        } else if demo || live == false {
+            forcedMode = .demo
+        } else if autoflowRounds > 0 {
+            forcedMode = .demo
+        } else {
+            forcedMode = nil
+        }
         _model = State(
             initialValue: AppModel(
                 engine: resolveEngine(demo: demo),
-                scripted: !whisperWalk,
+                forcedMode: forcedMode,
                 wavFixture: wavwalk,
                 voiceProcessing: voiceProcessing
             )
@@ -257,7 +265,7 @@ struct AppRoot: View {
                 .navigationDestination(for: AppModel.Phase.self) { phase in
                     switch phase {
                     case .walking:
-                        WalkView(model: model, scriptedLabel: !(live || wavwalk))
+                        WalkView(model: model)
                     case .building:
                         BuildView(model: model)
                     case .review:
@@ -273,9 +281,11 @@ struct AppRoot: View {
             // is never re-fired while a walk is live — one suspension point
             // ahead of it would Fail a live session. See runAppOpenSweeps().
             model.runAppOpenSweeps()
-            if live {
-                _ = await SpeechSource.requestPermissions()
-            }
+            // (Removed: the legacy SpeechSource permission ask for live=1.
+            // STT is Rust-side whisper — Apple Speech Recognition is never
+            // used on the walk path, and its system dialog carries "sent to
+            // Apple" copy that is untrue for this product. Mic permission is
+            // requested where it belongs: AppModel.startWalk, voice mode.)
             for round in 0..<autoflowRounds {
                 if round > 0 {
                     model.completeSend()

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // Live jobs board — the app's home. Trade is switchable from the business
 // name (validation strategy: watch which template operators react to).
@@ -18,6 +19,25 @@ struct BoardView: View {
                         .tracking(2.0)
                         .foregroundStyle(Theme.C.orangeDeep)
                     Spacer()
+                    // Input-mode chip: VOICE (the product) vs DEMO (the canned
+                    // walk — graduates into onboarding). Tap to toggle;
+                    // launch-arg-forced modes lock it.
+                    Button { model.toggleMode() } label: {
+                        Text(model.walkMode == .voice ? "MIC · VOICE" : "DEMO WALK")
+                            .font(Theme.F.mono(8, .semibold))
+                            .tracking(1.0)
+                            .foregroundStyle(model.walkMode == .voice ? Theme.C.greenTag : Theme.C.yellowTag)
+                            .padding(.horizontal, 6)
+                            .padding(.top, 3)
+                            .padding(.bottom, 2)
+                            .background(model.walkMode == .voice ? Theme.C.greenTint : Theme.C.yellowTint)
+                            .padding(6)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(-6)
+                    .opacity(model.modeLocked ? 0.5 : 1)
+                    .disabled(model.modeLocked)
                     // Vocabulary entry: a stamped chip in the tag grammar —
                     // this is a field tool, not settings, so no gear. Padding
                     // widens the tap target without growing the stamp.
@@ -58,6 +78,32 @@ struct BoardView: View {
             .padding(.horizontal, Theme.S.screenPad)
             .padding(.top, 14)
             .padding(.bottom, 12)
+
+            if model.micDenied {
+                // A voice walk was attempted with mic permission denied.
+                // Same red-note grammar as the photo error bar; tapping goes
+                // straight to the app's Settings pane.
+                Button {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                } label: {
+                    HStack(spacing: 0) {
+                        Theme.C.redTag.frame(width: 3)
+                        Text("MIC IS OFF — SITEWALK CAN'T HEAR YOUR WALK. TAP TO ENABLE IN SETTINGS")
+                            .font(Theme.F.mono(8, .semibold))
+                            .tracking(0.4)
+                            .foregroundStyle(Theme.C.redTag)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 6)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .background(Theme.C.redTint)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.bottom, 10)
+            }
 
             MetaStrip(left: model.trade.boardMeta, right: "SYNCED 07:58")
 

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -87,11 +87,18 @@ struct WalkView: View {
                             )
                     }
                     .buttonStyle(.plain)
+                    // DONE is finishable once ANYTHING has been captured —
+                    // transcript OR extracted items (issue #168). On a voice
+                    // walk the live board lags the speech (batched extraction),
+                    // and finish() runs a full extraction pass anyway, so
+                    // gating on items alone stranded the user on a stuck screen
+                    // whenever items hadn't landed yet. Transcript-or-items.
+                    let nothingCaptured = model.transcript.isEmpty && model.items.isEmpty
                     Button { model.finishWalk() } label: { DoneButton() }
                         .buttonStyle(.plain)
                         .frame(maxWidth: .infinity)
-                        .disabled(model.items.isEmpty)
-                        .opacity(model.items.isEmpty ? 0.4 : 1)
+                        .disabled(nothingCaptured)
+                        .opacity(nothingCaptured ? 0.4 : 1)
                 }
             }
             .padding(.horizontal, Theme.S.screenPad)

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -6,7 +6,6 @@ import PhotosUI
 
 struct WalkView: View {
     @Bindable var model: AppModel
-    var scriptedLabel: Bool
     @State private var showCamera = false
     @State private var pickerItem: PhotosPickerItem?
 
@@ -18,8 +17,8 @@ struct WalkView: View {
 
             MetaStrip(
                 left: model.trade.site,
-                right: scriptedLabel ? "DEMO WALK — SCRIPTED" : "REC — SAVED LOCAL",
-                warn: true
+                right: model.walkMode == .demo ? "DEMO WALK — SCRIPTED" : "REC — ON-DEVICE STT",
+                warn: model.walkMode == .demo
             )
 
             ScrollView {


### PR DESCRIPTION
## Thinking

Your #182 made live mic the default on devices, but mode still only existed as launch arguments — on the simulator the app *looks* like a demo toy, and there's no product-level way to choose. This makes input mode a **user choice**: a persisted stamped chip on the board (green `MIC · VOICE` / yellow `DEMO WALK`), voice default everywhere including the sim (talking to the Mac mic works), demo kept as the explicit secondary mode until it graduates into onboarding (per the #181 discussion — sac reactions coming separately).

Contracts kept: every launch arg still works and now *forces + locks* the mode (`wavwalk`/`live=1` → voice; `demo=1`/`live=0` → demo; `autoflow` → demo so screenshots/CI stay deterministic); forced modes never persist. Mic permission moved to where it belongs — `startWalk`, voice mode only, with a red open-Settings note bar on the board when denied (a walk that can't hear must never start; same posture as throwing `begin()`).

One deletion to flag against D10: the launch-time `SpeechSource.requestPermissions()` ask for `live=1` is gone — whisper never touches Apple Speech Recognition, and the system dialog it triggered carries "speech data will be sent to Apple" copy that is *untrue for this product* (screenshot in thread). The SpeechSource class itself stays (D10); only the wrong ask went.

Verified on sim: fresh install shows VOICE chip; hands-free voice walk runs clean (recording, on-device STT, zero dialogs); autoflow regression green (forced demo, full loop).