### PR TITLE
sac: notes screen UI + mic-granted fix — and a comprehensive-notes ask for the core

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -383,11 +383,20 @@ final class AppModel {
     /// The walk's items + summary land on the notes screen immediately; a
     /// document is built later, deliberately, by a `buildPrimaryDocument()`
     /// tap (or a future per-kind button — sac's taxonomy).
+    /// True while finish() is computing the notes — the notes screen shows a
+    /// skeleton + top progress bar. dam's UX note: navigate ONCE (straight to
+    /// the notes phase) and fill in place, rather than a separate building
+    /// screen that then shifts to notes (the layout-shift he flagged).
+    var notesLoading = false
+
     func finishWalk() {
         source?.stop()
         audioSource?.stop()
-        phase = .building
-        path = [.building]
+        // Navigate once, immediately, into the notes phase in a loading state.
+        notes = nil
+        notesLoading = true
+        phase = .notes
+        path = [.notes]
         Task {
             // Flush before finish (issue #155 / CANON: flush over speed —
             // the last words of a walk are often the price). `stop()` lets a
@@ -397,8 +406,7 @@ final class AppModel {
             _ = await pumpTask?.value
             let notes = await engine.finish()
             self.notes = notes
-            self.phase = .notes
-            self.path = [.notes]
+            self.notesLoading = false
         }
     }
 

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -415,21 +415,23 @@ final class AppModel {
         path = []
     }
 
-    /// Plan 13 Task 7: the ONE build-document button wired per template's
-    /// primary kind (`DocKinds.primaryKind(for:)`) — engine-keyed
-    /// (`currentSessionId`, snapshotted at walk start and kept through
-    /// review), calling the Stage-1 FFI `build_document` method. On success,
-    /// routes to the EXISTING `ReviewView` (unchanged). Disabled by the
-    /// notes screen while `notes?.queued` (D9: no authoritative board yet).
-    /// // sac: this is the plumbing for ONE button; the full per-trade
-    /// button set (estimate/invoice/work_order, etc.) is yours.
-    func buildPrimaryDocument() {
-        guard let sessionId = currentSessionId else { return }
-        let kind = DocKinds.primaryKind(for: trade.key)
+    /// Which doc kind is currently building (for a per-button spinner); nil
+    /// when idle. `isBuildingDocument` stays as the any-build flag.
+    var buildingKind: String?
+
+    /// Build the finished document for an explicit `kind` (Plan 13 Stage-1 FFI
+    /// `build_document`) and route to the existing ReviewView. Engine-keyed
+    /// via `currentSessionId` (snapshotted at walk start, kept through review —
+    /// works from history too). Each notes-screen action button passes its own
+    /// legal kind; illegal-kind / non-Processed errors surface on the notes
+    /// screen and leave the button available to retry, never crash.
+    func buildDocument(kind: String) {
+        guard let sessionId = currentSessionId, !isBuildingDocument else { return }
         documentBuildError = nil
         isBuildingDocument = true
+        buildingKind = kind
         Task {
-            defer { isBuildingDocument = false }
+            defer { isBuildingDocument = false; buildingKind = nil }
             do {
                 let doc = try await engine.buildDocument(sessionId: sessionId, kind: kind)
                 self.document = doc
@@ -437,11 +439,13 @@ final class AppModel {
                 self.path = [.review]
             } catch {
                 Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "document")
-                    .error("buildDocument failed: \(error, privacy: .public)")
-                self.documentBuildError = "\(error)"
+                    .error("buildDocument(\(kind, privacy: .public)) failed: \(error, privacy: .public)")
+                self.documentBuildError = "Couldn’t build the \(DocKinds.label(for: kind).lowercased()) — tap to try again."
             }
         }
     }
+
+    func buildPrimaryDocument() { buildDocument(kind: DocKinds.primaryKind(for: trade.key)) }
 
     // MARK: Vocabulary (Plan 10) — the write half of the vocabulary → STT
     // biasing loop. Defensive: a thrown FFI error becomes a logged breadcrumb +

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -108,6 +108,32 @@ enum DocKinds {
         legalKinds(for: templateKey).first ?? "report"
     }
 
+    /// Notes-screen action-button copy per kind: the button title and a small
+    /// stamp beneath it (the mockup's "ESTIMATE / QUOTE"). sac-owned taxonomy.
+    static func label(for kind: String) -> String {
+        switch kind {
+        case "estimate": return "Estimate"
+        case "invoice": return "Invoice"
+        case "work_order": return "Work Order"
+        case "condition": return "Condition"
+        case "move_out": return "Move-Out"
+        case "inspection": return "Inspection"
+        default: return "Report"
+        }
+    }
+
+    static func stamp(for kind: String) -> String {
+        switch kind {
+        case "estimate": return "QUOTE"
+        case "invoice": return "BILL"
+        case "work_order": return "CREW"
+        case "condition": return "REPORT"
+        case "move_out": return "DEPOSIT"
+        case "inspection": return "TREC REPORT"
+        default: return "EXPORT"
+        }
+    }
+
     static func isPricingKind(_ kind: String) -> Bool {
         kind == "estimate" || kind == "invoice"
     }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -1,141 +1,286 @@
 import SwiftUI
+import UIKit
 
 // Plan 13 (notes-first): the walk's PRIMARY result. finish() lands here —
-// items + summary — not a document. A document is only built when the
-// operator taps the action row below, via the engine-keyed
-// `buildDocument(sessionId:kind:)` call, landing in the EXISTING ReviewView.
+// summary + items, NOT a document. A document is built only when the operator
+// taps an action button, via the engine-keyed buildDocument(kind:) call,
+// landing in the existing ReviewView.
 //
-// // sac: this whole screen is functional-plain plumbing — the real design
-// (docs/design/notes-mockup.html) covers grouping by kind (SCOPE / NEEDS
-// ATTENTION / …), the full per-trade action-button set, an export/utility
-// row, and a collapsed "show what I heard" transcript row. This file only
-// guarantees: summary renders, items render, ONE button wires to the
-// template's primary doc kind and reaches ReviewView, and the empty/queued
-// states don't look broken.
+// Design: docs/design/notes-mockup.html. Notes are a smart field-log writeup —
+// a summary card, findings grouped by kind (trade-aware headers), the raw
+// transcript tucked away — with the "TURN THESE NOTES INTO" action row where
+// the visible, trade-specific document buttons ARE the differentiation.
 
 struct NotesView: View {
     @Bindable var model: AppModel
+    @State private var showTranscript = false
+    @State private var exportURL: URL?
 
     private var emptyNotes: NotesModel { NotesModel(summary: "", items: [], docKind: "report", queued: false) }
     private var notes: NotesModel { model.notes ?? emptyNotes }
     private var isEmpty: Bool { notes.items.isEmpty }
+    private var kinds: [String] { DocKinds.legalKinds(for: model.trade.key) }
 
     var body: some View {
         VStack(spacing: 0) {
+            header
+            MetaStrip(left: metaLeft, right: metaRight)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     summaryCard
                     if isEmpty {
                         emptyState
                     } else {
-                        SectionHead(left: "CAPTURED", right: itemCountLabel)
-                        // sac: grouping by item kind (SCOPE / NEEDS ATTENTION / …)
-                        // is yours — this is a flat list, plumbing only.
-                        ForEach(notes.items) { item in
-                            CapturedRow(item: item)
+                        ForEach(grouped, id: \.0) { kind, items in
+                            SectionHead(left: sectionTitle(kind), right: "\(items.count)", heavyRule: false)
+                                .padding(.top, 4)
+                            ForEach(items) { CapturedRow(item: $0) }
                         }
+                        transcriptRow
                     }
                     if let error = model.documentBuildError {
-                        Text(error)
-                            .font(Theme.F.mono(11))
-                            .foregroundStyle(Theme.C.redTag)
-                            .padding(Theme.S.screenPad)
+                        errorBar(error)
                     }
                 }
-                .padding(.bottom, 20)
+                .padding(.bottom, 18)
             }
             .background(Theme.C.paperDeep)
-
-            actionRow
+            actionBar
         }
         .background(Theme.C.paperDeep.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
-    }
-
-    private var summaryCard: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("NOTES")
-                .font(Theme.F.ui(11, .bold))
-                .tracking(1.6)
-                .foregroundStyle(Theme.C.ink60)
-            Text(notes.summary.isEmpty ? "—" : notes.summary)
-                .font(Theme.F.cond(15, .medium))
-                .foregroundStyle(Theme.C.ink)
-            if notes.queued {
-                Text("SAVED OFFLINE — WILL FINISH WHEN YOU RECONNECT")
-                    .font(Theme.F.mono(10.5, .semibold))
-                    .foregroundStyle(Theme.C.orange)
-                    .padding(.top, 2)
-            }
+        .sheet(isPresented: Binding(get: { exportURL != nil }, set: { if !$0 { exportURL = nil } })) {
+            if let url = exportURL { ShareSheet(url: url) { _ in exportURL = nil } }
         }
-        .padding(Theme.S.screenPad)
     }
 
-    private var emptyState: some View {
-        Text("Nothing was captured on this walk.")
-            .font(Theme.F.cond(13, .medium))
-            .foregroundStyle(Theme.C.ink60)
-            .padding(.horizontal, Theme.S.screenPad)
-            .padding(.vertical, 12)
-    }
+    // MARK: Header
 
-    private var actionRow: some View {
-        HStack(spacing: 10) {
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
             Button { model.dismissNotes() } label: {
-                Text("NOT NOW")
-                    .font(Theme.F.ui(14, .bold))
-                    .tracking(1.1)
-                    .foregroundStyle(Theme.C.ink)
-                    .frame(width: 124)
-                    .frame(height: 58)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Theme.S.radius)
-                            .stroke(Theme.C.ink, lineWidth: 2)
-                    )
+                Text("‹ CLOSE")
+                    .font(Theme.F.mono(9, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-
-            // sac: "TURN THESE NOTES INTO ___" is the design's action row —
-            // this is the ONE wired button (Task 7), keyed off
-            // DocKinds.primaryKind(for: model.trade.key), never off the
-            // FFI payload's advisory doc_kind.
-            Button { model.buildPrimaryDocument() } label: {
-                ZStack {
-                    RoundedRectangle(cornerRadius: Theme.S.radius)
-                        .fill(Theme.C.orangeDeep)
-                        .offset(y: 3)
-                    RoundedRectangle(cornerRadius: Theme.S.radius)
-                        .fill(Theme.C.orange)
-                    if model.isBuildingDocument {
-                        ProgressView()
-                            .tint(Theme.C.onOrange)
-                    } else {
-                        Text(buildButtonLabel)
-                            .font(Theme.F.ui(15, .bold))
-                            .tracking(1.2)
-                            .foregroundStyle(Theme.C.onOrange)
-                    }
-                }
-                .frame(height: 58)
-            }
-            .buttonStyle(.plain)
-            .disabled(notes.queued || model.isBuildingDocument)
-            .opacity(notes.queued ? 0.5 : 1)
-            .frame(maxWidth: .infinity)
+            Spacer()
+            Text("WALK NOTES")
+                .font(Theme.F.mono(9, .semibold))
+                .tracking(2.0)
+                .foregroundStyle(Theme.C.orangeDeep)
         }
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 12)
         .padding(.bottom, 10)
         .background(Theme.C.paper)
-        .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
     }
 
-    private var buildButtonLabel: String {
-        "BUILD \(DocKinds.primaryKind(for: model.trade.key).uppercased())"
+    private var metaLeft: String {
+        (BusinessProfile.current?.businessName ?? model.trade.biz).uppercased()
+    }
+    private var metaRight: String {
+        let d = Date().formatted(.dateTime.weekday(.abbreviated).month(.abbreviated).day())
+        return "\(d.uppercased()) · \(notes.items.count) ITEM\(notes.items.count == 1 ? "" : "S")"
     }
 
-    private var itemCountLabel: String {
-        "\(notes.items.count) ITEM\(notes.items.count == 1 ? "" : "S")"
+    // MARK: Summary
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 0) {
+                Rectangle().fill(Theme.C.orange).frame(width: 3)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("SUMMARY")
+                        .font(Theme.F.mono(8, .semibold)).tracking(2.0)
+                        .foregroundStyle(Theme.C.ink60)
+                    Text(notes.summary.isEmpty ? "Nothing was captured on this walk." : notes.summary)
+                        .font(Theme.F.serif(14))
+                        .foregroundStyle(Theme.C.ink)
+                        .lineSpacing(3)
+                    if notes.queued {
+                        Text("SAVED OFFLINE — DOCUMENTS UNLOCK WHEN YOU RECONNECT")
+                            .font(Theme.F.mono(8.5, .semibold)).tracking(0.4)
+                            .foregroundStyle(Theme.C.yellowTag)
+                            .padding(.top, 2)
+                    }
+                }
+                .padding(.horizontal, 13).padding(.vertical, 11)
+            }
+            .background(Theme.C.sheet)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 14)
+        .padding(.bottom, 4)
+    }
+
+    private var emptyState: some View {
+        Text("NOTHING WAS CAPTURED ON THIS WALK")
+            .font(Theme.F.mono(9)).tracking(0.6)
+            .foregroundStyle(Theme.C.ink35)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 22)
+            .overlay(RoundedRectangle(cornerRadius: 4)
+                .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                .foregroundStyle(Theme.C.ink35))
+            .padding(Theme.S.screenPad)
+    }
+
+    // MARK: Transcript (collapsed)
+
+    private var transcriptRow: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button { withAnimation(.easeOut(duration: 0.2)) { showTranscript.toggle() } } label: {
+                HStack {
+                    Text("SHOW WHAT I HEARD — FULL TRANSCRIPT")
+                        .font(Theme.F.mono(8.5, .semibold)).tracking(0.8)
+                        .foregroundStyle(Theme.C.ink60)
+                    Spacer()
+                    Text(showTranscript ? "▾" : "▸")
+                        .font(Theme.F.mono(9)).foregroundStyle(Theme.C.orangeDeep)
+                }
+                .padding(9)
+                .overlay(RoundedRectangle(cornerRadius: 3)
+                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                    .foregroundStyle(Theme.C.hairline))
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            if showTranscript {
+                Text(model.transcript.isEmpty ? "—" : model.transcript)
+                    .font(Theme.F.mono(10.5)).foregroundStyle(Theme.C.ink60)
+                    .lineSpacing(5)
+                    .padding(.top, 8)
+            }
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 14)
+    }
+
+    private func errorBar(_ text: String) -> some View {
+        HStack(spacing: 0) {
+            Theme.C.redTag.frame(width: 3)
+            Text(text)
+                .font(Theme.F.mono(9)).foregroundStyle(Theme.C.redTag)
+                .padding(.horizontal, 9).padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Theme.C.redTint)
+        .padding(.horizontal, Theme.S.screenPad).padding(.top, 12)
+    }
+
+    // MARK: Action bar — the differentiation, made visible
+
+    private var actionBar: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("TURN THESE NOTES INTO")
+                .font(Theme.F.mono(8.5, .semibold)).tracking(1.8)
+                .foregroundStyle(Theme.C.ink60)
+            HStack(spacing: 8) {
+                ForEach(Array(kinds.enumerated()), id: \.element) { i, kind in
+                    docButton(kind, hero: i == 0)
+                }
+            }
+            Button { exportNotes() } label: {
+                Text("⇪  EXPORT NOTES")
+                    .font(Theme.F.mono(9, .semibold)).tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+                    .frame(maxWidth: .infinity).frame(height: 40)
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.C.hairline, lineWidth: 1.5))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 11).padding(.bottom, 10)
+        .background(Theme.C.paper)
+        .overlay(alignment: .top) { Theme.C.ink.frame(height: 1.5) }
+    }
+
+    private func docButton(_ kind: String, hero: Bool) -> some View {
+        let building = model.buildingKind == kind
+        let disabled = notes.queued || (model.isBuildingDocument && !building)
+        return Button { model.buildDocument(kind: kind) } label: {
+            ZStack {
+                if hero {
+                    RoundedRectangle(cornerRadius: Theme.S.radius).fill(Theme.C.orangeDeep).offset(y: 3)
+                    RoundedRectangle(cornerRadius: Theme.S.radius).fill(Theme.C.orange)
+                } else {
+                    RoundedRectangle(cornerRadius: Theme.S.radius).stroke(Theme.C.ink, lineWidth: 2)
+                }
+                if building {
+                    ProgressView().tint(hero ? Theme.C.onOrange : Theme.C.ink)
+                } else {
+                    VStack(spacing: 2) {
+                        Text(DocKinds.label(for: kind).uppercased())
+                            .font(Theme.F.ui(12, .bold)).tracking(0.04)
+                            .foregroundStyle(hero ? Theme.C.onOrange : Theme.C.ink)
+                        Text(DocKinds.stamp(for: kind))
+                            .font(Theme.F.mono(6.5, .semibold)).tracking(0.6)
+                            .foregroundStyle(hero ? Theme.C.onOrange.opacity(0.85) : Theme.C.ink60)
+                    }
+                }
+            }
+            .frame(height: 54).frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .opacity(disabled ? 0.4 : 1)
+    }
+
+    // MARK: Grouping (trade-aware headers, attention-first)
+
+    private let order: [TagKind] = [.red, .yellow, .plain, .green]
+    private var grouped: [(TagKind, [CapturedFixture])] {
+        order.compactMap { k in
+            let items = notes.items.filter { $0.tag.kind == k }
+            return items.isEmpty ? nil : (k, items)
+        }
+    }
+
+    private func sectionTitle(_ kind: TagKind) -> String {
+        switch (model.trade.key, kind) {
+        case ("inspection", .red): return "SAFETY"
+        case ("inspection", .yellow): return "REPAIR"
+        case ("inspection", .plain): return "OBSERVED"
+        case ("inspection", .green): return "CHECKED — OK"
+        case ("property", .red): return "DEDUCTIONS"
+        case ("property", .yellow): return "FOLLOW-UP"
+        case ("property", .plain): return "NOTED"
+        case ("property", .green): return "CONDITION OK"
+        default:
+            switch kind {
+            case .red: return "NEEDS ATTENTION"
+            case .yellow: return "FOLLOW-UP"
+            case .plain: return "SCOPE"
+            case .green: return "LOOKS GOOD"
+            }
+        }
+    }
+
+    // MARK: Export — plain-text notes (Granola-style copy/paste) via share sheet
+
+    private func exportNotes() {
+        var lines: [String] = []
+        lines.append(metaLeft)
+        lines.append("Walk notes — \(Date().formatted(.dateTime.month().day().year()))")
+        lines.append("")
+        if !notes.summary.isEmpty { lines.append(notes.summary); lines.append("") }
+        for (kind, items) in grouped {
+            lines.append(sectionTitle(kind))
+            for it in items {
+                let right = it.right.isEmpty ? "" : "  (\(it.right))"
+                lines.append("  • \(it.text)\(right)")
+            }
+            lines.append("")
+        }
+        lines.append("Prepared with Sitewalk")
+        let text = lines.joined(separator: "\n")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("walk-notes.txt")
+        try? text.data(using: .utf8)?.write(to: url)
+        exportURL = url
     }
 }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -23,29 +23,43 @@ struct NotesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // Indeterminate top bar while finish() computes; everything below
