### PR TITLE
Plan 13 Stage 1: notes-first core — on-demand build_document (additive)

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -560,6 +560,8 @@ public protocol MurmurEngineProtocol : AnyObject {
      */
     func beginWalk(jobId: String?, template: String) throws  -> WalkSession
     
+    func buildDocument(sessionId: String, kind: String) async throws  -> DocumentPayload
+    
     /**
      * Core's entire file contract (Plan 11 D4): every live photo filename,
      * across all sessions. The shell sweep deletes any file on disk not in
@@ -726,6 +728,23 @@ open func beginWalk(jobId: String?, template: String)throws  -> WalkSession {
         FfiConverterString.lower(template),$0
     )
 })
+}
+    
+open func buildDocument(sessionId: String, kind: String)async throws  -> DocumentPayload {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_ffi_fn_method_murmurengine_build_document(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(sessionId),FfiConverterString.lower(kind)
+                )
+            },
+            pollFunc: ffi_ffi_rust_future_poll_rust_buffer,
+            completeFunc: ffi_ffi_rust_future_complete_rust_buffer,
+            freeFunc: ffi_ffi_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeDocumentPayload.lift,
+            errorHandler: FfiConverterTypeEngineError.lift
+        )
 }
     
     /**
@@ -2058,6 +2077,15 @@ public enum EngineError {
      */
     case Session(message: String)
     
+    /**
+     * An on-demand `build_document(kind)` call failed (Plan 13 D1/D8): a
+     * non-`Processed` session, an illegal `kind` for the session's
+     * template, a poisoned lock, or a store error reading back the
+     * artifact. Never a pricing-LLM failure — that degrades to a queued,
+     * unpriced document instead (R7); this variant is validation/store only.
+     */
+    case Document(message: String)
+    
 }
 
 
@@ -2098,6 +2126,10 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 7: return .Document(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2121,6 +2153,8 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(5))
         case .Session(_ /* message is ignored*/):
             writeInt(&buf, Int32(6))
+        case .Document(_ /* message is ignored*/):
+            writeInt(&buf, Int32(7))
 
         
         }
