### PR TITLE
release: fix overbroad upload-failure grep (false alarm on success)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,8 +325,17 @@ jobs:
             echo "::error::altool exited $STATUS — upload failed"
             exit "$STATUS"
           fi
-          if grep -qiE 'upload failed|error|\*\*\* Error' "$LOG"; then
+          # Match FAILURE signatures only. A bare 'error' pattern matched the
+          # word inside altool's SUCCESS line ("UPLOAD SUCCEEDED with no
+          # errors") and failed build #24's run AFTER Apple accepted it —
+          # require the explicit failure markers, and independently require
+          # the success line to be present.
+          if grep -qiE 'UPLOAD FAILED|ERROR: \[|\*\*\* Error' "$LOG"; then
             echo "::error::altool exited 0 but its output reports a failure — treating as a failed upload"
+            exit 1
+          fi
+          if ! grep -qi 'UPLOAD SUCCEEDED' "$LOG"; then
+            echo "::error::altool exited 0 but never printed UPLOAD SUCCEEDED — treating as a failed upload"
             exit 1
           fi
 


### PR DESCRIPTION
## Thinking

Build #24 was the FIRST build Apple actually accepted (altool: 'UPLOAD SUCCEEDED with no errors') — but the run went red because #194's belt-and-suspenders grep matched the substring 'error' inside 'no errors'. Wrong in the safe direction, but every good publish would alarm. Fix: match explicit failure signatures only (UPLOAD FAILED / 'ERROR: [' / '*** Error'), plus a positive check that UPLOAD SUCCEEDED is present — so both silence-on-failure (the #18–22 bug) and alarm-on-success (the #24 bug) are structurally closed. actionlint exit 0. Merging fires build #25, which double-confirms the fixed step end-to-end.