### PR TITLE
meta(sac): STATE freshen — notes-first landed, Jefe branding, #199/#200 up

### DIFF
--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -6,79 +6,92 @@ What sac is working on right now. Updated with every PR.
 
 ## Headline for dam (what needs you)
 
-Real-device voice walks work — sac ran them on an iPhone 16e. Off the back of
-that, **the product's output model is changing (notes-first)** and there are a
-handful of decisions waiting on you. Ordered by what unblocks the most:
+Notes-first landed (your Plan 13, #197/#198) and I built the Notes screen on top
+(#199). The name is settled — **Jefe** — and the branding is up (#200). Three
+things need you, ordered by unblock:
 
-1. **Notes-first architecture — PR #189** (design doc + `docs/design/notes-mockup.html`).
-   The output of a walk becomes **notes** (Granola/Copilot style), with action
-   buttons that turn them into an invoice/estimate/condition report/etc.
-   Documents stop being auto-produced at DONE. I posted recommendations on the
-   PR so you can react in one round. The only two answers I need to start
-   building the Notes screen:
-   - **finish() = notes only?** (recommend yes — drop the auto-document build).
-   - **Document transform = LLM pass or deterministic re-render?** (recommend
-     hybrid: re-render structure for free from the items you already return,
-     one focused LLM call only for pricing — or price-book lookup first).
-2. **Real-engine key on TestFlight.** #18/#19 ship demo-engine because
-   bake-vs-runtime-config is undecided. Recommend: bake via CI secret for
-   internal builds now; external-tester key handling later. Your call unblocks
-   real-engine beta.
-3. **small.en vs base.en.** sac felt real speech→transcript lag on device — the
-   datapoint your device RTF benchmark was for. If small.en can't hold
-   real-time on the phone, recommend shipping base.en default, small.en opt-in.
+1. **Comprehensive-notes CORE change — the big one.** Isaac's direction sharpened:
+   the notes aren't terse extracted items, they're a **client↔team coordination
+   artifact** — a Copilot-style structured writeup capturing what the client
+   wants + the restrictions (budget/permits/deadline/access) + conditions, so the
+   crew can execute and the paperwork has real meat to draw from. The live board
+   stays terse; only **`finish()`'s notes payload** gets rich. What I need from
+   the core (payload shape, then I wire the rendering — the UI shell already
+   groups + shows per-item detail):
+   - a **narrative summary** (not just a one-liner),
+   - a **`detail` string per item** (the "why/context" behind each captured line),
+   - **client-preference + logistics + budget capture** as first-class fields,
+   - a richer extraction prompt behind it.
+   v1 can stay ESSENTIAL — 4 buckets: **Summary · Scope of Work** (w/ client
+   prefs) **· Constraints** (budget/permits/deadline/access) **· Conditions &
+   Issues**. Expand later. I specced this on #199; waiting on the payload shape
+   before I build the richer rendering.
+2. **Review + merge #199 (notes screen) and #200 (Jefe branding).** Merging #200
+   auto-fires the internal TestFlight lane (release.yml on push→main).
+3. **CANON co-sign the name: Jefe.** #200 ships the icon + theme under it; this
+   retires the #188 rename hunt. Want your sign-off in CANON so it's official.
 
-## In-flight PRs (all pushed, thinking-first)
+## In-flight PRs (pushed, thinking-first)
 
-- **#187 voice-first input mode** — persisted MIC·VOICE / DEMO chip on the
-  board; voice default everywhere incl. sim. Removed the wrong launch-time
-  Apple-Speech permission ask (whisper is on-device; that dialog's "sent to
-  Apple" copy is untrue for us).
-- **#190 onboarding + business profile + DONE fix** (stacked on #187). First-run
-  welcome → business profile + trade → mic priming. Profile (app-side
-  UserDefaults JSON) threads into board header + letterhead everywhere,
-  replacing the fixture "Ridgeline". Board fixture jobs → this-session walk
-  history + empty state. **Seam ask:** when the core grows an operator/tenant
-  concept, `BusinessProfile` is the shape to migrate. Also folds the #168 DONE
-  fix (gate on transcript-OR-items — a voice walk was un-finishable while the
-  batched board lagged the speech).
-- **#189 notes-first output** — design doc + trade-switchable mockup. See headline.
-- **#188 sitewalk-cluster competitive research** — the name is taken by ≥7
-  products incl. a direct (poor) competitor; rename needed. Isaac's picking
-  from Jefe / Hardcopy / Goldenrod / CopyThat — CANON co-sign will come to you.
+- **#199 notes screen UI** (`pr/sac/notes-screen`) — post-walk Notes destination:
+  summary card, trade-aware kind-grouped sections, collapsed transcript, EXPORT,
+  and the full per-trade action-button row wired to `buildDocument(kind:)` via
+  DocKinds (Estimate/Invoice/Work Order | Inspection/Summary). Also folds the
+  onboarding mic-granted fix (green banner → inline ON stamps + START WALKING).
+  UI shell already handles grouping + per-item detail — it's ready for the richer
+  payload from decision #1.
+- **#200 Jefe branding — hard-hat icon + amber theme** (`pr/sac/brand-icon-theme`,
+  off `main`). New app icon (foreman/hard-hat mark, black field, marigold hat) +
+  palette moved off safety-orange (two App-Store competitors use it) to
+  black+amber. `Theme.C.orange*` token **names kept** (call-site stability),
+  **values** swapped to the hard-hat gold; ink-on-gold for contrast; thin marks →
+  darker amber so they don't vanish on paper. Pure Swift tokens + one asset, no
+  FFI surface. **Build-verified in isolation off main** (BUILD SUCCEEDED,
+  real-core, codesigned for device) + MERGEABLE. NOTE: two NotesView thin-mark
+  retints were intentionally left off #200 (they style #199's new UI, which
+  isn't on main) — one-line follow-up when #199 lands.
 
-## Recently landed
+## Recently landed (yours + mine)
 
-- #167 review follow-ups + CANON acks (template keys; STT flush-over-speed).
-- #173 base-URL Info.plist injection (icon-tap launches reach PPQ).
-- #176 walk-time photo capture + photo/vocab visual design pass.
-- Your #181 (vocab seeding) and #179 (Plan 12 photo grouping) merged with my
+- **Your Plan 13 notes-first** (#197 on-demand `build_document`, #198 the atomic
+  `finish()`→`NotesPayload` flip), decisions doc #192 (you took all my recs),
+  TestFlight→real-engine (#193), **STT→base.en (#196 — fixes my device lag)**,
+  app icon plumbing (#194).
+- **Mine:** #187 voice-first mode, #189 notes-first design, #190 onboarding +
+  business profile + DONE fix, #191 STATE freshen — all merged with your
   reactions in.
 
-## Device-test findings (iPhone 16e, first real-mic walks)
+## Device-test findings
 
-- **It works.** Real mic → whisper → extraction → document, on hardware.
-- **Lag** speech→committed transcript (small.en on device) — see decision #3.
-- **"wheelbarrow" heard as "water barrow" but corrected on the document** — the
-  two-stage design working as intended, and the strongest case for the
-  vocabulary-biasing loop (seed "wheelbarrow" → whisper hears it first time).
+- **Real-core builds, signs, and runs on device.** Full walk → whisper →
+  extraction → document verified on hardware earlier; the base.en switch (#196)
+  addressed the speech→transcript lag I hit on small.en.
+- **Phone install currently pending a USB retry.** A direct-to-device install
+  dropped mid-transfer (`IXRemoteErrorDomain code 6`, wireless) — a transfer
+  flake, not code. Cable install is the fix; nothing blocking on your side.
 
 ## What I'm doing next (no blockers)
 
-- Draft the per-trade action-button taxonomy for notes-first (mine; Q3 on #189).
-- Notes screen visuals are fully mocked; the build waits on your two #189 answers.
-- Photo-grouping styling on the review document (Plan 12 seam is ready).
+- Wire the richer notes rendering the moment the payload shape from decision #1
+  lands (UI shell is ready).
+- Per-trade action-button taxonomy is drafted and wired in #199.
+- Photo-grouping styling on the review document (Plan 12 seam ready).
 
 ## Notes for dam
 
-- **Stale items on your list, now done:** sacmeng is an org ADMIN (the CI
-  auto-fire gate is the Actions approval *setting*, not membership — but see
-  below); the harness Bearer/base-url patches shipped with #173; issue #2
-  closed by #167.
-- **CI still doesn't auto-fire on my PRs** — root cause found: GitHub Actions is
-  disabled at the **sacmeng account level** ("Actions is currently disabled for
-  your account"). Support ticket filed. Until it clears, your push to one of my
-  branches triggers the run (you're the actor). Not a repo/org setting.
-- Device signing for on-device builds: sac's Xcode team, not the ASC team
-  (com.damsac.sitewalk.gallery / J4R462XD94) — sac runs a personal-team build
-  with a unique bundle for testing.
+- **FFI gotcha that bit me today (your domain, worth knowing):**
+  `build-ffi.sh --device-only` leaves the **simulator** slice stale, and bindgen
+  regenerates `ffi.swift` **and the C header** from that sim lib — so it silently
+  drops types/checksums (I lost `NotesPayload` and the `build_document` checksum
+  → "cannot find in scope" / "No type named NotesPayload"). A full
+  `./build-ffi.sh` (both slices) fixes it; restoring the committed `ffi.swift`
+  alone does **not** (the gitignored xcframework header stays stale). Your #180
+  bindings-staleness CI is the right instinct — this is a sibling failure mode
+  (stale **binary/header** vs stale **bindings**); might be worth a guard.
+- **Device signing:** automatic → my personal Apple Development team
+  (`9UQKJHZ8J3`, isaacwm23@gmail.com), bundle `com.isaacwm.sitewalk`. Separate
+  from the ASC distribution identity `release.yml` uses for TestFlight.
+- **CI auto-fire on my PRs** — still gated at the **sacmeng account level**
+  ("Actions is disabled for your account"; ticket filed) unless it's cleared
+  since. Until then your push to one of my branches triggers the run (you're the
+  actor).


### PR DESCRIPTION
## Thinking

My `meta/sac/STATE.md` had drifted — it still framed notes-first as *undecided* and the name as an open pick. That's the exact file you read at session start, so it needs to reflect reality before you pick things up. This is a **docs-only** change (one file) kept on its own branch so it doesn't ride along with #199/#200 and doesn't trigger the TestFlight lane the way a direct-to-main push would.

## What changed

Rewrote `STATE.md` to the current pickup point:
- **Headline for dam**, reordered by unblock: (1) the **comprehensive-notes CORE change** — richer `finish()` notes payload (narrative summary + per-item `detail` + client/logistics/budget capture) so notes become the client↔team coordination artifact; (2) review + merge **#199** (notes screen) and **#200** (Jefe branding); (3) **CANON co-sign the name: Jefe** (retires the #188 rename hunt).
- Moved Plan 13 (#197/#198), base.en (#196), #193/#194, and my #187/#189/#190/#191 into **Recently landed**.
- Refreshed device-test state (real-core builds/signs/runs; phone install pending a USB retry after a wireless transfer flake).
- Added a **Notes for dam** entry on the `build-ffi.sh --device-only` stale-sim-slice gotcha (bindgen regenerates `ffi.swift` + header from the stale sim lib → silently drops `NotesPayload`/`build_document`; full rebuild fixes it) — a sibling failure mode to your #180 staleness CI.

## Testing

Docs only — no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)