@@ -2495,6 +2529,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_begin_walk() != 41375) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_build_document() != 48464) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_list_live_photo_filenames() != 39240) {

--- a/crates/ffi/src/document_build.rs
+++ b/crates/ffi/src/document_build.rs
@@ -1,0 +1,184 @@
+//! `MurmurEngine::build_document` (Plan 13 Stage 1, additive): the on-demand
+//! document build. Engine-keyed (D1), NOT `WalkSession`-scoped — `finish()`
+//! nils out its `WalkSession` handle, so a later tap (possibly after
+//! relaunch/from history) has no session object. Photos already solved this
+//! (`add_photo` is engine-keyed); this follows the same precedent.
+//!
+//! Stage 1 is purely additive: `process()`/`finish()` are untouched, so a
+//! `finish()`ed session in this stage already has a `document`-kind artifact
+//! from the OLD forced phase-B call. `build_document` mints and appends a
+//! NEW one (D7: burn-per-tap) and reads back EXACTLY the artifact id the
+//! builder just wrote — never `latest_document_artifact`, since multiple
+//! documents can now coexist for one session.
+
+use murmur_core::DocumentBuilder;
+
+use crate::convert;
+use crate::document::DocumentPayload;
+use crate::engine::{EngineError, MurmurEngine};
+
+#[uniffi::export(async_runtime = "tokio")]
+impl MurmurEngine {
+    pub async fn build_document(
+        &self,
+        session_id: String,
+        kind: String,
+    ) -> Result<DocumentPayload, EngineError> {
+        let builder = DocumentBuilder::new(
+            self.providers.processing.clone(),
+            self.store.clone(),
+            self.memory.clone(),
+            self.memory_store.clone(),
+        );
+        let outcome = builder
+            .build(&session_id, &kind)
+            .await
+            .map_err(|e| EngineError::Document(e.to_string()))?;
+        let artifact = {
+            let store = self
+                .store
+                .lock()
+                .map_err(|_| EngineError::Document("store lock poisoned".into()))?;
+            store.get_artifact(&outcome.document_artifact_id)
+        }
+        .map_err(|e| EngineError::Document(e.to_string()))?;
+        convert::document_payload(&artifact).map_err(|e| EngineError::Document(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use harness::{
+        CompletionResponse, ContentBlock, HarnessError, Memory, MemoryStore, MockProvider,
+        StopReason, Usage,
+    };
+
+    use crate::engine::Providers;
+
+    use super::*;
+
+    struct NullMemoryStore;
+    impl MemoryStore for NullMemoryStore {
+        fn load(&self) -> Result<Memory, HarnessError> {
+            Ok(Memory::default())
+        }
+        fn save(&self, _m: &Memory) -> Result<(), HarnessError> {
+            Ok(())
+        }
+    }
+
+    fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
+        CompletionResponse {
+            content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+        }
+    }
+
+    fn end_turn(text: &str) -> CompletionResponse {
+        CompletionResponse {
+            content: vec![ContentBlock::Text { text: text.into() }],
+            stop_reason: StopReason::EndTurn,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+        }
+    }
+
+    fn summary_response(text: &str) -> CompletionResponse {
+        tool_use("write_summary", serde_json::json!({"summary": text}))
+    }
+
+    /// Stage 1: `finish()` still runs the OLD forced phase-B `build_document`
+    /// call — every successful `process()` makes this call.
+    fn document_response() -> CompletionResponse {
+        tool_use(
+            "build_document",
+            serde_json::json!({"total_kind": "sum", "total_label_key": "total", "lines": []}),
+        )
+    }
+
+    /// Drives a walk through `begin_walk` -> `append_transcript` ->
+    /// `finish()` on `processing` responses `[add_item, end_turn, summary,
+    /// document]` (the Stage-1 phase-B flow), leaving the session `Processed`
+    /// with exactly one authoritative item. Returns the engine + session id.
+    async fn processed_landscape_session(
+        extra_processing_responses: Vec<CompletionResponse>,
+    ) -> (std::sync::Arc<MurmurEngine>, String) {
+        let store = murmur_core::Store::open_in_memory("device-a").unwrap();
+        let mut responses = vec![
+            tool_use("add_item", serde_json::json!({"kind": "todo", "text": "order lumber"})),
+            end_turn("done"),
+            summary_response("Lumber ordered."),
+            document_response(),
+        ];
+        responses.extend(extra_processing_responses);
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(responses)),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        );
+        let session = engine.clone().begin_walk(None, "landscape".into()).unwrap();
+        session.clone().append_transcript("order twelve two by tens for the deck".into());
+        let sid = session.session_id();
+        let _notes = session.finish().await; // Stage 1: still the old DocumentPayload
+        (engine, sid)
+    }
+
+    #[tokio::test]
+    async fn build_document_non_pricing_kind_returns_the_structure_only_document() {
+        let (engine, sid) = processed_landscape_session(vec![]).await;
+
+        let payload = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
+        assert_eq!(payload.doc_kind, "work_order");
+        assert_eq!(payload.doc_number, 1, "a fresh mint for this build_document call");
+        assert_eq!(payload.lines.len(), 1, "the one authoritative item survives finish()'s swap");
+        assert_eq!(payload.lines[0].title, "order lumber");
+        assert!(!payload.queued);
+
+        // Two document artifacts now exist for the session: the OLD phase-B
+        // one written by finish(), and this NEW one — burn-per-tap (D7), and
+        // build_document reads back exactly the one it just wrote, not
+        // latest_document_artifact's ambiguous "most recent of either kind".
+        let store = engine.store.lock().unwrap();
+        let docs: Vec<_> = store
+            .list_artifacts_for_session(&sid)
+            .unwrap()
+            .into_iter()
+            .filter(|a| a.kind == "document")
+            .collect();
+        assert_eq!(docs.len(), 2, "phase-B's document + build_document's new one coexist");
+    }
+
+    #[tokio::test]
+    async fn build_document_illegal_kind_for_template_is_an_engine_error() {
+        let (engine, sid) = processed_landscape_session(vec![]).await;
+        // "condition" is a property-only kind, not legal for landscape.
+        let err = engine.build_document(sid, "condition".into()).await.unwrap_err();
+        assert!(matches!(err, EngineError::Document(_)));
+    }
+
+    #[tokio::test]
+    async fn build_document_pricing_kind_feeds_the_real_item_id_and_lands_a_document() {
+        // The pricing response can't pre-know the run's real minted item id
+        // (Plan 12's C2 pattern), so it echoes a placeholder that will fail
+        // echo-validation — proving the wiring (a price_items request was
+        // made, fed the real id) without needing to pre-script it.
+        let (engine, sid) = processed_landscape_session(vec![tool_use(
+            "price_items",
+            serde_json::json!({"prices": [{"item_id": "placeholder", "amount_cents": 28500}]}),
+        )])
+        .await;
+
+        let payload = engine.build_document(sid, "estimate".into()).await.unwrap();
+        assert_eq!(payload.doc_kind, "estimate");
+        assert_eq!(payload.lines.len(), 1);
+        assert_eq!(payload.lines[0].amount_cents, None, "placeholder id degrades, never crashes");
+        assert!(!payload.queued, "the pricing call itself succeeded (a validation miss, not R7)");
+    }
+}

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -41,6 +41,13 @@ pub enum EngineError {
     /// store error — recoverable, surface don't crash.
     #[error("session error: {0}")]
     Session(String),
+    /// An on-demand `build_document(kind)` call failed (Plan 13 D1/D8): a
+    /// non-`Processed` session, an illegal `kind` for the session's
+    /// template, a poisoned lock, or a store error reading back the
+    /// artifact. Never a pricing-LLM failure — that degrades to a queued,
+    /// unpriced document instead (R7); this variant is validation/store only.
+    #[error("document build error: {0}")]
+    Document(String),
 }
 
 /// Config crossing the FFI boundary. `api_key` is an opaque `String` from the

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -7,6 +7,7 @@ uniffi::setup_scaffolding!();
 
 pub mod convert;
 pub mod document;
+pub mod document_build;
 pub mod engine;
 pub mod events;
 pub mod photos;

--- a/crates/murmur-core/src/lib.rs
+++ b/crates/murmur-core/src/lib.rs
@@ -13,7 +13,11 @@ pub use domain::{
 };
 pub use error::CoreError;
 pub use ids::new_id;
+pub use pipeline::document::{BuildDocumentOutcome, DocumentBuilder};
 pub use pipeline::live::{LiveExtractOutcome, LiveExtractor};
-pub use pipeline::{doc_kind_for_template, ProcessOutcome, SessionProcessor};
+pub use pipeline::{
+    doc_kind_for_template, doc_kinds_for_template, is_pricing_kind, ProcessOutcome,
+    SessionProcessor,
+};
 pub use pipeline::tools::{AddItemTool, BuildDocumentTool, UpsertContactTool, WriteReportTool};
 pub use store::Store;

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -1,0 +1,720 @@
+//! On-demand document builder (Plan 13 D2/D4/D5/D5a/D6/D7/D8/D9): renders the
+//! document structure deterministically from the session's authoritative
+//! items (no LLM), then for pricing kinds runs one focused items-only
+//! pricing pass (R6). A document always lands — pricing failure degrades to
+//! an unpriced structure-only document, never a hard failure (R7).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use harness::{
+    CompletionRequest, ContentBlock, HarnessError, LlmProvider, Memory, MemoryStore, Message,
+    ToolSpec, Usage,
+};
+
+use crate::domain::{Artifact, CapturedItem, SessionStatus};
+use crate::error::CoreError;
+use crate::pipeline::{doc_kinds_for_template, is_pricing_kind};
+use crate::store::Store;
+
+/// C1: whether a rendered line defaults to `is_gap: true`. `PerPricingKind`
+/// is the on-demand build's normal policy (D4); `AllGap` is reserved for a
+/// degraded/offline render where nothing has been through the LLM at all —
+/// "amount not yet priced" != "nothing has been through the LLM" (a naive
+/// `is_pricing_kind` delegation would wrongly flip a degraded non-pricing
+/// document to looks-confirmed).
+///
+/// `AllGap` is not constructed by any Stage-1 production caller —
+/// `DocumentBuilder::build` (the only caller) always renders with
+/// `PerPricingKind`; the offline/degraded fallback stays on its own
+/// `ffi::convert::partial_document_from_items` implementation by design (see
+/// `render_structure_document`'s doc comment). It exists as the documented
+/// N2 parity contract, pinned by the cross-check tests below — hence the
+/// explicit `allow` rather than deleting a variant this plan defines.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GapPolicy {
+    PerPricingKind,
+    #[allow(dead_code)]
+    AllGap,
+}
+
+/// Deterministic, no-LLM structure render (D4): one line per item, in item
+/// order, using a FRESH `new_id()` per line (`line.id != item_id`, the
+/// `build_document`-tool convention). Field shape matches
+/// `BuildDocumentTool`'s emitted lines exactly.
+///
+/// **Parity contract with the FFI offline fallback** (N2 —
+/// `crates/ffi/src/convert.rs::partial_document_from_items`): calling this
+/// with `GapPolicy::AllGap` produces lines with IDENTICAL
+/// title/detail/qty/amount_cents/section/item_id/is_gap semantics — title =
+/// item.text, detail = "", qty = "", amount_cents = None, section = None,
+/// is_gap = true, item_id = Some(item.id) — waiving only the `id` field (the
+/// offline fallback legacy-sets `line.id = item.id`; this render uses a
+/// fresh id). The two implementations are kept in lockstep by this
+/// documented contract (pinned by the cross-check test below), not by
+/// sharing code across the crate boundary — `ffi` depends on `murmur-core`,
+/// never the reverse, so this function can't call (or be called by) it.
+pub(crate) fn render_structure_document(
+    doc_kind: &str,
+    items: &[CapturedItem],
+    gap: GapPolicy,
+) -> Vec<serde_json::Value> {
+    items
+        .iter()
+        .map(|item| {
+            let is_gap = match gap {
+                GapPolicy::AllGap => true,
+                GapPolicy::PerPricingKind => is_pricing_kind(doc_kind),
+            };
+            serde_json::json!({
+                "id": crate::ids::new_id(),
+                "title": item.text,
+                "detail": "",
+                "qty": "",
+                "amount_cents": null,
+                "section": null,
+                "is_gap": is_gap,
+                "item_id": item.id,
+            })
+        })
+        .collect()
+}
+
+const PRICE_ITEMS: &str = "price_items";
+
+fn price_items_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: PRICE_ITEMS.into(),
+        description: "Attach a price to each item that should carry one. You may price only \
+                       items from the given list, by their exact item_id — you cannot add, \
+                       rename, or drop items."
+            .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "prices": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "item_id": { "type": "string" },
+                            "amount_cents": { "type": "integer" }
+                        },
+                        "required": ["item_id", "amount_cents"]
+                    }
+                },
+                "total_cents": { "type": "integer" }
+            },
+            "required": ["prices"]
+        }),
+    }
+}
+
+fn format_pricing_items(items: &[CapturedItem]) -> String {
+    items
+        .iter()
+        .map(|i| format!("- [{}] {} (item_id: {})", i.kind, i.text, i.id))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// D5/D5a: one focused pricing pass whose input is the items only (never the
+/// transcript, R6) plus an optional single scalar hint (the operator's
+/// spoken grand total, captured at summary time). The forced tool's output
+/// schema can only attach an amount to an `item_id` already in `items` — it
+/// has no line-authoring power: the line count is fixed by the deterministic
+/// structure render, only amounts can move. Echo-and-validate + first-wins
+/// dedup mirror Plan 12's `item_id` pattern.
+///
+/// Usage is accumulated into `usage` as soon as a response arrives (R9: a
+/// response that fails to parse into a valid tool call still cost tokens) —
+/// BEFORE this function's own success/failure is decided, matching
+/// `run_build_document`/`summarize`'s pattern elsewhere in this pipeline.
+/// (This is a small, deliberate signature addition vs the plan's literal
+/// `-> Result<HashMap<...>, HarnessError>` — an out-param is needed so a
+/// degrade path that reached the API but got an unparseable response still
+/// logs its cost; a `provider.complete` `Err` itself carries no usage, so the
+/// zero-token case is unaffected.)
+pub(crate) async fn price_items(
+    provider: &Arc<dyn LlmProvider>,
+    items: &[CapturedItem],
+    spoken_total_cents: Option<i64>,
+    memory_prompt: &str,
+    max_tokens: u32,
+    usage: &mut Usage,
+) -> Result<HashMap<String, i64>, HarnessError> {
+    let memory_block = if memory_prompt.trim().is_empty() {
+        String::new()
+    } else {
+        format!("\n\nWhat you know about this user:\n{memory_prompt}")
+    };
+    let system = format!(
+        "You price items from a field-work session for a tradesperson's estimate/invoice. \
+         Put a price only on an item whose value you can reasonably infer from its text and \
+         what you know about this user's pricing history — never guess wildly. You may price \
+         only items from the given list, by their exact item_id.{memory_block}"
+    );
+    let hint_block = spoken_total_cents
+        .map(|cents| {
+            format!(
+                "\n\nOperator's stated target total: ${:.2} — allocate line prices consistent with this.",
+                cents as f64 / 100.0
+            )
+        })
+        .unwrap_or_default();
+    let items_block = format_pricing_items(items);
+    let user_message = format!("Price these items.\n\n{items_block}{hint_block}");
+
+    let response = provider
+        .complete(CompletionRequest {
+            system,
+            messages: vec![Message::user_text(user_message)],
+            tools: vec![price_items_tool_spec()],
+            max_tokens,
+            tool_choice: Some(PRICE_ITEMS.to_string()),
+        })
+        .await?;
+    usage.add(&response.usage);
+
+    let input = response.content.iter().find_map(|b| match b {
+        ContentBlock::ToolUse { name, input, .. } if name == PRICE_ITEMS => Some(input.clone()),
+        _ => None,
+    });
+    let input = input.ok_or_else(|| {
+        HarnessError::Provider("price_items response missing price_items call".into())
+    })?;
+
+    let valid_ids: HashSet<&str> = items.iter().map(|i| i.id.as_str()).collect();
+    let mut map: HashMap<String, i64> = HashMap::new();
+    if let Some(prices) = input.get("prices").and_then(|v| v.as_array()) {
+        for p in prices {
+            let (Some(id), Some(amount)) = (
+                p.get("item_id").and_then(|v| v.as_str()),
+                p.get("amount_cents").and_then(|v| v.as_i64()),
+            ) else {
+                continue;
+            };
+            // First-wins dedup; unknown/hallucinated ids are dropped — never
+            // fail the whole pass over one bad row.
+            if valid_ids.contains(id) && !map.contains_key(id) {
+                map.insert(id.to_string(), amount);
+            }
+        }
+    }
+    Ok(map)
+}
+
+/// Applies validated prices onto rendered lines: a line whose `item_id` is a
+/// key in `map` gets `amount_cents` set and flips `is_gap: false`. `map` is
+/// already deduped by `price_items`; `claimed` is belt-and-suspenders against
+/// a future caller passing a map with a colliding line target.
+fn apply_prices(map: &HashMap<String, i64>, lines: &mut [serde_json::Value]) {
+    let mut claimed: HashSet<String> = HashSet::new();
+    for line in lines.iter_mut() {
+        let Some(item_id) = line.get("item_id").and_then(|v| v.as_str()).map(str::to_string)
+        else {
+            continue;
+        };
+        if claimed.contains(&item_id) {
+            continue;
+        }
+        if let Some(&amount) = map.get(&item_id) {
+            line["amount_cents"] = serde_json::json!(amount);
+            line["is_gap"] = serde_json::json!(false);
+            claimed.insert(item_id);
+        }
+    }
+}
+
+/// Total-shape per `doc_kind` (mirrors `ffi::convert::partial_document_from_items`):
+/// an inspection has no summable dollar total; everything else sums its lines.
+fn total_shape(doc_kind: &str) -> (&'static str, &'static str) {
+    match doc_kind {
+        "inspection" => ("static", "findings"),
+        _ => ("sum", "total"),
+    }
+}
+
+/// The result of one `DocumentBuilder::build` call (D7: burn-per-tap — every
+/// call mints a fresh document number and writes a new snapshot artifact).
+#[derive(Debug)]
+pub struct BuildDocumentOutcome {
+    pub document_artifact_id: String,
+    pub usage: Usage,
+    /// D5/C: true when the pricing pass could not run to completion (a
+    /// pricing-kind build whose LLM call failed) — reused posture of the
+    /// offline `queued` flag ("document incomplete — pricing did not run").
+    /// `false` for a non-pricing kind or a fully-priced/attempted document.
+    pub queued: bool,
+}
+
+/// On-demand document builder (D1/D8/D9), engine-keyed by the caller (FFI
+/// `MurmurEngine::build_document`, not `WalkSession`-scoped — the walk may
+/// already be over and its `WalkSession` handle dropped).
+pub struct DocumentBuilder {
+    provider: Arc<dyn LlmProvider>,
+    store: Arc<Mutex<Store>>,
+    memory: Arc<Mutex<Memory>>,
+    /// Reserved: a future price-book seam (D6) may consult saved facts
+    /// directly rather than only the rendered `to_prompt()` text.
+    #[allow(dead_code)]
+    memory_store: Arc<dyn MemoryStore>,
+    /// Pricing-call output budget.
+    pub max_tokens: u32,
+}
+
+impl DocumentBuilder {
+    pub fn new(
+        provider: Arc<dyn LlmProvider>,
+        store: Arc<Mutex<Store>>,
+        memory: Arc<Mutex<Memory>>,
+        memory_store: Arc<dyn MemoryStore>,
+    ) -> Self {
+        DocumentBuilder { provider, store, memory, memory_store, max_tokens: 1024 }
+    }
+
+    fn locked(&self) -> Result<std::sync::MutexGuard<'_, Store>, CoreError> {
+        self.store
+            .lock()
+            .map_err(|_| CoreError::InvalidState("store lock poisoned".into()))
+    }
+
+    /// D8 validation, D4 structure render, D5/D5a pricing pass, D7 mint +
+    /// persist. Never a hard failure on a pricing LLM error (R7) — degrades
+    /// to `queued: true` with an unpriced structure-only document instead.
+    pub async fn build(
+        &self,
+        session_id: &str,
+        doc_kind: &str,
+    ) -> Result<BuildDocumentOutcome, CoreError> {
+        let (session, items) = {
+            let store = self.locked()?;
+            let session = store.get_session(session_id)?;
+            if session.status != SessionStatus::Processed {
+                return Err(CoreError::InvalidState(format!(
+                    "cannot build a document for a {} session",
+                    session.status.as_str()
+                )));
+            }
+            let legal = doc_kinds_for_template(session.template.as_deref());
+            if !legal.contains(&doc_kind) {
+                return Err(CoreError::InvalidState(format!(
+                    "'{doc_kind}' is not a legal document kind for template {:?}",
+                    session.template
+                )));
+            }
+            let items = store.list_items_for_session(session_id)?;
+            (session, items)
+        };
+
+        let mut lines = render_structure_document(doc_kind, &items, GapPolicy::PerPricingKind);
+        let mut usage = Usage::default();
+        let mut queued = false;
+
+        if is_pricing_kind(doc_kind) && !items.is_empty() {
+            let hint = self.session_spoken_total(session_id)?;
+            let memory_prompt = self
+                .memory
+                .lock()
+                .map_err(|_| CoreError::InvalidState("memory lock poisoned".into()))?
+                .to_prompt();
+            match price_items(
+                &self.provider,
+                &items,
+                hint,
+                &memory_prompt,
+                self.max_tokens,
+                &mut usage,
+            )
+            .await
+            {
+                Ok(map) => apply_prices(&map, &mut lines),
+                // R7: never a hard failure — the structure-only document
+                // still lands, just unpriced and flagged queued (D5 degrade).
+                Err(_) => queued = true,
+            }
+        }
+
+        let (total_kind, total_label_key) = total_shape(doc_kind);
+        let payload = serde_json::json!({
+            "doc_kind": doc_kind,
+            "job_date_unix": session.started_at,
+            "total_kind": total_kind,
+            "total_label_key": total_label_key,
+            "static_total_cents": serde_json::Value::Null,
+            "lines": lines,
+            "queued": queued,
+        });
+
+        // D7: always mint a fresh number and write a new snapshot artifact —
+        // burn per tap, never reuse (regenerate leaves prior snapshots intact).
+        let artifact = self
+            .locked()?
+            .mint_document_number_and_add_artifact(session_id, doc_kind, None, payload)?;
+
+        // D9: log a "document"-purpose usage row only if a call was actually
+        // made (non-pricing kinds and the empty-items skip make zero calls).
+        if usage != Usage::default() {
+            self.locked()?.record_llm_usage(Some(session_id), "document", &usage)?;
+        }
+
+        Ok(BuildDocumentOutcome { document_artifact_id: artifact.id, usage, queued })
+    }
+
+    /// D5a: reads the `session_meta` artifact (if any) written by `process()`
+    /// on success and returns its `spoken_total_cents` scalar. `None` when no
+    /// meta artifact exists, or it exists but the field is absent (no total
+    /// was clearly stated, R6).
+    fn session_spoken_total(&self, session_id: &str) -> Result<Option<i64>, CoreError> {
+        let artifacts = self.locked()?.list_artifacts_for_session(session_id)?;
+        let meta: Option<&Artifact> = artifacts.iter().rev().find(|a| a.kind == "session_meta");
+        Ok(meta
+            .and_then(|a| serde_json::from_str::<serde_json::Value>(&a.body).ok())
+            .and_then(|v| v.get("spoken_total_cents").and_then(|n| n.as_i64())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use harness::{ContentBlock, MockProvider, StopReason};
+
+    use crate::domain::ItemSource;
+    use crate::store::Store;
+
+    use super::*;
+
+    struct NullMemoryStore;
+    impl MemoryStore for NullMemoryStore {
+        fn load(&self) -> Result<Memory, HarnessError> {
+            Ok(Memory::default())
+        }
+        fn save(&self, _m: &Memory) -> Result<(), HarnessError> {
+            Ok(())
+        }
+    }
+
+    fn tool_use(name: &str, input: serde_json::Value) -> harness::CompletionResponse {
+        harness::CompletionResponse {
+            content: vec![ContentBlock::ToolUse { id: "tu_1".into(), name: name.into(), input }],
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 80, output_tokens: 15 },
+        }
+    }
+
+    fn items(store: &Store, sid: &str, texts: &[(&str, &str)]) -> Vec<CapturedItem> {
+        texts
+            .iter()
+            .map(|(kind, text)| {
+                store.add_item_with_source(sid, kind, text, ItemSource::Authoritative).unwrap()
+            })
+            .collect()
+    }
+
+    // ---- Task 2: render_structure_document / GapPolicy -----------------
+
+    #[test]
+    fn per_pricing_kind_flags_gaps_only_for_pricing_kinds() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let its = items(&store, &session.id, &[("todo", "order lumber"), ("safety", "loose railing")]);
+
+        let est_lines = render_structure_document("estimate", &its, GapPolicy::PerPricingKind);
+        assert_eq!(est_lines.len(), 2);
+        for (line, item) in est_lines.iter().zip(&its) {
+            assert_eq!(line["amount_cents"], serde_json::Value::Null);
+            assert_eq!(line["is_gap"], true, "estimate lines are gaps until priced");
+            assert_eq!(line["item_id"], item.id);
+            assert_eq!(line["section"], serde_json::Value::Null);
+            assert_eq!(line["title"], item.text);
+            assert_ne!(line["id"], line["item_id"], "on-demand render uses a fresh new_id");
+        }
+
+        let insp_lines = render_structure_document("inspection", &its, GapPolicy::PerPricingKind);
+        for line in &insp_lines {
+            assert_eq!(line["is_gap"], false, "a normal finding is not a gap");
+        }
+    }
+
+    #[test]
+    fn all_gap_flags_every_line_regardless_of_kind() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let its = items(&store, &session.id, &[("todo", "order lumber")]);
+
+        let lines = render_structure_document("inspection", &its, GapPolicy::AllGap);
+        assert_eq!(
+            lines[0]["is_gap"],
+            true,
+            "a degraded inspection is wholly unconfirmed, not merely unpriced (C1)"
+        );
+    }
+
+    /// N2 cross-check: `AllGap` output matches the documented field contract
+    /// of `ffi::convert::partial_document_from_items` (title/detail/qty/
+    /// amount_cents/section/item_id/is_gap), waiving only `id`.
+    #[test]
+    fn all_gap_matches_the_offline_fallback_contract_except_id() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let its = items(&store, &session.id, &[("todo", "haul debris")]);
+
+        let lines = render_structure_document("estimate", &its, GapPolicy::AllGap);
+        let line = &lines[0];
+        let item = &its[0];
+        assert_eq!(line["title"], item.text);
+        assert_eq!(line["detail"], "");
+        assert_eq!(line["qty"], "");
+        assert_eq!(line["amount_cents"], serde_json::Value::Null);
+        assert_eq!(line["section"], serde_json::Value::Null);
+        assert_eq!(line["is_gap"], true);
+        assert_eq!(line["item_id"], item.id);
+        // id is deliberately NOT compared — the offline fallback sets
+        // line.id = item.id; this render always mints a fresh id.
+    }
+
+    // ---- Task 3: price_items echo-validate ------------------------------
+
+    #[tokio::test]
+    async fn price_items_echoes_and_validates_first_wins() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let its = items(&store, &session.id, &[("todo", "mulch"), ("todo", "edging")]);
+        let a1 = its[0].id.clone();
+        let a2 = its[1].id.clone();
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![tool_use(
+            "price_items",
+            serde_json::json!({
+                "prices": [
+                    {"item_id": a1, "amount_cents": 28500},
+                    {"item_id": "bogus", "amount_cents": 999},
+                    {"item_id": a2, "amount_cents": 31000},
+                    {"item_id": a2, "amount_cents": 99999}
+                ]
+            }),
+        )]));
+
+        let mut usage = Usage::default();
+        let map = price_items(&provider, &its, None, "", 512, &mut usage).await.unwrap();
+        assert_eq!(map.get(a1.as_str()), Some(&28500));
+        assert_eq!(map.get(a2.as_str()), Some(&31000), "first-wins on the duplicate a2");
+        assert_eq!(map.get("bogus"), None, "hallucinated id dropped");
+        assert_eq!(map.len(), 2);
+        assert_eq!(usage, Usage { input_tokens: 80, output_tokens: 15 });
+    }
+
+    #[tokio::test]
+    async fn price_items_fed_the_spoken_total_hint_never_the_transcript() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let its = items(&store, &session.id, &[("todo", "mulch")]);
+        let a1 = its[0].id.clone();
+
+        let provider = Arc::new(MockProvider::new(vec![tool_use(
+            "price_items",
+            serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 120000}]}),
+        )]));
+        let dyn_provider: Arc<dyn LlmProvider> = provider.clone();
+        let mut usage = Usage::default();
+        price_items(&dyn_provider, &its, Some(120000), "", 512, &mut usage).await.unwrap();
+
+        let reqs = provider.requests();
+        let ContentBlock::Text { text } = &reqs[0].messages[0].content[0] else {
+            panic!("expected text content");
+        };
+        assert!(text.contains("1200.00"), "the scalar hint reaches the prompt: {text}");
+        assert!(!text.to_lowercase().contains("transcript"), "never the transcript: {text}");
+    }
+
+    // ---- Task 3: DocumentBuilder::build ---------------------------------
+
+    fn processed_session_with_items(
+        texts: &[(&str, &str)],
+    ) -> (Store, String) {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session_with_template(None, "landscape").unwrap();
+        let mut run_item_ids = Vec::new();
+        for (kind, text) in texts {
+            let item =
+                store.add_item_with_source(&session.id, kind, text, ItemSource::Authoritative).unwrap();
+            run_item_ids.push(item.id);
+        }
+        store.append_transcript(&session.id, "site walk").unwrap();
+        store.end_and_record_session(&session.id).unwrap();
+        store
+            .finish_session_processed(
+                &session.id,
+                "Walked the site.",
+                &Usage::default(),
+                &run_item_ids,
+            )
+            .unwrap();
+        (store, session.id)
+    }
+
+    fn builder(
+        store: Arc<Mutex<Store>>,
+        provider: Arc<dyn LlmProvider>,
+    ) -> DocumentBuilder {
+        DocumentBuilder::new(provider, store, Arc::new(Mutex::new(Memory::default())), Arc::new(NullMemoryStore))
+    }
+
+    #[tokio::test]
+    async fn build_happy_path_prices_and_mints_a_document() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch"), ("safety", "loose railing")]);
+        // Re-read the real minted ids so the scripted response can echo one.
+        let a1 = store.list_items_for_session(&sid).unwrap()[0].id.clone();
+        let store = Arc::new(Mutex::new(store));
+
+        let provider = Arc::new(MockProvider::new(vec![tool_use(
+            "price_items",
+            serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 28500}]}),
+        )]));
+        let b = builder(store.clone(), provider);
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        assert!(!outcome.queued);
+        assert_eq!(outcome.usage, Usage { input_tokens: 80, output_tokens: 15 });
+
+        let store = store.lock().unwrap();
+        let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
+        assert_eq!(v["doc_number"], 1);
+        let lines = v["lines"].as_array().unwrap();
+        let priced = lines.iter().find(|l| l["item_id"] == a1).unwrap();
+        assert_eq!(priced["amount_cents"], 28500);
+        assert_eq!(priced["is_gap"], false);
+        let gap = lines.iter().find(|l| l["item_id"] != a1).unwrap();
+        assert_eq!(gap["amount_cents"], serde_json::Value::Null);
+        assert_eq!(gap["is_gap"], true);
+
+        let usage_rows = store.list_llm_usage_for_session(&sid).unwrap();
+        let document_rows: Vec<_> = usage_rows.iter().filter(|r| r.purpose == "document").collect();
+        assert_eq!(
+            document_rows.len(),
+            1,
+            "exactly one 'document'-purpose row (the fixture's finish_session_processed \
+             already logs its own 'processing' row separately)"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_degrades_to_unpriced_and_queued_on_llm_failure() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch")]);
+        let store = Arc::new(Mutex::new(store));
+        // Empty response queue -> provider errors on the pricing call.
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider);
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        assert!(outcome.queued, "pricing LLM failure degrades, never a hard failure (R7)");
+
+        let store = store.lock().unwrap();
+        let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
+        assert_eq!(v["doc_number"], 1, "the document still mints and lands");
+        assert_eq!(v["queued"], true);
+        for line in v["lines"].as_array().unwrap() {
+            assert_eq!(line["amount_cents"], serde_json::Value::Null);
+        }
+    }
+
+    #[tokio::test]
+    async fn build_non_pricing_kind_makes_zero_calls() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch")]);
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "work_order").await.unwrap();
+        assert!(!outcome.queued);
+        assert_eq!(outcome.usage, Usage::default());
+        assert!(provider.requests().is_empty(), "non-pricing kinds never call the LLM");
+
+        let store = store.lock().unwrap();
+        assert!(
+            store
+                .list_llm_usage_for_session(&sid)
+                .unwrap()
+                .iter()
+                .all(|r| r.purpose != "document"),
+            "non-pricing kinds log no 'document'-purpose usage row"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_rejects_non_processed_sessions_and_illegal_kinds() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session_with_template(None, "landscape").unwrap();
+        let store = Arc::new(Mutex::new(store));
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider);
+
+        // Not Processed yet (still Recording).
+        assert!(matches!(b.build(&session.id, "estimate").await, Err(CoreError::InvalidState(_))));
+
+        let (store2, sid2) = processed_session_with_items(&[]);
+        let store2 = Arc::new(Mutex::new(store2));
+        let provider2: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![]));
+        let b2 = builder(store2, provider2);
+        // "inspection" is not legal for the landscape template.
+        assert!(matches!(b2.build(&sid2, "inspection").await, Err(CoreError::InvalidState(_))));
+    }
+
+    #[tokio::test]
+    async fn build_empty_but_processed_session_yields_a_truthful_zero_line_document() {
+        let (store, sid) = processed_session_with_items(&[]);
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        assert!(!outcome.queued);
+        assert!(provider.requests().is_empty(), "nothing to price for zero items — skip the call");
+
+        let store = store.lock().unwrap();
+        let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
+        assert_eq!(v["doc_number"], 1);
+        assert!(v["lines"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_threads_the_spoken_total_hint_and_absence_when_no_meta_artifact() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch"), ("safety", "loose railing")]);
+        let a1 = store.list_items_for_session(&sid).unwrap()[0].id.clone();
+        store
+            .add_artifact(&sid, "session_meta", "meta", &serde_json::json!({"spoken_total_cents": 120000}).to_string())
+            .unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let provider = Arc::new(MockProvider::new(vec![tool_use(
+            "price_items",
+            serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 95000}]}),
+        )]));
+        let b = builder(store.clone(), provider.clone());
+        b.build(&sid, "estimate").await.unwrap();
+
+        let reqs = provider.requests();
+        let ContentBlock::Text { text } = &reqs[0].messages[0].content[0] else {
+            panic!("expected text content");
+        };
+        assert!(text.contains("1200.00"), "the spoken total hint reaches the pricing prompt: {text}");
+
+        // A session with no session_meta artifact gets no hint line at all.
+        let (store2, sid2) = processed_session_with_items(&[("todo", "haul")]);
+        let a2 = store2.list_items_for_session(&sid2).unwrap()[0].id.clone();
+        let store2 = Arc::new(Mutex::new(store2));
+        let provider2 = Arc::new(MockProvider::new(vec![tool_use(
+            "price_items",
+            serde_json::json!({"prices": [{"item_id": a2, "amount_cents": 5000}]}),
+        )]));
+        let b2 = builder(store2, provider2.clone());
+        b2.build(&sid2, "estimate").await.unwrap();
+        let reqs2 = provider2.requests();
+        let ContentBlock::Text { text: text2 } = &reqs2[0].messages[0].content[0] else {
+            panic!("expected text content");
+        };
+        assert!(!text2.contains("stated target total"), "no hint line without a meta artifact: {text2}");
+    }
+}

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -7,6 +7,8 @@ pub mod tools;
 
 pub mod live;
 
