### PR TITLE
Revert STT default to base.en + add export-compliance key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@
 #     rustup cargo + system Xcode toolchain). Device-only halves the whisper.cpp
 #     compile — a TestFlight archive is device-only anyway.
 #   - provisions the on-device whisper model via apps/ios/fetch-whisper-model.sh
-#     (sha256-pinned, small.en default, ~190 MB) cached with actions/cache.
+#     (sha256-pinned, base.en default) cached with actions/cache.
 #   - project-release.yml (xcodegen) replaces the removed project.yml/Makefile.
 #   - export uses destination=export (produces a signed .ipa artifact); the ASC
 #     upload is a SEPARATE, conditional altool step so a dry-run can verify the
@@ -84,8 +84,8 @@ concurrency:
 env:
   # Model choice + sha256 digests live in apps/ios/fetch-whisper-model.sh (the
   # same script ./generate.sh uses locally) — this is the default it fetches.
-  WHISPER_MODEL: small.en
-  MODEL_FILENAME: ggml-small.en-q5_1.bin
+  WHISPER_MODEL: base.en
+  MODEL_FILENAME: ggml-base.en-q5_1.bin
 
 jobs:
   release:

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -25,12 +25,10 @@ private let engineLog = Logger(subsystem: "com.damsac.sitewalk", category: "engi
 //   sttnsp=<float>                           → STT no_speech_prob drop
 //                                              threshold (default 0.6)
 //   sttmodel=base.en|small.en                → which bundled whisper model to
-//                                              load (default small.en — see
-//                                              resolveSttModelPath). One-arg
-//                                              revert to base.en: small.en's
-//                                              on-device RTF is Mac-proxy
-//                                              evidence only — the iPhone T5
-//                                              tier is PENDING in spikes/stt-whisper/RESULTS.md.
+//                                              load (default base.en — see
+//                                              resolveSttModelPath; small.en
+//                                              is the accuracy opt-in, demoted
+//                                              2026-07-10 after iPhone 16e lag)
 
 /// Engine selection (Plan 07 D10/Task 11): real `MurmurEngine` when an API
 /// key + config resolve, `DemoWalkEngine` when launched with `demo=1` OR
@@ -55,13 +53,11 @@ private func floatLaunchArg(_ prefix: String, in args: [String], default fallbac
 /// Resolves the three whisper knobs from launch args (all overridable for the
 /// on-device sweep and design QA):
 ///   `sttgpu=0|1` — force whisper CPU / GPU (Metal). Default: GPU on device,
-///     CPU on the simulator (Metal hard-crashes on sim — SIGTRAP in
-///     ggml_metal_buffer_set_tensor via MTLSimDevice; D7's "degrades to CPU"
-///     assumption was falsified, so a sim build can never crash by default).
+///     CPU on the simulator (Metal hard-crashes on sim — SIGTRAP via MTLSimDevice).
 ///   `sttvad=<float>` — per-window RMS pre-gate (default 0.0 = decode
 ///     everything; ~0.01 suppresses construction noise without dropping speech).
-///   `sttnsp=<float>` — no_speech_prob drop threshold (default 0.6).
-/// Float args parse defensively (see floatLaunchArg): a typo keeps the default.
+///   `sttnsp=<float>` — no_speech_prob drop threshold (default 0.6). Float args
+///     parse defensively (see floatLaunchArg): a typo keeps the default.
 private struct SttKnobs {
     var useGpu: Bool
     var vadRms: Float
@@ -87,8 +83,8 @@ private func resolveSttKnobs(_ args: [String]) -> SttKnobs {
 /// (superseded by the in-app mode chip — this now only reports an EXPLICIT
 /// arg; absent args defer to the user's persisted choice in AppModel.)
 /// scripted on sim (Metal STT SIGTRAPs on MTLSimDevice; QA assumes scripted),
-/// **live** on device. CAVEAT: small.en's on-device RTF is unmeasured (see
-/// resolveSttModelPath) — `sttmodel=base.en`/`live=0` reverts if too slow.
+/// **live** on device. CAVEAT: small.en caused felt lag on iPhone 16e (sac,
+/// 2026-07-10); base.en is now default — `sttmodel=small.en`/`live=0` opts back in.
 private func resolveLive(_ args: [String]) -> Bool? {
     if args.contains("live=1") { return true }
     if args.contains("live=0") { return false }
@@ -96,22 +92,18 @@ private func resolveLive(_ args: [String]) -> Bool? {
 }
 
 /// Resolves the bundled whisper model path from the `sttmodel=base.en|small.en`
-/// launch arg (default **small.en** — the spike-validated upgrade over
-/// base.en on every measured WER/hallucination axis, `spikes/stt-whisper/
-/// RESULTS.md`). This is the one-arg revert surface: the iPhone T5 device
-/// tier in that same doc is still PENDING, so small.en's on-device RTF is
-/// unproven — launching with `sttmodel=base.en` (or setting
-/// `STT_MODEL=base.en` before `./generate.sh`/`./fetch-whisper-model.sh`)
-/// falls straight back to the previously-shipped default with no code change.
+/// launch arg (default **base.en**). small.en (spike-validated on every
+/// measured WER/hallucination axis, `spikes/stt-whisper/RESULTS.md`) was
+/// DEMOTED 2026-07-10 after real-device lag on iPhone 16e — `sttmodel=
+/// small.en` (or `STT_MODEL=small.en` before `./generate.sh`) opts back in.
 ///
 /// Falls back to whichever model IS bundled if the requested one isn't
-/// present (e.g. only base.en was fetched) — same "degrade, never crash"
-/// posture as the rest of engine resolution. Returns `nil` (text-only) only
-/// if neither model is bundled.
+/// present — same "degrade, never crash" posture as the rest of engine
+/// resolution. Returns `nil` (text-only) only if neither model is bundled.
 private func resolveSttModelPath(_ args: [String]) -> String? {
     let requested = args
         .first(where: { $0.hasPrefix("sttmodel=") })
-        .map { String($0.dropFirst("sttmodel=".count)) } ?? "small.en"
+        .map { String($0.dropFirst("sttmodel=".count)) } ?? "base.en"
     let fallback = requested == "base.en" ? "small.en" : "base.en"
     for name in [requested, fallback] {
         if let path = Bundle.main.path(forResource: "ggml-\(name)-q5_1", ofType: "bin") {
@@ -157,11 +149,10 @@ private func resolveEngine(demo: Bool) -> WalkEngine? {
     let dbPath = appSupport
         .appendingPathComponent("murmur.sqlite3")
         .path
-    // Bundled whisper model (Plan 08 D5; sttmodel= knob added in the
-    // model-download PR) — resolved from the app bundle via
-    // resolveSttModelPath, which also handles the base.en/small.en fallback
-    // and revert. If neither model is bundled the walk degrades to text-only
-    // (no crash): the Rust side treats a nil path as a text-only session.
+    // Bundled whisper model (Plan 08 D5; sttmodel= knob) — resolved via
+    // resolveSttModelPath, which also handles the base.en/small.en fallback.
+    // If neither model is bundled, the walk degrades to text-only (no crash):
+    // the Rust side treats a nil path as a text-only session.
     let args = ProcessInfo.processInfo.arguments
     let sttModelPath = resolveSttModelPath(args)
     if sttModelPath == nil {

--- a/apps/ios/Sources/App/Info.plist
+++ b/apps/ios/Sources/App/Info.plist
@@ -22,6 +22,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Photos you take during a walk pin to the item you're describing and land in the finished document.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/apps/ios/generate.sh
+++ b/apps/ios/generate.sh
@@ -71,19 +71,16 @@ EOF
 
 # Whisper model fetch (Plan 08 D5, model-download PR): the model must be an
 # APP-TARGET resource under Sources/Resources (Bundle.main — a package
-# resource would land in Bundle.module and never resolve). Default model is
-# small.en (spike RESULTS.md: strictly better WER/hallucination than base.en
-# at every measured SNR, ~free RTF headroom on the Mac proxy) — override with
-# STT_MODEL=base.en for the one-arg revert (matches the `sttmodel=` runtime
-# launch arg in GalleryApp.swift). fetch-whisper-model.sh caches on sha256, so
-# repeat runs of generate.sh don't re-download once the file is verified
-# present.
-#
-# CAVEAT: small.en's promotion is decided on Mac-proxy RTF only — the iPhone
-# T5 device tier (spikes/stt-whisper/RESULTS.md Table 4) is still PENDING, so
-# small.en's on-device RTF is unproven. That's why this stays a one-var
-# revert (STT_MODEL=base.en / sttmodel=base.en) rather than a hard swap.
-STT_MODEL="${STT_MODEL:-small.en}"
+# resource would land in Bundle.module and never resolve). small.en was
+# promoted (spike RESULTS.md: strictly better WER/hallucination than base.en
+# at every measured SNR, ~free RTF headroom on the Mac proxy) but DEMOTED
+# 2026-07-10 after real-device lag on iPhone 16e (sac's felt-lag datapoint —
+# the T5 device tier the Mac-proxy numbers couldn't answer; CANON 2026-07-10).
+# Default model is back to base.en — override with STT_MODEL=small.en for the
+# accuracy opt-in (matches the `sttmodel=` runtime launch arg in
+# GalleryApp.swift). fetch-whisper-model.sh caches on sha256, so repeat runs
+# of generate.sh don't re-download once the file is verified present.
+STT_MODEL="${STT_MODEL:-base.en}"
 if ./fetch-whisper-model.sh "$STT_MODEL"; then
   # Exactly ONE model may be bundled: project.yml globs Sources/ wholesale, so
   # if both ggml bins are on disk (e.g. a default small.en run followed by a

--- a/apps/ios/project-release.yml
+++ b/apps/ios/project-release.yml
@@ -52,7 +52,11 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.isaacwm.murmur
-        MARKETING_VERSION: "1.0"
+        # 2.0.0 clears every Era-I version: the old app's last TestFlight build
+        # was 1.0.1 (11), and TestFlight orders versions semantically — testers
+        # on 1.0.1 are never offered a 1.0 build, so rebuild uploads at 1.0
+        # were invisible to them. The rebuild IS the 2.0.
+        MARKETING_VERSION: "2.0.0"
         CURRENT_PROJECT_VERSION: "1"
         # Distribution build is signed. Automatic style lets the archive step
         # cloud-generate the Distribution cert + profile with -allowProvisioningUpdates

--- a/apps/ios/project-release.yml
+++ b/apps/ios/project-release.yml
@@ -42,6 +42,11 @@ targets:
       path: Sources/App/Info.plist
       properties:
         CFBundleDisplayName: Sitewalk
+        # Belt-and-suspenders (see TARGETED_DEVICE_FAMILY comment below): app
+        # uses only exempt (HTTPS/TLS) encryption — no custom crypto. Explicit
+        # here too so a future project.yml edit can't silently drop it and
+        # strand builds on ASC's manual "Missing Compliance" review (build #24).
+        ITSAppUsesNonExemptEncryption: false
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
     settings:

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -33,6 +33,10 @@ targets:
         # the key; empty => provider default (api.anthropic.com).
         ANTHROPIC_BASE_URL: "$(ANTHROPIC_BASE_URL)"
         CFBundleDisplayName: Sitewalk
+        # App uses only exempt (HTTPS/TLS) encryption — no custom crypto. Without
+        # this, every TestFlight build sits on a manual "Missing Compliance"
+        # answer in ASC before testers can install it.
+        ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: "Sitewalk records your walk-and-talk so it can turn it into paperwork."
         NSSpeechRecognitionUsageDescription: "Sitewalk transcribes your walk on-device to build your document."


### PR DESCRIPTION
## Thinking

Three independently-decided, mechanical TestFlight/CANON items in one PR since
none touches shared surface with the others:

**A — device STT default reverts to base.en.** small.en's promotion (#175)
was decided on Mac-proxy RTF numbers only; the iPhone T5 device tier was
explicitly left PENDING at the time. sac's felt-lag datapoint on iPhone 16e
is that pending evidence coming back negative — CANON 2026-07-10 demotes
small.en back to a one-arg opt-in (`STT_MODEL=small.en` / `sttmodel=
small.en`), matching the exact revert mechanism #175 built in for this
scenario. No new code paths — `generate.sh`, `GalleryApp.swift`, and
`release.yml` just flip which model is fetched/loaded/bundled by default.
Both models' sha256 digests already live in `fetch-whisper-model.sh`
(added in #175), so no digest work is needed. Trimmed some unrelated
comment prose in `GalleryApp.swift` to stay under SwiftLint's 400-line
`file_length` gate — the file was already at 409 lines pre-change and this
touch would otherwise have pushed a pre-existing violation further over.

**B — export-compliance key.** Build #24 has been stuck on "Missing
Compliance" in App Store Connect: the Era-I app's export-compliance answer
died at the rebuild pivot, so every TestFlight build now waits on a manual
ASC answer. `apps/ios` uses only exempt (HTTPS/TLS) encryption — no custom
crypto — so the fix is declaring that in Info.plist
(`ITSAppUsesNonExemptEncryption: false`) instead of answering the ASC
prompt by hand on every future upload. Set in both `project.yml` (dev/demo
base) and `project-release.yml` (belt-and-suspenders, mirroring the
existing app-icon-key pattern in that file) so xcodegen bakes it into
every build variant. Per the #177 lesson, the regenerated
`Sources/App/Info.plist` is committed alongside the spec changes so no
checkout needs a manual regen step — verified the diff on that file
contains only the new key.

**C — MARKETING_VERSION 2.0.0.** The rebuild uploads as 1.0, but the Era-I
app's last TestFlight build was 1.0.1 (11) — TestFlight orders versions
semantically, so testers on 1.0.1 are never offered 1.0 builds; dam's
phone still shows the April build. 2.0.0 clears every Era-I version and is
semantically honest: the rebuild IS the 2.0. Release-spec only — the demo
spec carries no MARKETING_VERSION (its Info.plist "1.0" is xcodegen's
default), and the `$(MARKETING_VERSION)` plumbing is untouched, so tag
pushes can still override per lane.

## Test plan

- [x] `cargo test --workspace` — 34 passed, all doctests pass (exit 0)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- [x] `xcodegen generate` (project.yml, demo spec) — regenerates
      `Sources/App/Info.plist` with only `ITSAppUsesNonExemptEncryption`
      added vs. the prior committed version
- [x] `xcodegen generate -s project-release.yml` — generates cleanly;
      pbxproj carries `MARKETING_VERSION = 2.0.0` in both configs
      (release-spec Info.plist churn reverted by regenerating the demo
      spec before commit — committed baseline is the demo output)
- [x] `xcodebuild ... build` (demo, iPhone 17 sim, outside nix) — BUILD
      SUCCEEDED
- [x] `nix run nixpkgs#actionlint -- .github/workflows/release.yml` — clean
- [x] Confirmed `ggml-base.en-q5_1.bin`'s sha256 digest is already present
      in `fetch-whisper-model.sh` (from #175); no digest change needed