### PR TITLE
release: real-engine internal builds (base URL for the baked PPQ key)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,11 @@ jobs:
             "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
             "CURRENT_PROJECT_VERSION=${{ github.run_number }}"
             "PPQ_API_KEY=$PPQ_API_KEY"
+            # A PPQ key against the default Anthropic host 401s silently and
+            # the app LOOKS like the demo engine (sac's #173 icon-tap bug,
+            # release-lane edition). Key = PPQ_API_KEY repo secret; the host
+            # is not secret-sensitive so it lives here in the clear.
+            "ANTHROPIC_BASE_URL=https://api.ppq.ai"
           )
           if [ -n "$MARKETING_VERSION_OVERRIDE" ]; then
             BUILD_SETTINGS+=("MARKETING_VERSION=$MARKETING_VERSION_OVERRIDE")


### PR DESCRIPTION
## Thinking

The 2026-07-10 decision (CANON): internal TestFlight goes real-engine via a repo secret. dam set `PPQ_API_KEY` today, and the reconciled release.yml already threads that secret into the archive's build settings — the ONLY missing piece was the base URL, which was flagged at reconciliation: a PPQ key sent to the default Anthropic host 401s silently and the app looks exactly like the demo engine (sac's #173 icon-tap bug, release-lane edition). One build setting added: `ANTHROPIC_BASE_URL=https://api.ppq.ai` (host isn't secret-sensitive; key stays in the secret; both ride the existing $() Info.plist expansion from #173/#177).

Merging this fires the next build — the first REAL-ENGINE internal TestFlight build. Known accepted risk (CANON): the key ships inside the internal binary; external-lane key handling remains a separate future decision. actionlint exit 0.