+pub mod document;
+
 pub(crate) mod prompts;
 
 use std::sync::{Arc, Mutex};
@@ -22,17 +24,34 @@ use crate::error::CoreError;
 use crate::store::Store;
 use tools::{AddItemTool, BuildDocumentTool, UpsertContactTool, WriteReportTool};
 
-/// Maps a session's template key (D4: `landscape`|`property`|`inspection`) to
-/// the document's `doc_kind` vocabulary (D2/D5: `estimate`|`report`|
-/// `inspection`) that `BuildDocumentTool` and document-number minting use.
-/// `None`/unrecognized defaults to `report` — the safest shape (mixed
-/// dollar/non-dollar lines, gaps only where explicitly flagged).
-pub fn doc_kind_for_template(template: Option<&str>) -> &'static str {
+/// Plan 13 D8: the legal `doc_kind` vocabulary for a session's template, in
+/// priority order (`[0]` is the template's default kind — see
+/// `doc_kind_for_template`). This is core's concern (kind vocabulary +
+/// pricing flags); which button *leads* and its label copy are sac's.
+pub fn doc_kinds_for_template(template: Option<&str>) -> &'static [&'static str] {
     match template {
-        Some("landscape") => "estimate",
-        Some("inspection") => "inspection",
-        _ => "report",
+        Some("landscape") => &["estimate", "invoice", "work_order"],
+        Some("property") => &["condition", "move_out"],
+        Some("inspection") => &["inspection"],
+        _ => &["report"],
     }
+}
+
+/// Plan 13 D5: whether a `doc_kind` needs a pricing pass (an amount on every
+/// line). Only `estimate`/`invoice` are pricing kinds.
+pub fn is_pricing_kind(kind: &str) -> bool {
+    matches!(kind, "estimate" | "invoice")
+}
+
+/// Maps a session's template key (D4: `landscape`|`property`|`inspection`) to
+/// the document's default `doc_kind` (D2/D5) that `BuildDocumentTool` and
+/// document-number minting use. **Plan 13 N3:** redefined as
+/// `doc_kinds_for_template(t)[0]` — the property default CHANGES from
+/// `"report"` to `"condition"` (property's own legal-kind list starts with
+/// `condition`, not `report`; the old `_ => "report"` arm landed outside
+/// property's own list). `None`/unrecognized still defaults to `report`.
+pub fn doc_kind_for_template(template: Option<&str>) -> &'static str {
+    doc_kinds_for_template(template)[0]
 }
 
 #[derive(Debug)]