+            // stays a stable skeleton, so nothing shifts when the notes land
+            // (dam's UX note: navigate once, fill in place).
+            if model.notesLoading {
+                ProgressView().progressViewStyle(.linear).tint(Theme.C.orange).frame(height: 2)
+            } else {
+                Theme.C.paper.frame(height: 2)
+            }
             header
-            MetaStrip(left: metaLeft, right: metaRight)
+            MetaStrip(left: metaLeft, right: model.notesLoading ? "READING YOUR WALK…" : metaRight)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    summaryCard
-                    if isEmpty {
-                        emptyState
+                    if model.notesLoading {
+                        skeleton
                     } else {
-                        ForEach(grouped, id: \.0) { kind, items in
-                            SectionHead(left: sectionTitle(kind), right: "\(items.count)", heavyRule: false)
-                                .padding(.top, 4)
-                            ForEach(items) { CapturedRow(item: $0) }
+                        summaryCard
+                        if isEmpty {
+                            emptyState
+                        } else {
+                            ForEach(grouped, id: \.0) { kind, items in
+                                SectionHead(left: sectionTitle(kind), right: "\(items.count)", heavyRule: false)
+                                    .padding(.top, 4)
+                                ForEach(items) { CapturedRow(item: $0) }
+                            }
+                            transcriptRow
                         }
-                        transcriptRow
-                    }
-                    if let error = model.documentBuildError {
-                        errorBar(error)
+                        if let error = model.documentBuildError {
+                            errorBar(error)
+                        }
                     }
                 }
                 .padding(.bottom, 18)
             }
             .background(Theme.C.paperDeep)
             actionBar
