### PR TITLE
research: 'sitewalk' is a crowded cluster — rename needed (shortlist inside)

### DIFF
--- a/docs/research/2026-07-08-sitewalk-cluster-competitive.md
+++ b/docs/research/2026-07-08-sitewalk-cluster-competitive.md
@@ -1,0 +1,52 @@
+# Competitive: the "sitewalk" cluster (and why we rename)
+
+*sac, 2026-07-08. Trigger: ASC rename attempt found the name taken; teardown
+followed. sac also installed the closest competitor firsthand.*
+
+## The cluster
+
+At least seven shipping products use the Sitewalk name; five are small
+"AI site reporting" plays launched within ~12 months:
+
+| Product | Who / scale | Price | Output |
+|---|---|---|---|
+| SiteWalk: Smart Field Notes (iOS 6745303434) | solo dev, 3 ratings, broken apex SSL, loading-shell web app | free | voice/photo/video → transcript → "daily reports". sac installed it: **quality is poor firsthand** |
+| Bynaus AI Sitewalk (iOS 6754751858) | Turn 10 LLC, Dec 2025 | $9.99 / $19.99 / $49 mo | narration+photos → captioned, categorized photo docs + email summaries (CompanyCam-with-narration) |
+| SiteWalks.app | tiny | $19.99/mo | voice+photos → formatted walkthrough PDF; copy claims it "adapts to your industry's language" — closest conceptual neighbor |
+| sitewalk.io | minimal, free | basic field reports |
+| Dalux SiteWalk | enterprise vendor | — | 360° reality capture vs BIM — different job entirely |
+| + SiteWalk Insights, sitewalk.co.uk, Raaya Sitewalk | long tail | — | — |
+
+## The finding
+
+**Every product in the cluster stops at "a clean report of what I saw."**
+None of them:
+
+1. produce the MONEY document (estimate with line-item prices, deposit
+   deduction report) — they all ship documentation, not paperwork;
+2. mark unheard values as gaps (they confidently summarize; wrong-number
+   risk is unaddressed);
+3. learn the operator's vocabulary into STT (Apple's speech API cannot —
+   our whisper-biasing loop is structurally unavailable to them);
+4. template per trade.
+
+Five independent founders building the vitamin version in one year is strong
+demand validation for the pain. The painkiller half — R-numbered in the
+vision spec, shipped in our engine — is unclaimed. The July-1 competitive
+read ("thin moat, it's a race") is now empirical; so is "the racers are
+shallow."
+
+## Consequences
+
+- **Rename is mandatory** (trademark + confusion + reputational adjacency).
+  Shortlist researched: **WalkOrder** (no collisions found, walkorder.com
+  available at check time — the pun is the pitch) > Walkdown (industry term,
+  .com taken). Needs: dam+sac pick → CANON revision → ASC name → USPTO
+  screen before anything permanent. Bundle id stays (frozen to the ASC app
+  record; user-invisible).
+- **Positioning language**: never "field notes"/"daily reports"/"AI
+  documentation." Always the output: "the estimate you'd have typed
+  tonight." The demo that wins is SEND, not transcribe.
+- **Urgency**: operator validation before someone in the cluster discovers
+  the document layer. The quality bar out there is low; speed matters more
+  than polish beyond Gate-2.


### PR DESCRIPTION
## Thinking

sac went to do the ASC rename and the name was taken — teardown followed, and it reframes two things. (1) **Rename is mandatory, not cosmetic**: ≥7 shipping products use the name, five of them small AI-site-reporting apps launched in the last year; we'd inherit their confusion and their reputation (sac installed the closest one — poor). Shortlist researched in the doc: **WalkOrder** (clean, .com available, the pun is the pitch) over Walkdown. Needs both our signatures → CANON revision. (2) **The cluster is demand validation**: five independent founders built the *vitamin* (clean reports of what I saw). None produce the money document, none do gaps-not-guesses, none can do vocabulary→STT biasing (Apple's API can't; whisper was the right call). The painkiller lane is empirically unclaimed — positioning and urgency notes in the doc.

Docs-only (skips publish per #186).