@@ -920,6 +939,45 @@ mod tests {
             Arc::new(NullMemoryStore),
         );
         assert!(processor.process_pending().await.unwrap().is_empty());
+    }
+
+    /// Plan 13 Task 1: the legal `doc_kind` vocabulary + pricing flags per
+    /// template.
+    #[test]
+    fn doc_kinds_for_template_lists_the_legal_kinds_per_template() {
+        assert_eq!(
+            doc_kinds_for_template(Some("landscape")),
+            &["estimate", "invoice", "work_order"]
+        );
+        assert_eq!(doc_kinds_for_template(Some("property")), &["condition", "move_out"]);
+        assert_eq!(doc_kinds_for_template(Some("inspection")), &["inspection"]);
+        assert_eq!(doc_kinds_for_template(None), &["report"]);
+    }
+
+    #[test]
+    fn is_pricing_kind_flags_only_estimate_and_invoice() {
+        assert!(is_pricing_kind("estimate"));
+        assert!(is_pricing_kind("invoice"));
+        assert!(!is_pricing_kind("work_order"));
+        assert!(!is_pricing_kind("inspection"));
+        assert!(!is_pricing_kind("report"));
+        assert!(!is_pricing_kind("condition"));
+    }
+
+    /// Plan 13 N3: `doc_kind_for_template` is redefined as
+    /// `doc_kinds_for_template(t)[0]` — the property default CHANGES from
+    /// today's `"report"` to `"condition"` (property's own legal-kind list
+    /// starts with `condition`, not `report`).
+    #[test]
+    fn doc_kind_for_template_is_the_first_legal_kind() {
+        assert_eq!(doc_kind_for_template(Some("landscape")), "estimate");
+        assert_eq!(doc_kind_for_template(Some("inspection")), "inspection");
+        assert_eq!(doc_kind_for_template(None), "report");
+        assert_eq!(
+            doc_kind_for_template(Some("property")),
+            "condition",
+            "property's default CHANGES from report to condition (N3)"
+        );
     }
 
     #[tokio::test]

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -25,8 +25,9 @@ use crate::store::Store;
 use tools::{AddItemTool, BuildDocumentTool, UpsertContactTool, WriteReportTool};
 
 /// Plan 13 D8: the legal `doc_kind` vocabulary for a session's template, in