+                .disabled(model.notesLoading)
+                .opacity(model.notesLoading ? 0.4 : 1)
         }
         .background(Theme.C.paperDeep.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
@@ -116,6 +130,28 @@ struct NotesView: View {
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 14)
         .padding(.bottom, 4)
+    }
+
+    // Stable placeholder while notes compute — same rough shape as the real
+    // content so the swap-in doesn't move anything.
+    private var skeleton: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep)
+                .frame(height: 78)
+                .padding(.horizontal, Theme.S.screenPad).padding(.top, 14)
+            ForEach(0..<3, id: \.self) { _ in
+                HStack(spacing: 10) {
+                    RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep).frame(width: 44, height: 16)
+                    VStack(alignment: .leading, spacing: 5) {
+                        RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep).frame(height: 12).frame(maxWidth: .infinity)
+                        RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep).frame(height: 9).frame(maxWidth: 180)
+                    }
+                }
+                .padding(.horizontal, Theme.S.screenPad).padding(.vertical, 12)
+                .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
+            }
+        }
+        .opacity(0.7)
     }
 
     private var emptyState: some View {

--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -248,7 +248,8 @@ struct OnboardingFlow: View {
         VStack(alignment: .leading, spacing: 0) {
             SectionLabel("MIC CHECK", color: Theme.C.orangeDeep)
                 .padding(.top, 18)
-            Text("Sitewalk hears your walk.")
+            // The heading itself confirms the grant — no jarring banner.
+            Text(micState == .granted ? "You’re ready to walk." : "Sitewalk hears your walk.")
                 .font(Theme.F.ui(23, .bold))
                 .padding(.top, 6)
             Text("EVERYTHING TRANSCRIBES ON YOUR PHONE")
@@ -257,10 +258,12 @@ struct OnboardingFlow: View {
                 .foregroundStyle(Theme.C.ink60)
                 .padding(.top, 4)
 
+            // On grant, each row picks up a small green ON stamp — the
+            // confirmation lives in the content, not a full-width block.
             VStack(spacing: 0) {
-                ledgerRow("MIC", "LISTENS ONLY WHILE YOU WALK")
-                ledgerRow("STT", "TRANSCRIBES ON-DEVICE")
-                ledgerRow("AUDIO", "NEVER LEAVES YOUR PHONE")
+                micRow("MIC", "LISTENS ONLY WHILE YOU WALK")
+                micRow("STT", "TRANSCRIBES ON-DEVICE")
+                micRow("AUDIO", "NEVER LEAVES YOUR PHONE")
             }
             .padding(.top, 22)
             .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
@@ -269,19 +272,16 @@ struct OnboardingFlow: View {
 
             // TODO(#181): the vocabulary-seeding step slots in here once that design lands.
 
-            if micState == .granted {
-                noteBar("MIC IS ON — TALK YOUR FIRST WALK WHENEVER YOU'RE READY",
-                        color: Theme.C.greenTag, tint: Theme.C.greenTint)
-                    .padding(.bottom, 12)
-            } else if micState == .denied {
-                // Same red note-bar grammar as BoardView's mic-denied bar.
-                // Denied never blocks finishing — the board re-surfaces it.
-                noteBar("MIC IS OFF — YOU CAN FINISH NOW AND ENABLE IT ANYTIME IN SETTINGS",
+            // Only the DENIED case still needs a bar — it's a real problem the
+            // operator has to act on. Grant is confirmed inline above.
+            if micState == .denied {
+                noteBar("MIC IS OFF — YOU CAN CONTINUE AND ENABLE IT ANYTIME IN SETTINGS",
                         color: Theme.C.redTag, tint: Theme.C.redTint)
                     .padding(.bottom, 12)
             }
 
-            if micState == .idle {
+            switch micState {
+            case .idle:
                 blockButton("REQUEST MIC ACCESS") {
                     Task {
                         let granted = await AudioCaptureSource.requestPermissions()
@@ -289,12 +289,39 @@ struct OnboardingFlow: View {
                     }
                 }
                 .padding(.bottom, 10)
-            } else {
-                blockButton("FINISH") { onComplete() }
+            case .granted:
+                blockButton("START WALKING") { onComplete() }
+                    .padding(.bottom, 10)
+            case .denied:
+                blockButton("CONTINUE") { onComplete() }
                     .padding(.bottom, 10)
             }
         }
         .padding(.horizontal, Theme.S.screenPad)
+    }
+
+    /// Ledger row for the mic step — like `ledgerRow`, but gains a green ON
+    /// stamp on the right once permission is granted.
+    private func micRow(_ index: String, _ label: String) -> some View {
+        HStack(spacing: 14) {
+            Text(index)
+                .font(Theme.F.mono(10, .semibold))
+                .foregroundStyle(Theme.C.orangeDeep)
+            Text(label)
+                .font(Theme.F.mono(11, .semibold))
+                .tracking(1.6)
+                .foregroundStyle(Theme.C.ink)
+            Spacer(minLength: 0)
+            if micState == .granted {
+                Text("ON")
+                    .font(Theme.F.mono(8, .semibold)).tracking(1.0)
+                    .foregroundStyle(Theme.C.greenTag)
+                    .padding(.horizontal, 6).padding(.top, 3).padding(.bottom, 2)
+                    .background(Theme.C.greenTint)
+            }
+        }
+        .padding(.vertical, 13)
+        .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
     }
 
     private func noteBar(_ text: String, color: Color, tint: Color) -> some View {

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -8,6 +8,7 @@ struct WalkView: View {
     @Bindable var model: AppModel
     @State private var showCamera = false
     @State private var pickerItem: PhotosPickerItem?
+    @State private var showDiscardConfirm = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,15 +51,26 @@ struct WalkView: View {
 
             VStack(spacing: 12) {
                 if model.isPaused {
-                    Button { model.discardWalk() } label: {
-                        Text("DISCARD WALK — NOTHING SAVED")
-                            .font(Theme.F.mono(10, .semibold))
-                            .tracking(1.4)
+                    // A real outlined button (dam's note: the plain red text
+                    // didn't read as tappable) + a confirm, since discard is
+                    // destructive — it drops the whole walk, not just text.
+                    Button(role: .destructive) { showDiscardConfirm = true } label: {
+                        Text("DISCARD WALK")
+                            .font(Theme.F.ui(13, .bold))
+                            .tracking(1.0)
                             .foregroundStyle(Theme.C.redTag)
-                            .frame(height: 30)
+                            .frame(height: 44)
                             .frame(maxWidth: .infinity)
+                            .overlay(RoundedRectangle(cornerRadius: Theme.S.radius)
+                                .stroke(Theme.C.redTag, lineWidth: 2))
                     }
                     .buttonStyle(.plain)
+                    .confirmationDialog("Discard this walk?", isPresented: $showDiscardConfirm, titleVisibility: .visible) {
+                        Button("Discard — nothing will be saved", role: .destructive) { model.discardWalk() }
+                        Button("Keep walking", role: .cancel) {}
+                    } message: {
+                        Text("The transcript and everything captured on this walk will be deleted.")
+                    }
                 } else {
                     Waveform()
                 }

--- a/docs/design/notes-mockup.html
+++ b/docs/design/notes-mockup.html
@@ -94,7 +94,7 @@
   .row{display:flex;align-items:baseline;gap:9px;padding:8px 20px;border-bottom:1px solid var(--hair-soft)}
   .row .bullet{width:5px;height:5px;flex:none;background:var(--ink-35);transform:translateY(4px)}
   .row .tx{flex:1;font-family:var(--cond);font-weight:600;font-size:13.5px;line-height:1.3}
-  .row .tx small{display:block;font-family:var(--mono);font-weight:400;font-size:8.5px;letter-spacing:.03em;color:var(--ink-60);margin-top:2px}
+  .row .tx small{display:block;font-family:var(--cond);font-weight:500;font-size:11.5px;letter-spacing:0;color:var(--ink-60);margin-top:3px;line-height:1.35}
   .row .rt{font-family:var(--mono);font-size:10px;color:var(--ink-60);flex:none}
   .tag{font-family:var(--mono);font-size:8px;font-weight:600;letter-spacing:.1em;padding:3px 6px 2px;flex:none;transform:translateY(-1px)}
   .tag.red{color:var(--red);background:var(--red-tint)} .tag.yellow{color:var(--yellow);background:var(--yellow-tint)}
@@ -237,21 +237,24 @@
 <script>
 const T = {
   landscape:{
-    kick:"WALK NOTES · JUST NOW", title:"1418 Alder Ct", metaL:"TUE JUL 09 · 8:12 AM", metaR:"6 MIN · 5 ITEMS",
-    summary:"Estimate walk on Susan Hollis’s front yard. Fresh bark mulch, boxwood trimming, and bed edging — plus a broken zone-2 irrigation head to replace. Target around $1,200; she wants the quote by Friday.",
+    kick:"WALK NOTES · JUST NOW", title:"1418 Alder Ct", metaL:"TUE JUL 09 · 8:12 AM", metaR:"6 MIN WALK",
+    summary:"Estimate walk for Susan Hollis — a full front-yard refresh before a family event in about three weeks. Budget-conscious; she’s targeting around $1,200 and wants the quote by Friday. Main work is fresh mulch, boxwood shaping, and bed edging, plus a cracked irrigation head to replace.",
     sections:[
-      {l:"SCOPE",c:"3",rows:[
-        {tx:"Bark mulch — front beds",sub:"DELIVERED + INSTALLED",rt:"3 CU YD"},
-        {tx:"Trim boxwoods along the walkway",sub:"SHAPE + HAUL CLIPPINGS",rt:"× 4"},
-        {tx:"Edge the front beds",sub:"SPADE EDGE, RE-CUT",rt:"~60 LF"},
+      {l:"SCOPE OF WORK",c:"3",rows:[
+        {tx:"Bark mulch — front beds",sub:"About 3 cubic yards of premium bark, delivered and installed. She wants a darker brown than last year — the old mulch has faded badly.",rt:"~3 CU YD"},
+        {tx:"Trim & shape the boxwoods",sub:"All four along the walkway; they’ve gotten leggy and uneven. Shape them up and haul the clippings.",rt:"× 4"},
+        {tx:"Re-edge the front beds",sub:"Clean spade edge, re-cut the full run along the front — roughly 60 linear feet.",rt:"~60 LF"},
       ]},
-      {l:"NEEDS ATTENTION",c:"1",rows:[
-        {tag:["yellow","REPAIR"],tx:"Irrigation head — zone 2 is broken",sub:"REPLACE — PARTS + LABOR",ph:1},
+      {l:"SITE CONDITIONS & ISSUES",c:"2",rows:[
+        {tag:["yellow","REPAIR"],tx:"Zone-2 irrigation head is cracked",sub:"By the driveway — spraying onto the sidewalk and wasting water. Needs replacing, parts and labor.",ph:1},
+        {tag:["plain","NOTE"],tx:"Front-right bed soil is compacted",sub:"Mentioned it may want amending before the mulch goes down — not committed, flag it in the quote as optional.",rt:"OPT"},
       ]},
-      {l:"PEOPLE",c:"1",rows:[{tag:["plain","CLIENT"],tx:"Susan Hollis — homeowner"}]},
-      {l:"FOLLOW-UPS",c:"2",rows:[
-        {tag:["yellow","DUE FRI"],tx:"Send the quote by Friday"},
-        {tx:"Target the whole job around $1,200"},
+      {l:"CLIENT & LOGISTICS",c:"2",rows:[
+        {tag:["plain","CLIENT"],tx:"Susan Hollis — homeowner",sub:"Prefers a text over email. Side-yard gate code is #1418."},
+        {tag:["yellow","DEADLINE"],tx:"Quote due Friday · work before the event",sub:"Family gathering in ~3 weeks; she needs the job done before then."},
+      ]},
+      {l:"BUDGET",c:"1",rows:[
+        {tag:["green","TARGET"],tx:"Around $1,200 for the whole job",sub:"Her ballpark — keep the estimate close to it."},
       ]},
     ],
     docs:[{t:"ESTIMATE",s:"QUOTE",hero:1},{t:"INVOICE",s:"BILL"},{t:"WORK ORDER",s:"CREW"}],


### PR DESCRIPTION
## Thinking

Built the notes screen against your Plan 13 seam (finish() → NotesModel, action buttons → buildDocument(kind:)): summary card, findings grouped by kind with trade-aware headers (SCOPE/NEEDS ATTENTION/… ; SAFETY/REPAIR/MONITOR/OK for inspection), collapsed transcript, export-notes-as-text, and the full per-trade button row (DocKinds legal kinds, each wired to its kind — not just the primary). Also fixed the onboarding mic-granted state Isaac flagged: the big green banner is gone, replaced by inline ON stamps on the ledger rows + a confident START WALKING button.

## The important part — a core ask (blocks the real value)

Isaac reviewed the notes on device and the direction sharpened: **the notes must be a COMPREHENSIVE, Copilot-style structured writeup — not the terse extracted line-items re-labeled.** Right now the notes payload is the live-board items (short labels for glance-ability) + a one-line summary. That drops exactly the detail that matters downstream: "she wants a *darker* mulch, the old one faded", "soil's compacted, amend before mulching — optional", "gate code #1418", "before the event in 3 weeks". Those notes are the MEAT that feeds the paperwork, the crew directives, everything.

Updated target in `docs/design/notes-mockup.html` (landscape) — comprehensive summary + detailed entries + Client/Logistics + Budget sections.

The depth has to come from your extraction/summary pass — the UI renders whatever `finish()` returns. Proposed core change (your call on shape):
- **Richer summary** — a real narrative paragraph, not one line.
- **Detailed findings** — each notes item gains a `detail` string (the full spoken context). The live board stays terse; the *notes* payload carries the detail. (Add optional `detail` to the notes item, nil on the live board?)
- **Broader capture** — notes should include client/logistics/budget items the current work-item extraction skips.
- Net: the notes summary pass produces a comprehensive structured writeup from the transcript, keyed by kind so the UI can group it.

The live board (during the walk) is correct as-is — terse and glanceable. This is only about what `finish()` returns for the notes screen. Want to align on the payload shape before I wire the richer rendering (the shell handles grouping + detail lines already).

Stacked on the merged notes-first core; targets main.