-/// priority order (`[0]` is the template's default kind — see
-/// `doc_kind_for_template`). This is core's concern (kind vocabulary +
+/// priority order (`[0]` becomes the template's default kind when Stage 2
+/// redefines `doc_kind_for_template` as `[0]` — deferred, see that
+/// function's doc comment). This is core's concern (kind vocabulary +
 /// pricing flags); which button *leads* and its label copy are sac's.
 pub fn doc_kinds_for_template(template: Option<&str>) -> &'static [&'static str] {
     match template {
@@ -44,14 +45,31 @@ pub fn is_pricing_kind(kind: &str) -> bool {
 }
 
 /// Maps a session's template key (D4: `landscape`|`property`|`inspection`) to
-/// the document's default `doc_kind` (D2/D5) that `BuildDocumentTool` and
-/// document-number minting use. **Plan 13 N3:** redefined as
-/// `doc_kinds_for_template(t)[0]` — the property default CHANGES from
-/// `"report"` to `"condition"` (property's own legal-kind list starts with
-/// `condition`, not `report`; the old `_ => "report"` arm landed outside
-/// property's own list). `None`/unrecognized still defaults to `report`.
+/// the document's `doc_kind` vocabulary (D2/D5: `estimate`|`report`|
+/// `inspection`) that `BuildDocumentTool` and document-number minting use.
+/// `None`/unrecognized defaults to `report` — the safest shape (mixed
+/// dollar/non-dollar lines, gaps only where explicitly flagged).
+///
+/// **Plan 13 N3 — deliberately DEFERRED to Stage 2 (review blocker).** The
+/// plan redefines this as `doc_kinds_for_template(t)[0]` (property →
+/// `condition`), but this function is still called by Stage 1's LIVE
+/// phase-B path (`process()` below) and the FFI offline fallback
+/// (`ffi/src/session.rs::partial_document`), and the shipped
+/// `MurmurEngine.swift` has no `"condition"` arm in its `switch docKind` —
+/// flipping it here would send a property walk down Swift's default arm
+/// ("SEND ESTIMATE" chrome on a move-out report) on the auto-published
+/// build. Stage 1 must behave identically to #27, so the old body stays;
+/// Stage 2 (which removes phase B and rewires Swift) performs the N3
+/// redefinition to `doc_kinds_for_template(template)[0]`. `DocumentBuilder`
+/// never calls this — it validates against `doc_kinds_for_template`
+/// (plural) + `is_pricing_kind` directly, so the new on-demand path is
+/// unaffected either way.
 pub fn doc_kind_for_template(template: Option<&str>) -> &'static str {
-    doc_kinds_for_template(template)[0]
+    match template {
+        Some("landscape") => "estimate",
+        Some("inspection") => "inspection",
+        _ => "report",
+    }
 }
 
 #[derive(Debug)]
@@ -964,19 +982,25 @@ mod tests {
         assert!(!is_pricing_kind("condition"));
     }
 
-    /// Plan 13 N3: `doc_kind_for_template` is redefined as
-    /// `doc_kinds_for_template(t)[0]` — the property default CHANGES from
-    /// today's `"report"` to `"condition"` (property's own legal-kind list
-    /// starts with `condition`, not `report`).
+    /// Stage-1 pin: `doc_kind_for_template` KEEPS its pre-Plan-13 behavior
+    /// (property → `"report"`) because it still drives the LIVE phase-B
+    /// build and the FFI offline fallback, and the shipped
+    /// `MurmurEngine.swift` has no `"condition"` arm — Stage 1 must behave
+    /// identically to #27 on the auto-published TestFlight build.
+    ///
+    /// **Stage 2 flips this** (Plan 13 N3): once phase B is removed and
+    /// Swift is rewired, redefine the function as
+    /// `doc_kinds_for_template(t)[0]` and change the property assertion
+    /// below to `"condition"`.
     #[test]
-    fn doc_kind_for_template_is_the_first_legal_kind() {
+    fn doc_kind_for_template_keeps_stage1_defaults() {
         assert_eq!(doc_kind_for_template(Some("landscape")), "estimate");
         assert_eq!(doc_kind_for_template(Some("inspection")), "inspection");
         assert_eq!(doc_kind_for_template(None), "report");
         assert_eq!(
             doc_kind_for_template(Some("property")),
-            "condition",
-            "property's default CHANGES from report to condition (N3)"
+            "report",
+            "Stage 1 pins the OLD default — Stage 2 (N3) flips this to \"condition\""
         );
     }
 

--- a/docs/superpowers/plans/2026-07-10-rust-core-13-notes-first.md
+++ b/docs/superpowers/plans/2026-07-10-rust-core-13-notes-first.md
@@ -1,0 +1,322 @@
+# Murmur Rust Core — Plan 13: notes-first core
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. The Rust tasks (Stage 1 + Stage 2 core/ffi) are **hermetic**: in-memory `Store`, `MockProvider`, `with_providers`/`SessionProcessor`/`DocumentBuilder` — **no model, no `whisper` feature, no network, no camera, no real-photo filesystem**. `cargo test --workspace` must NEVER require the `whisper` feature or a model file (the load-bearing CI invariant). The Swift tasks are **not CI-gated** (real-core-only, needs the gitignored `MurmurCoreFFI` xcframework) and the **notes-screen visual/grouping design is explicitly sac's** — `// sac:` markers throughout. Run `cargo`/`xcodegen` **inside** the Nix dev shell; run `xcodebuild` **outside** it (Nix linker env breaks Xcode `ld`). Never read `.env` or `project.local.yml`.
+>
+> **⚠ SHIPPABILITY — merging any task on this plan auto-publishes the TestFlight internal lane on real-engine** (CANON 2026-07-10). main must build the **real-core archive** at every merge. That is why this plan is split into **two mergeable stages**: Stage 1 is purely **additive** (new `build_document` path, nothing removed — old `finish()` still returns a document); Stage 2 is the **atomic flip** (finish→notes across Rust *and* Swift in one PR). Never merge a task that leaves the real-core archive un-compilable. See **§Staging**.
+>
+> **Plan review (2026-07-10) — APPROVE WITH CONDITIONS (applied).** Adversarial review recomputed the D7 terminal-state claim (documents build only from `Processed`, `Processed` is terminal → `clear_authoritative_outputs` never races a live document) — **HELD**; staging boundary clean; evals clean. Three conditions folded in: **C1** — the structure render's `is_gap` default must NOT naively delegate to `is_pricing_kind`: that would flip a *degraded/offline* non-pricing document to looks-confirmed. Gap policy is now an **explicit parameter** (`GapPolicy::PerPricingKind` for the on-demand build; `GapPolicy::AllGap` for the offline fallback — "amount not yet priced" ≠ "nothing has been through the LLM"). **N2** — the on-demand render uses a fresh `new_id()` per line (the `build_document`-tool convention, `line.id != item_id`); the offline fallback keeps its legacy `line.id = item.id`; the cross-check waives the `id` field. **N3** — `doc_kind_for_template(t)` is redefined as `doc_kinds_for_template(t)[0]` (property now → `condition`, pinned by test); `NotesPayload.doc_kind` is **advisory**, and Swift button wiring keys off the **client-known template**, not the payload field. dam's three answers folded: doc numbers **burn per tap** (confirmed); `session_transcript` getter **deferred** (future work, not an open question); the **spoken grand total IS threaded** into the pricing pass as one scalar hint captured at summary time (D5a) — never by reopening transcript access in the pricing prompt.
+
+**Goal.** Implement the ADOPTED notes-first pivot (`meta/CANON.md` 2026-07-10; `docs/design/2026-07-10-decisions-notes-first.md`; sac's #189 design `docs/design/2026-07-09-notes-first-output.md` + `docs/design/notes-mockup.html`; dam's ruling on PR #189). A walk's finish output becomes **notes** (items + summary — the payload `finish()` already computes); the finished document stops being auto-built at DONE and becomes an **on-demand** `build_document(kind)` engine call powering the trade's action buttons.
+
+**What lands:**
+
+1. **murmur-core (pipeline) — drop phase B from `process()`.** `SessionProcessor::process()` stops making the forced `build_document` call. `ProcessOutcome.document_artifact_id` is removed. Extraction + summary + the finish swap are unchanged; a successful `process()` now costs one fewer LLM call. (Stage 2.)
+2. **murmur-core (pipeline) — new `DocumentBuilder`.** An on-demand builder: validate the session is `Processed` + the `kind` is legal for the template; **deterministically render** document structure from the session's authoritative items (no LLM); for **pricing kinds** (estimate/invoice) run **one focused pricing pass** whose input is the items only (never the transcript — R6); attach validated per-item amounts (Plan 12's echo-and-validate, reused); mint the doc number and persist the document as an immutable **snapshot** artifact. LLM failure degrades to an unpriced structure-only document — never a hard failure (R7). (Stage 1, additive.)
+3. **murmur-core — pricing seam.** A `price_items(...)` function (LLM impl now) behind which a future price-book lookup slots (lookup-first, LLM-fallback). Seam defined, price-book NOT built. (Stage 1.)
+4. **ffi — new `MurmurEngine::build_document(session_id, kind)`** (async, throwing) returning the existing `DocumentPayload` (read back via `convert::document_payload`). **`WalkSession::finish()` changes its return type** from `DocumentPayload` to a new `NotesPayload` record (items + summary + queued). (build_document = Stage 1; finish flip = Stage 2.)
+5. **apps/ios — seam + routing.** `WalkEngine.finish()` returns a new `NotesModel`; `WalkEngine.buildDocument(sessionId:kind:)` is added. `MurmurEngine` + `DemoWalkEngine` conform (scripted notes + canned document). `AppModel` routes DONE → a Notes screen; the action buttons call `buildDocument` → the **existing `ReviewView`** (unchanged, now reached deliberately). The Notes screen itself is a minimal seam behind `// sac:` markers — sac owns its visuals. (Stage 2.)
+
+**What this plan is NOT (see Non-goals for the full list).** No price-book store (seam only). No PDF export changes. No notes **editing**. No per-trade button-set **content** or notes-screen visual design (sac's). No follow-ups system. No vision. No new SQLite migration (documents remain `artifacts.body` JSON — additive).
+
+---
+
+## Hard dependencies (all DONE, on `main`)
+
+- **Plan 07** (`crates/ffi`, `crates/murmur-core`): the structured document is an `Artifact` with `kind="document"` + a **JSON body** (`store/documents.rs`, `mint_document_number_and_add_artifact`) — *no domain type, no migration*. `DocLine`/`DocumentPayload` uniffi records + `convert::document_payload` parse the body **defensively field-by-field** (`convert.rs:36–69`); `partial_document_from_items` (`convert.rs:79–116`) is the item→line fallback. Per-`doc_kind` number minting (`store/documents.rs`). The **empty-session contract**: empty/whitespace transcript → `process()` short-circuits, summary `"(empty session)"`, no document, no panic (`pipeline/mod.rs:134–143`).
+- **Plan 06a** (`items.source`): `ItemSource { Live, Authoritative, Manual }`. After `finish_session_processed`, the surviving board = this-run **authoritative** + **manual** items (`sessions.rs:404–442`). Phase 0 `clear_authoritative_outputs` sweeps prior authoritative items + **all artifacts** before a (re)process (`sessions.rs:466–485`) — only reachable from `AwaitingProcessing|Failed`.
+- **Plan 12** (`DocLine.item_id`): the document already carries an **optional per-line `item_id`** validated by **echo-and-validate / first-wins dedup / degrade-to-None** (`pipeline/tools.rs:338–388`); the offline fallback carries `item_id` trivially (it builds rows straight from items). `convert::document_payload` reads `item_id` (`convert.rs:53`). **The pricing pass in this plan reuses this exact echo-validate pattern for amounts.**
+- **Plan 11** (`photos`): `count_live_photos_by_item_for_session` (batched per-item photo counts) already feeds the board snapshot (`ffi/src/session.rs:372–409`); the notes payload reuses it.
+
+**Verified API facts (checked against source, not guessed):**
+- **No migration.** Documents live in `artifacts.body` JSON; `document_payload` tolerates any missing field. Adding `NotesPayload` (a new uniffi record) and a new engine method is additive — `MIGRATIONS.len()` unchanged, no `user_version` bump.
+- **`process()` phase B is self-contained.** `run_build_document` (`pipeline/mod.rs:292–397`) is the ONLY document-writing path in `process()`; `run_llm_phases` returns `(summary, Option<String> document_artifact_id)` (`mod.rs:217, 285`); `ProcessOutcome.document_artifact_id` (`mod.rs:47`) is read only by `WalkSession::finish` (`ffi/src/session.rs:674–694`). Removing phase B touches exactly these.
+- **`finish()` return is `DocumentPayload`** (`ffi/src/session.rs:632`), mapped to `DocumentModel` by `MurmurEngine.document(_:)` (`MurmurEngine.swift:378`), stored on `AppModel.document` (`AppModel.swift:95`), rendered by `ReviewView`. The Swift seam is `WalkEngine.finish() async -> DocumentModel` (`WalkEngine.swift:89`).
+- **Doc-number minting is per-`doc_kind`** and lazy (`store/documents.rs:53`); `mint_document_number_and_add_artifact` mints + writes in one tx (a number is consumed iff the artifact lands).
+- **Evals do NOT pin finish-time document behavior.** Only live-prompt + swap-at-finish board plumbing pins exist (`crates/evals/tests/live_prompt_pins.rs`, `carried_scenarios.rs`) — verified: no transcript→document score test. Dropping phase B moves no eval.
+- `doc_kind_for_template` (`pipeline/mod.rs:30`) maps template→a single default kind; this plan generalizes it to an allow-list.
+
+**Spec basis:** R6 (under-extraction bias — the pricing pass must not author lines), R7 (never lose the artifact — a document always lands, pricing failure degrades), R9 (spend meter — per-tap cost is proportional and logged). Design: notes-first (#189), Q1/Q2/Q6/Q7 rulings on the PR thread.
+
+---
+
+## Architecture — decisions, justified (reviewers read these first)
+
+### D1. `finish()` = notes only; the document build moves to an explicit `build_document(kind)`
+
+`finish()` today extracts items + summary **and** forces a document build (phase B). The pivot removes phase B: `finish()` returns a `NotesPayload` (the items + summary it already computed) and nothing more. Documents are built later, deliberately, by a new **engine-keyed** method (not `WalkSession`-scoped — the walk is over and the `WalkSession` is dropped; documents are generated from the notes screen, possibly after relaunch/from history):
+
+```
+MurmurEngine::build_document(session_id: String, kind: String) async throws -> DocumentPayload
+```
+
+**Why engine-keyed, not session-keyed:** `MurmurEngine.finish()` nils out its `WalkSession` handle (`MurmurEngine.swift:197`); a later tap has no session object. Photos already solved this — `add_photo` is engine-keyed on `session_id` (`ffi/src/photos.rs`). `build_document` follows that precedent.
+
+**Why plain async return, not a `DocumentReady` event:** the caller (a button tap) has a direct `await` result — the simplest shape. No new `WalkEvent` variant, no listener wiring. (An event flow would only pay off for background/batch generation, which is a non-goal.)
+
+### D2. `NotesPayload` — the exact finish record
+
+```rust
+// crates/ffi/src/notes.rs  (new; uniffi::Record)
+pub struct NotesPayload {
+    pub session_id: String,
+    pub doc_kind: String,        // template's DEFAULT kind (estimate|report|inspection) — for button curation only
+    pub summary: String,         // session.summary; "(empty session)" for a silent walk
+    pub items: Vec<BoardItem>,   // authoritative+manual board post-swap, with batched photo_count (reuse BoardItem)
+    pub queued: bool,            // true = finish degraded offline (D9); session NOT Processed → buttons disabled
+}
+```
+
+- **`items` reuses `BoardItem`** (`events.rs:10` — id/kind/text/right/photo_count). No new item record; the notes screen groups by `kind` client-side (sac's trade-aware buckets). Photo counts come from the same batched `count_live_photos_by_item_for_session` the board snapshot uses.
+- **Transcript is NOT in the payload.** The Swift side already accumulates the full transcript from `transcriptCommitted` events during the walk (`AppModel`); the notes screen's "show what I heard" row reads that. Adding it to the payload would duplicate state. (Noted as an open question if the history screen — which has no live event stream — needs it; a `session_transcript(session_id)` getter is the trivial future add.)
+- **`doc_kind`** is the template's default kind (`doc_kinds_for_template(template)[0]`), carried as an **advisory** hint only. **Swift button wiring keys off the client-known template** (`AppModel` already holds the `TradeFixture`/template it began the walk with), NOT off `NotesPayload.doc_kind` — so the property mismatch (default `condition` vs the legacy `report` copy) never drives UI. The real per-trade taxonomy is sac's.
+
+### D3. Empty-notes contract (maps Plan 07's empty-session contract onto notes)
+
+Plan 07: silent walk → truthful empty document (queued=false, doc_number=0, no panic). The notes equivalent:
+
+| finish scenario | NotesPayload |
+|---|---|
+| empty/whitespace transcript (process short-circuits) | `summary:"(empty session)"`, `items: <manual items only, usually []>`, `queued:false` |
+| offline / LLM-down (process `Err`) — D9 | `summary:""`, `items: <current live board>`, `queued:true` |
+| double-`finish()` / post-`cancel()` degrade | `summary: <stored summary or "">`, `items: <current board>`, `queued:false` |
+| normal | `summary:<computed>`, `items:<authoritative+manual>`, `queued:false` |
+
+No branch panics across FFI (finish returns a bare `NotesPayload`, not a `Result` — same posture as today's `DocumentPayload`).
+
+### D4. Deterministic structure render — items are the source of truth
+
+The document **structure** is rendered in Rust with **no LLM**: one line per authoritative item, in item order.
+
+```
+line = { id: new_id(), title: item.text, detail:"", qty:"",
+         amount_cents: None, section: None, is_gap: <GapPolicy>, item_id: Some(item.id) }
+```
+
+- **`item_id` is carried directly** from the item. Plan 12's fallback path `partial_document_from_items` is the *prototype* for the item→line mapping; the shared core render is `render_structure_document(doc_kind, items, gap: GapPolicy)`. The **on-demand build** uses it; the **FFI offline fallback** keeps its own `DocLine` construction (it sets `line.id = item.id`, a legacy shortcut) but must produce **identical field semantics except `id`** — the cross-check test (Task 2) waives the `id` field. The on-demand render uses a fresh `new_id()` per line, matching the `build_document`-tool convention (`line.id != item_id`, asserted in Plan 12).
+- **`section: None`** — section/grouping copy is sac's (SCOPE / NEEDS ATTENTION / …); Swift groups by item `kind`. Core stays out of section-copy.
+- **`is_gap` is an explicit `GapPolicy` parameter (C1)** — NOT a naive `is_pricing_kind` delegation:
+  - `GapPolicy::PerPricingKind` (the on-demand build): `is_gap = is_pricing_kind(doc_kind)` — `estimate`/`invoice` lines are gaps until priced; `report`/`inspection`/`work_order`/`move_out`/`condition` lines are not gaps (a normal finding is not a gap). Reuses the D2a rule.
+  - `GapPolicy::AllGap` (the offline/degraded fallback): `is_gap = true` **unconditionally**, for every kind. A degraded document has had **nothing** through the LLM — even an inspection finding is *wholly unconfirmed*, not merely unpriced. "Amount not yet priced" ≠ "nothing has been through the LLM." (This preserves today's `partial_document_from_items` behavior, which sets `is_gap:true` unconditionally by design.)
+  - A line that the pricing pass (D5) later prices flips to `is_gap:false` regardless of policy.
+
+**Consequence, stated honestly:** the document is now exactly as rich as the extracted items — no transcript re-derivation. This is the *point* of notes-first (items are authoritative; the document is a view of them) and is what CANON means by "structure re-renders deterministically from the structured items." It is a deliberate quality trade vs today's transcript-authored lines: fewer hallucinated lines, no synthesized rollups, tighter R6. (Richer per-trade line templates are sac's future button-content work — a non-goal here.)
+
+### D5. Pricing pass — items only, amounts only, echo-validated (R6)
+
+For pricing kinds (`estimate`, `invoice`), after the structure render, run **one** focused LLM call:
+
+- **Input = the items only** (`item_id`, `kind`, `text`) + memory prompt (the operator's vocabulary/history, already injected by `build_document_prompt`). **NOT the transcript.** Argument: the pricing model has **no line-authoring power** — its output schema can only attach an amount to an `item_id` that already exists in the structure. Feeding the transcript would reintroduce exactly the transcript→line re-derivation Plan 12 moved away from and reopen the R6 line-inflation surface. Items-only ⇒ **line count is fixed by the deterministic render; the LLM can move only amounts.** (Price genuinely needs domain knowledge; v1 lets the LLM guess from item text + memory — the honest v1 per CANON; the price-book seam D6 slots in front later.)
+- **Output schema** (forced tool `price_items`):
+  ```json
+  { "prices": [ { "item_id": "<id>", "amount_cents": <int> } ], "total_cents": <int, optional> }
+  ```
+- **Apply** with Plan 12's rules: for each returned price, keep `amount_cents` **iff** `item_id ∈ structure item-id set` and not already claimed (first-wins); unknown/duplicate/absent → the line stays unpriced (amount `None`, `is_gap` per-template). A priced line flips `is_gap:false`. `total_kind:"sum"`.
+- **Degrade path (LLM `Err` — offline/down):** skip the pricing pass entirely. The structure-only document (all amounts `None`, `is_gap` per-template) still **mints a number and persists**, with `queued:true` (reused as "document incomplete — pricing did not run"; Swift's existing `queued` note copy — "SAVED OFFLINE — WILL FINISH WHEN YOU RECONNECT" — fits). **Never a hard failure** (R7).
+
+Non-pricing kinds skip the LLM entirely — zero-cost, structure-only, `queued:false`.
+
+### D5a. Spoken grand total — threaded as one scalar hint, captured at summary time (dam answer 3)
+
+If the operator spoke a target total ("keep the whole thing under twelve hundred"), the pricing pass should honor it — **without** reopening transcript access in the pricing prompt (which would break D5's no-line-authoring guarantee). Mechanism, chosen to preserve the zero-migration invariant:
+
+- **Capture at summary time.** The `summarize` pass already legitimately reads the transcript (`prompts::summarize(provider, assembled_transcript, ...)`). Extend its forced `write_summary` tool with an **optional** `spoken_total_cents` field; the model returns it only when a grand total was actually stated (R6: absent when unsure). So transcript access stays confined to the pass that already has it.
+- **Persist with no migration.** Store the scalar as a tiny per-session artifact `kind = "session_meta"`, body `{"spoken_total_cents": N}`, written by `process()` on success (the `artifacts` table already exists; `kind` is free-form — "the store doesn't care what `kind` means", `artifacts.rs:24`). No column, no `user_version` bump. `clear_authoritative_outputs` already sweeps all artifacts on reprocess, so a retry re-captures cleanly. Absent field / no meta artifact → no hint.
+- **Feed as one scalar.** `DocumentBuilder::build` reads the meta artifact (`session_spoken_total(session_id) -> Option<i64>`) and, for a pricing kind, passes it into `price_items` as a single scalar the prompt renders as one line: *"Operator's stated target total: $1200.00 — allocate line prices consistent with this."* The pricing prompt still receives **items only + this one scalar** — never the transcript. The output schema is unchanged (amounts on existing `item_id`s only), so the hint cannot author lines.
+
+See Worked Example G.
+
+### D6. Pricing seam for the future price book
+
+`price_items` is a free function `async fn price_items(provider, items, memory_prompt, budget) -> Result<HashMap<String,i64>, HarnessError>` (LLM impl now). The future price book slots in as a pre-step: `lookup_prices(items) -> (resolved, unresolved)`, then LLM only for `unresolved`. **Seam = the `HashMap<item_id, cents>` return contract**; nothing about the caller changes. Price-book store is NOT built.
+
+### D7. Doc numbers — mint per generate (burn per tap); documents are immutable snapshots
+
+Each `build_document(kind)` call mints the **next** number for that `doc_kind` (per-kind sequences already independent) and writes a **new** document artifact. Regenerating an estimate ⇒ `EST-0002` (a fresh snapshot), leaving `EST-0001` intact. **0..N documents per session** (Q6/Q7 ruling); regenerate is explicit; a generated snapshot is **never silently mutated** (a sent estimate is a sent estimate).
+
+- **R9 note — numbers burn per tap.** Two taps of Estimate ⇒ EST-0001, EST-0002. Accepted: a document number identifies a *snapshot*; a regenerate genuinely is a new document. Sequences are cheap local integers. (If burn-rate ever matters, a "replace last" that reuses the number is the seam — flagged as an open question, recommend burn-per-tap for v1.)
+- **Snapshot vs `clear_authoritative_outputs` on REPROCESS:** `clear_authoritative_outputs` tombstones **all** artifacts, but it runs **only** on a (re)process of an `AwaitingProcessing|Failed` session. Documents are built **only** from a `Processed` session (D8), and `mark_session_processed` makes `Processed` **terminal** (`sessions.rs:194–198`) — there is no user path that reprocesses a Processed session, so **`clear_authoritative_outputs` never races a live document.** The dangling-`item_id` concern (a future "recover this walk" flow re-extracting items under an existing document) is handled by design regardless: **snapshot text is the truth; `item_id` links resolve best-effort at render** (a link to a tombstoned item simply yields no jump/photo-group — `document_payload` already reads `item_id` tolerantly, and the render never fails on a stale id). 
+- **Old pre-13 auto-built documents** (built at finish before this plan) remain valid artifacts and **render unchanged** through the same tolerant `document_payload` parser. No migration; the history/notes screen surfaces them via `latest_document_artifact` if present.
+
+### D8. `build_document` validation
+
+- **Session must be `Processed`** — its items are final/authoritative. A non-Processed session (offline notes, `queued:true`) has no authoritative board; `build_document` returns `EngineError` and the Swift buttons stay disabled while `queued`. (An empty-but-Processed session is allowed — it yields a truthful **zero-line** document, D3-parallel; still mints a number, still lands.)
+- **`kind` must be legal for the session's template.** New `doc_kinds_for_template(template) -> &'static [&'static str]` allow-list; `is_pricing_kind(kind) -> bool`. Unknown/mismatched kind → `EngineError`.
+
+| template | legal kinds | pricing kinds |
+|---|---|---|
+| `landscape` | `estimate`, `invoice`, `work_order` | `estimate`, `invoice` |
+| `property` | `condition`, `move_out` | — |
+| `inspection` | `inspection` | — |
+
+(These are the **kind vocabulary + pricing flags** — core's concern. Which button *leads* and its label copy are sac's.)
+
+### D9. Per-tap cost is logged (R9)
+
+`build_document`'s pricing call logs one `llm_usage` row with `purpose = "document"` (distinct from `"processing"`), so per-tap spend is measured and attributable. Non-pricing kinds log nothing (no call). A degraded (pricing-failed) build logs whatever partial usage the failed call incurred, same posture as `process()`.
+
+---
+
+## Worked examples (reviewers: hand-recompute against the code)
+
+**A — finish() notes payload (happy path, Stage 2).** Template `landscape`. Transcript: *"bark mulch, three cubic yards. call Dev the framer. loose railing on the back deck."*
+`process()`: extraction adds A1=`todo "order bark mulch 3 cu yd"`, A2=`safety "loose railing back deck"`; contact Dev; summary `"Ordered mulch; flagged loose railing."`; **no phase B**. `finish_session_processed` swaps → A1,A2 survive.
+`finish()` → `NotesPayload{ session_id:S, doc_kind:"estimate", summary:"Ordered mulch; flagged loose railing.", items:[{A1,todo,"order bark mulch 3 cu yd",pc0},{A2,safety,"loose railing back deck",pc0}], queued:false }`.
+**Cost:** one folded `"processing"` usage row = extraction + summary tokens **only**; assert `provider.requests()` contains **no** `build_document` request (phase B gone). Finish is strictly cheaper than today.
+
+**B — build_document("estimate") deterministic + pricing (Stage 1).** Session S `Processed`, items A1,A2 as above.
+1. validate: `landscape` allows `estimate` ✓; `estimate` is a pricing kind.
+2. structure render → `L1{title:"order bark mulch 3 cu yd", item_id:A1, amount:None, is_gap:true}`, `L2{title:"loose railing back deck", item_id:A2, amount:None, is_gap:true}`.
+3. pricing pass input = `[{A1,todo,"order bark mulch 3 cu yd"},{A2,safety,"loose railing back deck"}]`; model returns `{prices:[{A1,28500}]}`.
+4. echo-validate vs `{A1,A2}`: A1 valid → `L1.amount=28500, is_gap:false`; A2 unpriced → stays gap. `total_kind:"sum"` → total `28500`.
+5. mint `estimate` #1 → `doc_number:1`; persist snapshot; `queued:false`. Usage → one `"document"` row.
+`DocumentPayload{ doc_kind:"estimate", doc_number:1, lines:[L1 $285.00 item_id A1, L2 gap item_id A2], total sum }`. Swift renders `EST-0001` in the **existing ReviewView**.
+
+**C — pricing LLM fails → structure-only degrade (Stage 1).** As B, pricing provider returns `Err`. Steps 1–2 as above; step 3 fails → skip. Document lands: L1,L2 both amount `None`, `is_gap:true`, **still minted `estimate` #1**, `queued:true`. No error thrown (R7). Any partial pricing-call usage logged.
+
+**D — build_document("work_order") non-pricing (Stage 1).** `landscape` allows `work_order` (non-pricing). Structure render only, **no LLM call**: L1,L2 amount `None`, `is_gap:false` (non-pricing default), mint `work_order` #1, `queued:false`, zero usage rows.
+
+**E — doc numbers burn per tap; independent sequences (Stage 1).** `build_document(S,"estimate")`→EST #1. Again→EST #2 (new snapshot; #1 intact; 2 estimate artifacts for S). `build_document(S,"invoice")`→INV #1 (independent sequence). `latest_document_artifact(S)` returns the newest by `id DESC` (INV #1).
+
+**F — empty-but-Processed session (Stage 1 + D3).** Silent walk: `finish()`→`NotesPayload{summary:"(empty session)", items:[], queued:false}`. `build_document(S,"estimate")`: structure render over **zero** items → **zero lines**; pricing pass over zero items (skip the call — nothing to price); mint EST #1; truthful empty document lands, `queued:false`. No panic, no error.
+
+**G — spoken grand total threaded (D5a).** Template `landscape`. Transcript includes *"keep the whole thing under twelve hundred bucks."* plus the mulch/railing content of Ex B.
+- `process()`: extraction adds A1,A2 (as B); the `summarize` call returns `summary:"…" , spoken_total_cents:120000`; `process()` writes a `session_meta` artifact `{"spoken_total_cents":120000}`. `finish()` notes are unchanged (`queued:false`) — the scalar does NOT appear in the notes payload.
+- `build_document(S,"estimate")`: structure render L1(A1),L2(A2); `session_spoken_total(S)` → `120000`; `price_items` prompt = items `[{A1,…},{A2,…}]` + the scalar line *"stated target total: $1200.00"* (no transcript). Model returns `{prices:[{A1,95000},{A2,25000}]}` summing 120000. Echo-validate vs `{A1,A2}` → both kept; total `sum` = 120000. Mint EST #1; `queued:false`.
+- **`is_gap` check (C1):** both priced → `is_gap:false`. Contrast Ex C's degraded path, where the *offline* `AllGap` policy would have set every line `is_gap:true` even for a non-pricing kind.
+
+---
+
+## Staging (main stays shippable at every merge)
+
+Because a merge auto-publishes the **real-core** TestFlight lane, the real-core archive must compile after every PR. The FFI signature of `finish()` cannot change until `MurmurEngine.swift` matches it, so:
+
+- **Stage 1 — additive Rust + FFI (PR-1).** Everything for `build_document`: `DocumentBuilder`, `render_structure_document`, `price_items`, `doc_kinds_for_template`/`is_pricing_kind`, the FFI `MurmurEngine::build_document` export. **`process()`/`finish()` untouched** — old finish still returns `DocumentPayload`. `MurmurEngine.swift` needs no edit (the new FFI method simply goes uncalled). Real-core archive compiles; behavior unchanged; TestFlight ships the identical old flow. Gated by `cargo test`/`clippy` + iOS demo build. *(Tasks 1–4.)*
+- **Stage 2 — the atomic flip (PR-2), Rust + Swift in ONE PR.** Drop phase B from `process()`; add `NotesPayload`; change `WalkSession::finish()` to return it; update `MurmurEngine.swift` (`finish→NotesModel`, `buildDocument` mapping), the `WalkEngine` protocol, `DemoWalkEngine` parity, `AppModel` routing (DONE→Notes screen; button→`buildDocument`→ReviewView), and a minimal `NotesView` seam (`// sac:`). The finish-signature change and its Swift consumer land together — the only way the real-core archive stays compilable. Gated by `cargo test`/`clippy` + iOS **demo** build (green because DemoWalkEngine + protocol + AppModel are internally consistent) + **dam's local real-core compile** (`./build-ffi.sh && ./generate.sh && xcodebuild`, since CI can't build real-core) + bindings-drift check. *(Tasks 5–8.)*
+
+Within Stage 1 the Rust tasks are independently `cargo`-testable; Stage 2's Rust tasks (5) are testable before the Swift tasks (6–8) but must **merge together**.
+
+---
+
+## Tasks
+
+### Stage 1 — additive `build_document` (PR-1)
+
+#### Task 1 — `doc_kinds_for_template` + `is_pricing_kind` (core)
+- [ ] **RED:** in `crates/murmur-core/src/pipeline/mod.rs` tests, assert `doc_kinds_for_template(Some("landscape"))` == `["estimate","invoice","work_order"]`, `Some("property")`==`["condition","move_out"]`, `Some("inspection")`==`["inspection"]`, `None`→`["report"]`; `is_pricing_kind("estimate")`==true, `is_pricing_kind("work_order")`==false, `is_pricing_kind("inspection")`==false.
+- [ ] **RED (N3):** pin `doc_kind_for_template(Some("landscape"))=="estimate"`, `Some("inspection"))=="inspection"`, `None)=="report"`, and **`Some("property"))=="condition"`** — the property value CHANGES from today's `"report"` to `"condition"` (property's own legal-kind list starts with `condition`, not `report`). This only affects the offline fallback's `doc_kind` + the advisory `NotesPayload.doc_kind`; both `condition` and `report` map to `sum`/`total` in `partial_document_from_items` (no total-shape regression), and Swift keys buttons off the template (D2), so the copy switch is unaffected.
+- [ ] **GREEN:** add `pub fn doc_kinds_for_template(template: Option<&str>) -> &'static [&'static str]` and `pub fn is_pricing_kind(kind: &str) -> bool`. **Redefine `doc_kind_for_template(t)` as `doc_kinds_for_template(t)[0]`** (N3 — no more `_ => "report"` arm that lands outside property's own list).
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core`.
+
+#### Task 2 — `render_structure_document` with explicit `GapPolicy` (core; C1)
+- [ ] **RED (PerPricingKind):** given `[A1 todo, A2 safety]` and `doc_kind:"estimate"`, `GapPolicy::PerPricingKind` → two lines, each `amount_cents:None`, **`is_gap:true`**, `item_id:Some(item.id)`, `section:None`, `title==item.text`; same items + `doc_kind:"inspection"` + `PerPricingKind` → **`is_gap:false`**. Assert line `id != item_id` (fresh `new_id`).
+- [ ] **RED (AllGap, C1):** same items + `doc_kind:"inspection"` + **`GapPolicy::AllGap`** → **`is_gap:true`** for every line (a degraded inspection is wholly unconfirmed, not merely unpriced). This is the assertion that stops the naive `is_pricing_kind` delegation from flipping degraded non-pricing docs to looks-confirmed.
+- [ ] **RED (cross-check, N2):** `render_structure_document("estimate", items, AllGap)` and today's `partial_document_from_items("estimate", items, true)` produce lines with identical `title`/`detail`/`qty`/`amount_cents`/`section`/`item_id`/`is_gap` — **waiving the `id` field** (on-demand render uses fresh `new_id()`; the offline fallback uses `line.id = item.id`). Assert field-by-field except `id`.
+- [ ] **GREEN:** add `pub(crate) enum GapPolicy { PerPricingKind, AllGap }` and `pub(crate) fn render_structure_document(doc_kind: &str, items: &[CapturedItem], gap: GapPolicy) -> Vec<serde_json::Value>` (same field shape `BuildDocumentTool` emits; `is_gap` per the policy). Leave `convert::partial_document_from_items` (ffi) as-is (it keeps `line.id = item.id` and passes the equivalent of `AllGap`) — do NOT force delegation across the crate boundary; the cross-check test is the contract that keeps the two in lockstep.
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core`.
+
+#### Task 3 — `price_items` + `DocumentBuilder::build` (core)
+- [ ] **RED (pricing echo-validate):** with a `MockProvider` scripted to return `price_items {prices:[{A1,28500},{bogus,999},{A2,...}], ...}` where only A1,A2 are real and A2 is returned twice, assert the applied prices keep A1=28500, first A2 wins, bogus degrades — mirror Plan 12's `build_document_echoes_and_validates_item_ids` matrix but for amounts.
+- [ ] **RED (build happy path B):** construct a store, add A1,A2 as `Authoritative`, `end_and_record_session` + `mark_session_processed`. `DocumentBuilder::build(S,"estimate")` with a scripted pricing response → the persisted `document` artifact has `doc_number:1`, L1 priced/`is_gap:false` with `item_id:A1`, L2 gap. Assert one `"document"` usage row.
+- [ ] **RED (degrade C):** pricing provider `Err` → document still lands (mint #1), all amounts `None`, `queued:true`, `build` returns `Ok`. 
+- [ ] **RED (non-pricing D):** `build(S,"work_order")` makes **zero** provider calls, lands a structure-only doc, `queued:false`.
+- [ ] **RED (validation D8):** `build` on a non-`Processed` session → `CoreError`; `build(S,"estimate")` where template is `inspection` → `CoreError` (illegal kind); empty-but-Processed → zero-line doc, `Ok` (F).
+- [ ] **RED (spoken total, D5a / Ex G):** write a `session_meta` artifact `{"spoken_total_cents":120000}` for a Processed session with A1,A2; `build(S,"estimate")` with a scripted pricing response → assert the `price_items` request's user message contains the scalar hint (e.g. `"1200"` / `"120000"`) and does **NOT** contain the transcript. With no meta artifact, the hint line is absent.
+- [ ] **GREEN:** add `crates/murmur-core/src/pipeline/document.rs`:
+  - `async fn price_items(provider, items: &[CapturedItem], spoken_total_cents: Option<i64>, memory_prompt, max_tokens) -> Result<HashMap<String,i64>, HarnessError>` — one forced `price_items` tool call. User block = the items (id/kind/text) **only** + (if `Some`) one scalar hint line (D5a); NEVER the transcript. Parse `prices[]`, drop entries whose `item_id ∉ items`, first-wins dedup, ignore returned `total_cents` (sum is derived). Provider `Err` propagates.
+  - `pub struct DocumentBuilder { provider, store, memory, memory_store, budgets }` with `pub async fn build(&self, session_id: &str, doc_kind: &str) -> Result<BuildDocumentOutcome, CoreError>`:
+    1. lock/read session; require `status == Processed` (else `InvalidState`); validate `doc_kind ∈ doc_kinds_for_template(session.template)` (else `InvalidState`).
+    2. `items = list_items_for_session(session_id)` (authoritative+manual survivors).
+    3. `lines = render_structure_document(doc_kind, &items, GapPolicy::PerPricingKind)`.
+    4. if `is_pricing_kind(doc_kind)` and `!items.is_empty()`: `let hint = self.session_spoken_total(session_id)?;` then `match price_items(.., hint, ..).await { Ok(map) => apply(map, &mut lines), Err(_) => queued=true }`; else `queued=false`.
+    5. build payload (`doc_kind`, `job_date_unix=session.started_at`, `total_kind:"sum"`/label per kind, `lines`, `queued`) **without** `doc_number`; `mint_document_number_and_add_artifact(session_id, doc_kind, None /* burn per tap */, payload)`.
+    6. `record_llm_usage(Some(session_id), "document", &usage)` (only if a call was made).
+    7. return `BuildDocumentOutcome { document_artifact_id, usage, queued }`.
+  - `apply(map, lines)`: for each line with `item_id` present in `map` (and unclaimed), set `amount_cents`, `is_gap=false`; first-wins.
+  - `session_spoken_total(session_id) -> Result<Option<i64>, CoreError>`: read the `session_meta` artifact (kind-scoped), parse `spoken_total_cents`. `None` when absent.
+- [ ] **Note (R9/D9):** the pricing prompt is fed **items only + the one optional scalar** (D5/D5a) — the transcript-absence assertion above is load-bearing. Reuse `build_document_prompt`'s memory injection but a new items-only user block + a pricing-specific system prompt in `prompts.rs`.
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core` + `nix develop -c cargo clippy -p murmur-core --all-targets -- -D warnings`.
+
+#### Task 4 — FFI `MurmurEngine::build_document` (ffi, additive)
+- [ ] **RED:** in `crates/ffi/src/session.rs` (or a new `document_build.rs`), a `#[tokio::test]` using `with_providers`: begin a walk, append transcript, `finish()` (old path still returns a document here in Stage 1 — that's fine), then `engine.build_document(session_id, "estimate")` returns a `DocumentPayload` with the expected lines; an illegal kind returns `EngineError`.
+
+  ⚠ ordering note: in Stage 1, `finish()` still runs phase B, so a `finish()`ed session already has a document artifact. `build_document` **appends a new** one (burn-per-tap) — assert it reads back **its own** newly-written artifact, not the phase-B one. (After Stage 2 removes phase B, this ambiguity disappears; the test stays valid either way because `build_document` returns the id it just wrote.)
+- [ ] **GREEN:** add to `#[uniffi::export(async_runtime = "tokio")] impl MurmurEngine`:
+  ```rust
+  pub async fn build_document(&self, session_id: String, kind: String) -> Result<DocumentPayload, EngineError> {
+      let builder = DocumentBuilder::new(self.providers.processing.clone(), self.store.clone(),
+                                         self.memory.clone(), self.memory_store.clone());
+      let outcome = builder.build(&session_id, &kind).await.map_err(|e| EngineError::Document(e.to_string()))?;
+      let art = { self.store.lock()?.get_artifact(&outcome.document_artifact_id) };
+      convert::document_payload(&art?).map_err(|e| EngineError::Document(e.to_string()))
+  }
+  ```
+  Add an `EngineError::Document(String)` variant. Return the payload by reading back exactly the artifact id the builder wrote (never `latest_document_artifact` — burn-per-tap means multiple docs).
+- [ ] **Gate:** `nix develop -c cargo test -p ffi` + `clippy`. Regenerate bindings locally (dam) to confirm the new method + no drift on existing records. **Merge PR-1** — real-core archive still compiles (MurmurEngine.swift unchanged).
+
+### Stage 2 — the atomic flip (PR-2, Rust + Swift together)
+
+#### Task 5 — drop phase B; `finish()` returns `NotesPayload` (core + ffi)
+- [ ] **RED (core):** update `pipeline/mod.rs` tests: `processes_a_session_end_to_end` no longer scripts a `document_response()`; assert `provider.requests()` has **no** `build_document` request; usage row = extraction + summary only. Remove/retarget `processes_and_builds_a_document_artifact`, `build_document_echoes_real_id_...`, `failed_attempt_does_not_burn_a_document_number` (these pinned phase B — move the still-relevant echo-validate coverage to Task 3's builder tests, which is where document building now lives). `ProcessOutcome` loses `document_artifact_id`.
+- [ ] **RED (spoken total capture, D5a):** a session whose transcript states a total → after `process()`, `session_spoken_total(session_id)` == `Some(N)` (a `session_meta` artifact was written); a session with no stated total → `None` (no meta artifact). A `summarize` response omitting `spoken_total_cents` → `None`.
+- [ ] **GREEN (core):** delete `run_build_document`; `run_llm_phases` returns just `summary`; `process()` returns `ProcessOutcome { session, usage }`. Drop the `existing_doc_number` read-back + `doc_kind` threading in `process()` (dead once phase B is gone). Extend `prompts::summarize` to also return `Option<i64> spoken_total_cents` (an additive optional field on the `write_summary` tool schema, R6: absent unless clearly stated); `process()` writes it as a `session_meta` artifact **only when `Some`**, inside the success path before/with `finish_session_processed`. Keep `clear_authoritative_outputs` as-is (it already sweeps the `session_meta` artifact on reprocess).
+- [ ] **RED (ffi):** in `crates/ffi/src/session.rs`, `finish()` returns `NotesPayload`. Tests: happy path (Worked Ex A) — items+summary+`queued:false`, no `build_document` request; empty transcript → `summary:"(empty session)", items:[], queued:false` (retarget the existing empty-session finish test); offline degrade (process `Err`) → `queued:true` with the live board; double-finish → degraded notes, no panic.
+- [ ] **GREEN (ffi):** add `crates/ffi/src/notes.rs` (`NotesPayload` uniffi record + a `convert::notes_payload(session, items, photo_counts, queued)` builder). Rewrite `WalkSession::finish()` to return `NotesPayload`: on `Ok(outcome)` build notes from `list_items_for_session` + the batched photo counts + `outcome.session.summary`; on the empty/degrade branches follow the D3 table. Replace the `partial_document`/`degraded_document` document helpers with notes equivalents (`partial_notes(queued)`, `degraded_notes()`), reusing `list_items_for_session`. Keep `cancel()` unchanged.
+- [ ] **Gate:** `nix develop -c cargo test --workspace` + `clippy --workspace --all-targets -- -D warnings`.
+
+#### Task 6 — Swift seam: `WalkEngine` protocol + models (apps/ios)
+- [ ] Add `NotesModel` (summary, items `[CapturedFixture]`, docKind, queued) and change the protocol:
+  ```swift
+  func finish() async -> NotesModel
+  func buildDocument(sessionId: String, kind: String) async throws -> DocumentModel
+  ```
+  Keep `DocumentModel`/`DocRowFixture` exactly as-is (ReviewView unchanged). `// sac:` marker on `NotesModel`'s grouping expectations.
+- [ ] **`MurmurEngine`** (real, behind `#if canImport`): `finish()` maps `NotesPayload → NotesModel` (reuse the `board(_:)` item mapping for `items`); add `buildDocument` calling `engine.buildDocument(sessionId:kind:)` and mapping `DocumentPayload → DocumentModel` via the **existing** `document(_:)`. Update `lastDocument`/re-entrancy notes to a `lastNotes` cache.
+- [ ] **`DemoWalkEngine`** parity: `finish()` returns scripted notes (`trade` fixtures → `NotesModel`); `buildDocument(sessionId:kind:)` returns the canned `DocumentModel` it returns today (Worked Ex B shape). No-op/echo for unknown kinds.
+- [ ] **Gate:** iOS **demo** build (xcodebuild OUTSIDE nix) green.
+
+#### Task 7 — `AppModel` routing + Notes screen seam (apps/ios)
+- [ ] Add a `.notes` phase (or reuse `.review` for the document). `finishWalk()` sets `self.notes = await engine.finish()` → `phase = .notes`. The action buttons call `Task { let doc = try await engine.buildDocument(sessionId:kind:); self.document = doc; phase = .review }`; disable buttons when `notes.queued`.
+- [ ] Minimal `NotesView` (`// sac:` — visuals/grouping/action-button taxonomy are sac's): summary card, items grouped by `kind`, a "TURN THESE NOTES INTO" action row wired to `buildDocument(kind:)` per `doc_kinds_for_template`'s Swift mirror, an Export/utility row (stub), a collapsed transcript row (from the accumulated transcript). Keep it deliberately thin — sac replaces the chrome; the **wiring** (which button → which kind → ReviewView) is what this task guarantees.
+- [ ] `ReviewView` unchanged — verify it still renders a `DocumentModel` reached via the button path.
+- [ ] **Gate:** iOS demo build green; manual walk-through of the demo flow (DONE→Notes→button→ReviewView).
+
+#### Task 8 — real-core compile + bindings drift (dam-manual) + merge
+- [ ] dam runs `cd apps/ios && ./build-ffi.sh && ./generate.sh && xcodebuild -project SitewalkGallery.xcodeproj -scheme SitewalkGallery -destination 'platform=iOS Simulator,name=iPhone 17' build` — confirm the real-core archive compiles against the flipped `finish()` + new `build_document` bindings (CI cannot do this).
+- [ ] Bindings-drift check: regenerate the Swift bindings from `crates/ffi`; confirm `MurmurEngine.swift`'s referenced symbols (`NotesPayload`, `build_document`, unchanged `DocumentPayload`/`DocLine`) all resolve.
+- [ ] **Merge PR-2** — this is the ship. TestFlight internal lane publishes the notes-first flow on real-engine.
+
+---
+
+## Gates (every task)
+- `nix develop -c cargo test --workspace` — exit code 0 (never grep counts; run under the Nix shell so the toolchain resolves).
+- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings`.
+- iOS **demo** build (CI-gated): `xcodebuild -project SitewalkGallery.xcodeproj -scheme SitewalkGallery -destination 'platform=iOS Simulator,name=iPhone 17' build` — **outside** the Nix shell.
+- Stage 2 only: real-core compile + bindings-drift (dam-manual, Task 8).
+
+## Acceptance criteria
+1. A successful `process()` makes **no** `build_document` call; `finish()` returns notes (items + summary); one folded `"processing"` usage row.
+2. `MurmurEngine::build_document(session_id, kind)` renders structure deterministically from the session's authoritative items, prices estimate/invoice via one items-only LLM pass, and **always lands a numbered document snapshot** — pricing failure degrades to unpriced + `queued:true`, never an error.
+3. Illegal `kind`-for-template and non-`Processed` sessions return `EngineError`; empty-but-Processed yields a truthful zero-line document.
+4. Doc numbers mint per generate (burn-per-tap), per-kind independent sequences; regenerate leaves prior snapshots intact.
+5. Empty/offline/double-finish notes follow the D3 table; no panic across FFI.
+6. Pre-13 documents and `convert::document_payload` still parse unchanged (no migration).
+7. main builds the real-core archive at every merge (Stage 1 additive; Stage 2 atomic).
+8. `ReviewView` is reached via the button path and renders unchanged; the Notes screen wiring routes each action button → the correct `kind` → ReviewView.
+
+## Non-goals (explicit)
+- Price-book store (D6 seam only).
+- Notes **editing**; follow-ups system; per-trade button-set **content** + notes-screen **visuals** (sac's).
+- PDF export changes; vision; QuickBooks/Jobber integrations.
+- A `session_transcript(session_id)` getter (deferred — future work when the history screen needs it; dam 2026-07-10).
+- "Replace last document" / doc-number reuse (v1 burns per tap — dam confirmed).
+- A price-book-backed spoken-total (D5a captures the *stated* total only; reconciling it against a price book is future work).
+- Reprocess-after-Processed / "recover this walk" UX (the dangling-`item_id` render rule is defined for it, but the flow is out of scope).
+
+## Resolved by dam (2026-07-10)
+- **Doc numbers burn per tap (D7)** — CONFIRMED. A sent estimate keeps its number; regenerate = a new number/snapshot. No reuse.
+- **Spoken grand total (D5a)** — CONFIRMED threaded, captured at summary time and fed as one scalar hint; the pricing prompt never regains transcript access. Mechanism is the plan's call (see D5a).
+- **`session_transcript` getter** — DEFERRED. Notes-screen transcript stays client-accumulated; add a core getter only when the history screen (no live event stream) needs it. Future work, not a blocker.
+
+## Open questions for sac
+1. **`doc_kinds_for_template` taxonomy (D8)** — the kind vocabulary + pricing flags are core's; confirm the landscape/property/inspection kind lists match sac's button taxonomy (labels/lead-button are sac's). — **sac**
+2. **`queued` reuse for pricing-failed documents (D5/C)** — reusing the offline `queued` flag + its "SAVED OFFLINE…" note copy for a pricing-unavailable document — acceptable, or does sac want a distinct "unpriced" state/copy? — **sac**


### PR DESCRIPTION
## Thinking

Plan 13 pivots the walk's finished output from an auto-built document to
notes-first: `finish()` will eventually return items+summary, and the
document moves to an on-demand `build_document(kind)` call powering the
trade's action buttons. Because merging any task on this plan auto-publishes
the TestFlight internal lane on real-engine (CANON 2026-07-10), the plan
splits into two mergeable stages so the real-core archive never goes
uncompilable at a merge. **This PR is Stage 1 only** — the additive half
(Tasks 1-4): everything needed for `build_document` to exist and work,
with `process()`/`finish()` completely untouched.

**Scope line:** additive + inert. `MurmurEngine.swift` needs no edit — the
new FFI method (`build_document`) simply goes uncalled. A merge here behaves
identically to what's on `main` today (same as PR #27): old `finish()` still
forces its own phase-B document build; nothing in Swift calls the new path
yet. Stage 2 (a separate PR, Rust+Swift together) is the atomic flip that
actually changes what ships.

**GapPolicy (C1).** The structure render's `is_gap` default is an explicit
parameter, not a naive `is_pricing_kind` delegation: `PerPricingKind` (the
on-demand build's real policy — estimate/invoice lines are gaps until
priced, everything else defaults to not-a-gap) vs `AllGap` (reserved for a
future degraded/offline render where *nothing* has been through the LLM —
"amount not yet priced" != "nothing has been through the LLM"). `AllGap` is
pinned by cross-check tests against the documented contract of
`ffi::convert::partial_document_from_items` (N2 — waiving only the `id`
field, since the on-demand render always mints a fresh id while the offline
fallback legacy-sets `line.id = item.id`) but is not constructed by any
Stage-1 production caller; the offline fallback intentionally keeps its own
separate implementation rather than delegating across the crate boundary.

**D5a spoken-total mechanism.** The pricing pass never reopens transcript
access (staying true to R6 / D5's "items only, never the transcript"
guarantee). Capture happens in Stage 2's `summarize` extension (out of
scope here); Stage 1 builds the *consumption* side now: `DocumentBuilder`
reads a `session_meta` artifact's `spoken_total_cents` scalar (if present)
and feeds it into `price_items` as one prompt line — proven by a test that
asserts the request text contains the dollar figure and does NOT contain
the word "transcript".

**Degrade semantics (R7).** A pricing-kind build whose LLM call fails never
hard-fails: the structure-only document still mints a number and lands,
`queued: true` (reusing the offline `queued` posture — a note copy question
flagged for sac in the plan). A pricing call that *succeeds* but returns
prices for a mismatched/unknown `item_id` is NOT a degrade — it's an
echo-validation miss, and `queued` stays `false` (the LLM did respond).

**N3 — DEFERRED to Stage 2 (review blocker, fixed in `64b2905`).** The
plan's approved condition redefines `doc_kind_for_template` as
`doc_kinds_for_template(t)[0]` (property → `"condition"`). Review caught
that doing this in Stage 1 changes LIVE behavior: the function still
drives Stage 1's phase-B build (`pipeline/mod.rs` `process()`) and the FFI
offline fallback (`ffi/src/session.rs::partial_document`), and the shipped
`MurmurEngine.swift`'s `switch docKind` has no `"condition"` arm — a
property walk on the auto-published build would fall to the default arm
and show "SEND ESTIMATE" chrome on a move-out report. Stage 1 must behave
identically to #27, so this PR keeps the old body (property → `"report"`),
pins it with a test whose comment names the Stage-2 flip, and defers the
`[0]` redefinition to Stage 2 (which removes phase B and rewires Swift
together). **Stage-2 task note:** perform the N3 redefinition + flip the
`doc_kind_for_template_keeps_stage1_defaults` property assertion to
`"condition"` as part of Task 5. `DocumentBuilder` is unaffected either
way — it validates against `doc_kinds_for_template` (plural) +
`is_pricing_kind`, never the singular default.

## What's in this PR (Tasks 1-4 of Plan 13 Stage 1)

1. **`doc_kinds_for_template` / `is_pricing_kind`** (`crates/murmur-core/src/pipeline/mod.rs`) — the legal `doc_kind` vocabulary + pricing flags per template.
2. **`render_structure_document` + `GapPolicy`** (`crates/murmur-core/src/pipeline/document.rs`, new file) — deterministic, no-LLM structure render.
3. **`price_items` + `DocumentBuilder::build`** (same file) — the one-shot items-only pricing pass (echo-and-validate, first-wins dedup, D5a scalar hint) and the on-demand builder: validates the session is `Processed` + the kind is legal, renders structure, prices if applicable, mints + persists a snapshot artifact (burn-per-tap, D7), logs a `"document"`-purpose usage row (D9).
4. **`MurmurEngine::build_document`** (`crates/ffi/src/document_build.rs`, new file) — engine-keyed async throwing FFI export; reads back exactly the artifact id the builder just wrote. `EngineError::Document` variant added. Committed Swift bindings regenerated (pure codegen diff, verified via `apps/ios/check-bindings.sh` → exit 0).

## Deviations from the plan (flagged, not improvised)

- `GapPolicy`/`render_structure_document` live in a new `pipeline/document.rs` (created in Task 2, extended in Task 3) rather than only in `mod.rs` — the plan's Task 3 GREEN step already introduces this file for `price_items`/`DocumentBuilder`, so Task 2's pieces were placed there from the start rather than moved later.
- `price_items`'s signature takes a `usage: &mut Usage` out-param, not the plan's literal `-> Result<HashMap<...>, HarnessError>`. Needed so a response that arrives but fails to parse into a valid tool call still gets its tokens logged (R9) — mirrors the existing `run_build_document`/`summarize` pattern elsewhere in this pipeline, where `usage.add(&response.usage)` happens right after the response arrives, before success/failure is decided. A true `provider.complete` `Err` still carries zero usage either way.
- Task 4's FFI test doesn't pre-script a `price_items` response keyed to the run's real (UUIDv7, minted mid-run) item id — `MockProvider` is a pure FIFO queue with no request-aware matching, so a scripted amount can't reference an id that doesn't exist yet. Followed Plan 12's own precedent for this exact problem (`build_document_echoes_real_id_degrades_bad_ids_and_survives_the_swap`): script a placeholder id (which degrades cleanly via echo-validation) and assert on the wiring instead — a `price_items` request is made, the resulting document lands, `queued` stays false. Full pricing-with-known-ids coverage lives in Task 3's murmur-core tests, where items are created via `store.add_item_with_source` before scripting (real ids known upfront).
- Task 1-3 commits are coarser than fully granular per-checkbox — squashed into one commit per Task (1, then 3 folds Task 2's already-written code in, since both landed in the same file before the first commit). Task 4 is its own commit, split further into the Rust/FFI code commit and the bindings-regeneration commit (drift gate hygiene).

## Test plan

- [x] `nix develop -c cargo test --workspace` — exit 0
- [x] `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cd apps/ios && xcodegen generate` + demo build (`xcodebuild ... -scheme SitewalkGallery -destination 'platform=iOS Simulator,name=iPhone 17' build`, outside the Nix shell) — BUILD SUCCEEDED
- [x] `apps/ios/check-bindings.sh` (regenerates `ffi.swift` from a host build and diffs against committed) — exit 0, diff is pure codegen (new `buildDocument` method + `EngineError.Document` case)
- [x] `process()`/`finish()` untouched — `MurmurEngine.swift` has zero edits; the real-core archive's Swift consumer surface is unchanged, so main stays shippable at this merge exactly like it is today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
