### PR TITLE
Plan 14: comprehensive notes — four-bucket coordination artifact

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -1942,6 +1942,80 @@ public func FfiConverterTypeEngineConfig_lower(_ value: EngineConfig) -> RustBuf
 }
 
 
+public struct NotesEntry {
+    public var bucket: NotesBucket
+    public var label: String
+    public var detail: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(bucket: NotesBucket, label: String, detail: String) {
+        self.bucket = bucket
+        self.label = label
+        self.detail = detail
+    }
+}
+
+
+
+extension NotesEntry: Equatable, Hashable {
+    public static func ==(lhs: NotesEntry, rhs: NotesEntry) -> Bool {
+        if lhs.bucket != rhs.bucket {
+            return false
+        }
+        if lhs.label != rhs.label {
+            return false
+        }
+        if lhs.detail != rhs.detail {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bucket)
+        hasher.combine(label)
+        hasher.combine(detail)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeNotesEntry: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotesEntry {
+        return
+            try NotesEntry(
+                bucket: FfiConverterTypeNotesBucket.read(from: &buf), 
+                label: FfiConverterString.read(from: &buf), 
+                detail: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: NotesEntry, into buf: inout [UInt8]) {
+        FfiConverterTypeNotesBucket.write(value.bucket, into: &buf)
+        FfiConverterString.write(value.label, into: &buf)
+        FfiConverterString.write(value.detail, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeNotesEntry_lift(_ buf: RustBuffer) throws -> NotesEntry {
+    return try FfiConverterTypeNotesEntry.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeNotesEntry_lower(_ value: NotesEntry) -> RustBuffer {
+    return FfiConverterTypeNotesEntry.lower(value)
+}
+
+
 public struct NotesPayload {
     public var sessionId: String
     /**
@@ -1959,6 +2033,12 @@ public struct NotesPayload {
      * (reuses `BoardItem` — no new item record).
      */
     public var items: [BoardItem]
+    /**
+     * Plan 14: the comprehensive, bucketed coordination entries captured at
+     * summary time (D1-14). Empty for pre-14 sessions, an empty/offline
+     * finish, or a `write_notes` response with no notes (D6-14 table).
+     */
+    public var notes: [NotesEntry]
     /**
      * `true` when `finish()` degraded offline (D9) — the session did NOT
      * reach `Processed`; the client disables build-document buttons.
@@ -1981,6 +2061,11 @@ public struct NotesPayload {
          * (reuses `BoardItem` — no new item record).
          */items: [BoardItem], 
         /**
+         * Plan 14: the comprehensive, bucketed coordination entries captured at
+         * summary time (D1-14). Empty for pre-14 sessions, an empty/offline
+         * finish, or a `write_notes` response with no notes (D6-14 table).
+         */notes: [NotesEntry], 
+        /**
          * `true` when `finish()` degraded offline (D9) — the session did NOT
          * reach `Processed`; the client disables build-document buttons.
          */queued: Bool) {
@@ -1988,6 +2073,7 @@ public struct NotesPayload {
         self.docKind = docKind
         self.summary = summary
         self.items = items
+        self.notes = notes
         self.queued = queued
     }
 }
@@ -2008,6 +2094,9 @@ extension NotesPayload: Equatable, Hashable {
         if lhs.items != rhs.items {
             return false
         }
+        if lhs.notes != rhs.notes {
+            return false
+        }
         if lhs.queued != rhs.queued {
             return false
         }
@@ -2019,6 +2108,7 @@ extension NotesPayload: Equatable, Hashable {
         hasher.combine(docKind)
         hasher.combine(summary)
         hasher.combine(items)
+        hasher.combine(notes)
         hasher.combine(queued)
     }
 }
@@ -2035,6 +2125,7 @@ public struct FfiConverterTypeNotesPayload: FfiConverterRustBuffer {
                 docKind: FfiConverterString.read(from: &buf), 
                 summary: FfiConverterString.read(from: &buf), 
                 items: FfiConverterSequenceTypeBoardItem.read(from: &buf), 
+                notes: FfiConverterSequenceTypeNotesEntry.read(from: &buf), 
                 queued: FfiConverterBool.read(from: &buf)
         )
     }
@@ -2044,6 +2135,7 @@ public struct FfiConverterTypeNotesPayload: FfiConverterRustBuffer {
         FfiConverterString.write(value.docKind, into: &buf)
         FfiConverterString.write(value.summary, into: &buf)
         FfiConverterSequenceTypeBoardItem.write(value.items, into: &buf)
+        FfiConverterSequenceTypeNotesEntry.write(value.notes, into: &buf)
         FfiConverterBool.write(value.queued, into: &buf)
     }
 }
@@ -2299,6 +2391,81 @@ extension EngineError: Foundation.LocalizedError {
         String(reflecting: self)
     }
 }
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * The three entry buckets (D2-14). The top-level narrative summary is NOT
+ * a bucket — it's `NotesPayload.summary`.
+ */
+
+public enum NotesBucket {
+    
+    case scopeOfWork
+    case constraints
+    case conditionsAndIssues
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeNotesBucket: FfiConverterRustBuffer {
+    typealias SwiftType = NotesBucket
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotesBucket {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .scopeOfWork
+        
+        case 2: return .constraints
+        
+        case 3: return .conditionsAndIssues
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: NotesBucket, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .scopeOfWork:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .constraints:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .conditionsAndIssues:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeNotesBucket_lift(_ buf: RustBuffer) throws -> NotesBucket {
+    return try FfiConverterTypeNotesBucket.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeNotesBucket_lower(_ value: NotesBucket) -> RustBuffer {
+    return FfiConverterTypeNotesBucket.lower(value)
+}
+
+
+
+extension NotesBucket: Equatable, Hashable {}
+
+
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -2561,6 +2728,31 @@ fileprivate struct FfiConverterSequenceTypeDocLine: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeDocLine.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeNotesEntry: FfiConverterRustBuffer {
+    typealias SwiftType = [NotesEntry]
+
+    public static func write(_ value: [NotesEntry], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeNotesEntry.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [NotesEntry] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [NotesEntry]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeNotesEntry.read(from: &buf))
         }
         return seq
     }

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -150,9 +150,31 @@ final class DemoWalkEngine: WalkEngine {
             summary: "Walked \(trade.site.capitalized(with: nil)) — \(board.count) \(itemWord) captured.",
             items: board,
             docKind: DocKinds.primaryKind(for: trade.key),
-            queued: false
+            queued: false,
+            notes: Self.sampleNotes
         )
     }
+
+    // Plan 14 Task 6: scripted sample buckets (WE-A shape) so the demo build
+    // exercises `NotesModel.notes` with zero backend. // sac: bucket
+    // rendering is your follow-up — this data is inert until then.
+    private static let sampleNotes: [NotesEntryFixture] = [
+        NotesEntryFixture(
+            bucket: .scopeOfWork,
+            label: "Mulch — front beds",
+            detail: "Darker mulch than last year; the old mulch faded."
+        ),
+        NotesEntryFixture(
+            bucket: .constraints,
+            label: "Budget",
+            detail: "Keep the whole job under $1,200."
+        ),
+        NotesEntryFixture(
+            bucket: .conditionsAndIssues,
+            label: "Zone-2 irrigation head broken",
+            detail: "Replace — parts + labor."
+        )
+    ]
 
     // Plan 13 D1: the on-demand build, engine-keyed. The demo has no real
     // per-kind rendering — it returns the trade's canned document rows

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -40,10 +40,14 @@ import MurmurCoreFFI
 typealias FFIMurmurEngine = MurmurCoreFFI.MurmurEngine
 typealias FFIWalkSession = MurmurCoreFFI.WalkSession
 typealias FFIEngineConfig = MurmurCoreFFI.EngineConfig
-private typealias FFIDocumentPayload = MurmurCoreFFI.DocumentPayload
-private typealias FFIDocLine = MurmurCoreFFI.DocLine
-private typealias FFINotesPayload = MurmurCoreFFI.NotesPayload
-private typealias FFIBoardItem = MurmurCoreFFI.BoardItem
+// Not `private`: `MurmurEngineFormatting.swift` (the mapping/formatting
+// extension, split out to keep this file under the file-length lint) uses
+// these too.
+typealias FFIDocumentPayload = MurmurCoreFFI.DocumentPayload
+typealias FFIDocLine = MurmurCoreFFI.DocLine
+typealias FFINotesPayload = MurmurCoreFFI.NotesPayload
+typealias FFINotesEntry = MurmurCoreFFI.NotesEntry
+typealias FFIBoardItem = MurmurCoreFFI.BoardItem
 private typealias FFIWalkEvent = MurmurCoreFFI.WalkEvent
 private typealias FFIWalkEventListener = MurmurCoreFFI.WalkEventListener
 
@@ -280,150 +284,6 @@ final class MurmurEngine: WalkEngine {
             filename: ref.filename,
             capturedAt: ref.capturedAt
         )
-    }
-
-    // MARK: - Formatting layer (D2): core is display-copy-free; this is
-    // where cents → "$285", doc_number → "EST-0047", job_date_unix →
-    // "JUL 01 2026", and label keys → display copy happen.
-
-    // nonisolated: pure value mapping, called from the Rust callback thread
-    // (the direct-yield path above) — must not be @MainActor-isolated.
-    private nonisolated static func board(_ item: FFIBoardItem) -> CapturedFixture {
-        CapturedFixture(
-            id: UUID(uuidString: item.id) ?? UUID(),
-            tag: tag(for: item.kind),
-            text: item.text,
-            right: item.right,
-            photos: Int(item.photoCount)
-        )
-    }
-
-    private nonisolated static func tag(for kind: String) -> TagFixture {
-        switch kind {
-        case "safety": return TagFixture(kind: .red, label: "SAFETY")
-        case "price": return TagFixture(kind: .green, label: "PRICE")
-        case "part": return TagFixture(kind: .yellow, label: "PART")
-        case "decision": return TagFixture(kind: .plain, label: "DECISION")
-        default: return TagFixture(kind: .plain, label: "ITEM")
-        }
-    }
-
-    private static let centsFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-
-    private static func amountString(_ cents: Int64?) -> String {
-        guard let cents else { return "——" }
-        let dollars = Double(cents) / 100.0
-        return "$" + (centsFormatter.string(from: NSNumber(value: dollars)) ?? "\(dollars)")
-    }
-
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM dd yyyy"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter
-    }()
-
-    private static func dateLabel(_ unixSeconds: UInt64) -> String {
-        dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(unixSeconds))).uppercased()
-    }
-
-    private static func docNumberLabel(docKind: String, docNumber: UInt64) -> String {
-        let prefix: String
-        switch docKind {
-        case "estimate": prefix = "EST"
-        case "invoice": prefix = "INV"
-        case "work_order": prefix = "WO"
-        case "inspection": prefix = "IR"
-        case "condition": prefix = "COND"
-        case "move_out": prefix = "MO"
-        default: prefix = "DOC"
-        }
-        return "\(prefix)-\(String(format: "%04d", docNumber))"
-    }
-
-    /// Per-`doc_kind` display copy the milestone doesn't yet source from
-    /// core — letterhead/board chrome stays in `TradeFixture` (D2); this
-    /// table is the document-body chrome only (total label, footer note,
-    /// send button copy). // sac: the notes-screen button labels/taxonomy
-    /// are yours (D8 open question) — this table only keeps the document
-    /// body's OWN chrome (reached via the button, in the unchanged
-    /// ReviewView) correct for every Plan 13 kind, so no template silently
-    /// falls through to the old "estimate" default copy.
-    private static func totalLabel(_ key: String) -> String {
-        switch key {
-        case "deposit_deduction": return "DEPOSIT DEDUCTION"
-        case "findings": return "FINDINGS"
-        default: return "TOTAL"
-        }
-    }
-
-    private static func note(for docKind: String, queued: Bool) -> String {
-        if queued {
-            return "SAVED OFFLINE — WILL FINISH WHEN YOU RECONNECT"
-        }
-        switch docKind {
-        case "inspection": return "FINDINGS MARKED — NOT YET ASSESSED"
-        case "report", "condition", "move_out": return "DEDUCTIONS LEFT OPEN ARE MARKED — CONFIRM BEFORE SENDING"
-        case "work_order": return "GAPS ARE MARKED — CONFIRM SCOPE BEFORE SENDING"
-        default: return "GAPS ARE MARKED — TAP TO FILL BEFORE SENDING"
-        }
-    }
-
-    private static func sendLabel(for docKind: String) -> String {
-        switch docKind {
-        case "inspection": return "SEND REPORT"
-        case "report", "condition", "move_out": return "SEND REPORT"
-        case "invoice": return "SEND INVOICE"
-        case "work_order": return "SEND WORK ORDER"
-        default: return "SEND ESTIMATE"
-        }
-    }
-
-    private static func row(_ line: FFIDocLine) -> DocRowFixture {
-        DocRowFixture(
-            title: line.title,
-            sub: line.isGap ? "NOT HEARD — TAP OR SAY IT" : line.detail,
-            subWarn: line.isGap,
-            hint: nil, // Deferred 4: price-book autofill hint
-            qty: line.qty,
-            amount: amountString(line.amountCents),
-            isEdit: false, // Deferred 4: pre-filled-from-history affordance
-            isGap: line.isGap,
-            itemId: line.itemId
-        )
-    }
-
-    private static func document(_ payload: FFIDocumentPayload) -> DocumentModel {
-        DocumentModel(
-            rows: payload.lines.map(row),
-            totalKey: totalLabel(payload.totalLabelKey),
-            staticTotal: payload.staticTotalCents.map(amountString) ?? "——",
-            note: note(for: payload.docKind, queued: payload.queued),
-            send: sendLabel(for: payload.docKind)
-        )
-    }
-
-    private static func emptyDocument() -> DocumentModel {
-        DocumentModel(rows: [], totalKey: "TOTAL", staticTotal: "——", note: "", send: "SEND")
-    }
-
-    // MARK: - Notes mapping (Plan 13 D2/D3)
-
-    private static func notes(_ payload: FFINotesPayload) -> NotesModel {
-        NotesModel(
-            summary: payload.summary,
-            items: payload.items.map(Self.board),
-            docKind: payload.docKind,
-            queued: payload.queued
-        )
-    }
-
-    private static func emptyNotes() -> NotesModel {
-        NotesModel(summary: "", items: [], docKind: "report", queued: false)
     }
 }
 #endif

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+// The formatting/mapping layer for `MurmurEngine` (D2), split out of
+// MurmurEngine.swift to keep that file under the file-length lint. Core is
+// display-copy-free (cents, unix seconds, integer doc number, label keys);
+// this file formats currency/date/prefix and owns board-chrome/document-body
+// lookups. Same `canImport(MurmurCoreFFI)` gate as MurmurEngine.swift — inert
+// on the demo build.
+#if canImport(MurmurCoreFFI)
+import MurmurCoreFFI
+
+extension MurmurEngine {
+    // MARK: - Formatting layer (D2): core is display-copy-free; this is
+    // where cents → "$285", doc_number → "EST-0047", job_date_unix →
+    // "JUL 01 2026", and label keys → display copy happen.
+
+    // nonisolated: pure value mapping, called from the Rust callback thread
+    // (the direct-yield path in MurmurEngine.swift) — must not be
+    // @MainActor-isolated.
+    nonisolated static func board(_ item: FFIBoardItem) -> CapturedFixture {
+        CapturedFixture(
+            id: UUID(uuidString: item.id) ?? UUID(),
+            tag: tag(for: item.kind),
+            text: item.text,
+            right: item.right,
+            photos: Int(item.photoCount)
+        )
+    }
+
+    nonisolated static func tag(for kind: String) -> TagFixture {
+        switch kind {
+        case "safety": return TagFixture(kind: .red, label: "SAFETY")
+        case "price": return TagFixture(kind: .green, label: "PRICE")
+        case "part": return TagFixture(kind: .yellow, label: "PART")
+        case "decision": return TagFixture(kind: .plain, label: "DECISION")
+        default: return TagFixture(kind: .plain, label: "ITEM")
+        }
+    }
+
+    private static let centsFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+
+    static func amountString(_ cents: Int64?) -> String {
+        guard let cents else { return "——" }
+        let dollars = Double(cents) / 100.0
+        return "$" + (centsFormatter.string(from: NSNumber(value: dollars)) ?? "\(dollars)")
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM dd yyyy"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
+    static func dateLabel(_ unixSeconds: UInt64) -> String {
+        dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(unixSeconds))).uppercased()
+    }
+
+    static func docNumberLabel(docKind: String, docNumber: UInt64) -> String {
+        let prefix: String
+        switch docKind {
+        case "estimate": prefix = "EST"
+        case "invoice": prefix = "INV"
+        case "work_order": prefix = "WO"
+        case "inspection": prefix = "IR"
+        case "condition": prefix = "COND"
+        case "move_out": prefix = "MO"
+        default: prefix = "DOC"
+        }
+        return "\(prefix)-\(String(format: "%04d", docNumber))"
+    }
+
+    /// Per-`doc_kind` display copy the milestone doesn't yet source from
+    /// core — letterhead/board chrome stays in `TradeFixture` (D2); this
+    /// table is the document-body chrome only (total label, footer note,
+    /// send button copy). // sac: the notes-screen button labels/taxonomy
+    /// are yours (D8 open question) — this table only keeps the document
+    /// body's OWN chrome (reached via the button, in the unchanged
+    /// ReviewView) correct for every Plan 13 kind, so no template silently
+    /// falls through to the old "estimate" default copy.
+    static func totalLabel(_ key: String) -> String {
+        switch key {
+        case "deposit_deduction": return "DEPOSIT DEDUCTION"
+        case "findings": return "FINDINGS"
+        default: return "TOTAL"
+        }
+    }
+
+    static func note(for docKind: String, queued: Bool) -> String {
+        if queued {
+            return "SAVED OFFLINE — WILL FINISH WHEN YOU RECONNECT"
+        }
+        switch docKind {
+        case "inspection": return "FINDINGS MARKED — NOT YET ASSESSED"
+        case "report", "condition", "move_out": return "DEDUCTIONS LEFT OPEN ARE MARKED — CONFIRM BEFORE SENDING"
+        case "work_order": return "GAPS ARE MARKED — CONFIRM SCOPE BEFORE SENDING"
+        default: return "GAPS ARE MARKED — TAP TO FILL BEFORE SENDING"
+        }
+    }
+
+    static func sendLabel(for docKind: String) -> String {
+        switch docKind {
+        case "inspection": return "SEND REPORT"
+        case "report", "condition", "move_out": return "SEND REPORT"
+        case "invoice": return "SEND INVOICE"
+        case "work_order": return "SEND WORK ORDER"
+        default: return "SEND ESTIMATE"
+        }
+    }
+
+    static func row(_ line: FFIDocLine) -> DocRowFixture {
+        DocRowFixture(
+            title: line.title,
+            sub: line.isGap ? "NOT HEARD — TAP OR SAY IT" : line.detail,
+            subWarn: line.isGap,
+            hint: nil, // Deferred 4: price-book autofill hint
+            qty: line.qty,
+            amount: amountString(line.amountCents),
+            isEdit: false, // Deferred 4: pre-filled-from-history affordance
+            isGap: line.isGap,
+            itemId: line.itemId
+        )
+    }
+
+    static func document(_ payload: FFIDocumentPayload) -> DocumentModel {
+        DocumentModel(
+            rows: payload.lines.map(row),
+            totalKey: totalLabel(payload.totalLabelKey),
+            staticTotal: payload.staticTotalCents.map(amountString) ?? "——",
+            note: note(for: payload.docKind, queued: payload.queued),
+            send: sendLabel(for: payload.docKind)
+        )
+    }
+
+    static func emptyDocument() -> DocumentModel {
+        DocumentModel(rows: [], totalKey: "TOTAL", staticTotal: "——", note: "", send: "SEND")
+    }
+
+    // MARK: - Notes mapping (Plan 13 D2/D3; Plan 14 D2-14 grows it with buckets)
+
+    static func notes(_ payload: FFINotesPayload) -> NotesModel {
+        NotesModel(
+            summary: payload.summary,
+            items: payload.items.map(Self.board),
+            docKind: payload.docKind,
+            queued: payload.queued,
+            notes: payload.notes.map(Self.notesEntry)
+        )
+    }
+
+    // Plan 14 D2-14: the FFI boundary already dropped any unknown-bucket row
+    // (`crates/ffi/src/convert.rs::notes_entries`) — this `switch` over
+    // `FFINotesBucket` is exhaustive and safe.
+    static func notesEntry(_ entry: FFINotesEntry) -> NotesEntryFixture {
+        let bucket: NotesBucket
+        switch entry.bucket {
+        case .scopeOfWork: bucket = .scopeOfWork
+        case .constraints: bucket = .constraints
+        case .conditionsAndIssues: bucket = .conditionsAndIssues
+        }
+        return NotesEntryFixture(bucket: bucket, label: entry.label, detail: entry.detail)
+    }
+
+    static func emptyNotes() -> NotesModel {
+        NotesModel(summary: "", items: [], docKind: "report", queued: false)
+    }
+}
+#endif

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -62,6 +62,30 @@ struct DocumentModel {
     }
 }
 
+/// Plan 14 D2-14: the three notes buckets. Mirrors the uniffi `NotesBucket`
+/// enum — an exhaustive `switch` over this is safe because the FFI
+/// conversion boundary (`crates/ffi/src/convert.rs::notes_entries`) already
+/// drops any row whose bucket string isn't one of the three known variants
+/// (R6: never fabricate/coerce a bucket).
+enum NotesBucket {
+    case scopeOfWork
+    case constraints
+    case conditionsAndIssues
+}
+
+/// Plan 14 D2-14: one comprehensive-notes coordination entry — the detail
+/// behind a terse board item (client preferences, budget, site conditions,
+/// deadlines). `label` is terse (mirrors a board label); `detail` is the
+/// full spoken context. // sac: the grouped bucket sections + visuals are
+/// your follow-up (NotesView.swift's kind-grouped rendering already covers
+/// the terse board — bucket rendering is additive on top).
+struct NotesEntryFixture: Identifiable {
+    var id: String { label + detail }
+    var bucket: NotesBucket
+    var label: String
+    var detail: String
+}
+
 /// Plan 13 D2/D3: `finish()`'s notes-first result — items + summary, NOT a
 /// document. The document build moves to an explicit, later
 /// `buildDocument(sessionId:kind:)` call from the notes screen's action row.
@@ -77,6 +101,12 @@ struct NotesModel {
     /// exists yet, so build-document actions must stay disabled until a
     /// retry succeeds.
     var queued: Bool
+    /// Plan 14: the comprehensive, bucketed coordination entries captured at
+    /// summary time. Defaults to `[]` — additive, so every existing caller
+    /// (including test fixtures) keeps compiling unchanged. // sac: unrendered
+    /// until the bucket-section follow-up lands; carrying data is this task's
+    /// only job.
+    var notes: [NotesEntryFixture] = []
 }
 
 @MainActor

--- a/crates/evals/src/grade.rs
+++ b/crates/evals/src/grade.rs
@@ -21,6 +21,13 @@ pub const MATCH_THRESHOLD: f64 = 0.5;
 const BETA_SQ: f64 = 0.25;
 
 /// Pipeline output as plain data (built from store rows by `run.rs`).
+///
+/// Plan 14 D3-14/WE-B: `summary_present` is the ONLY summary field the
+/// grader reads — no text/length pin — and there is no artifact read at
+/// all, so a longer narrative summary (D2-14: 2-4 sentences) plus a notes
+/// artifact (written to `kind="notes"`, never to item rows) cannot move
+/// the F0.5 score. `cargo test -p evals` (Task 4 gate) is the byte-identical
+/// pin for every corpus scenario.
 #[derive(Clone, Debug)]
 pub struct Observed {
     pub items: Vec<ObservedItem>,

--- a/crates/evals/tests/grader_hermetic.rs
+++ b/crates/evals/tests/grader_hermetic.rs
@@ -21,7 +21,7 @@ fn end_turn(t: &str) -> CompletionResponse {
     CompletionResponse { content: vec![ContentBlock::Text { text: t.into() }], stop_reason: StopReason::EndTurn, usage: Usage { input_tokens: 20, output_tokens: 4 } }
 }
 fn summary(t: &str) -> CompletionResponse {
-    tool_use("write_summary", serde_json::json!({ "summary": t }))
+    tool_use("write_notes", serde_json::json!({ "summary": t }))
 }
 
 /// Builds a MockProvider script that emits exactly the scenario's ground-truth

--- a/crates/ffi/src/convert.rs
+++ b/crates/ffi/src/convert.rs
@@ -7,6 +7,7 @@ use murmur_core::{Artifact, CapturedItem};
 
 use crate::document::{DocLine, DocumentPayload};
 use crate::events::BoardItem;
+use crate::notes::{NotesBucket, NotesEntry};
 
 /// `CapturedItem` -> `BoardItem`. `right` has no core equivalent yet (board
 /// chrome text the Swift layer owns) and stays empty. `photo_count` is looked
@@ -22,6 +23,20 @@ pub fn board_item(item: &CapturedItem, photo_counts: &HashMap<String, u32>) -> B
         right: String::new(),
         photo_count: photo_counts.get(&item.id).copied().unwrap_or(0),
     }
+}
+
+/// Plan 14 D2-14: core-side `NotesEntry` (string `bucket`) -> FFI
+/// `NotesEntry` (enum `bucket`). A row whose `bucket` string isn't one of
+/// the three known variants is DROPPED (R6: never fabricate/coerce a
+/// bucket) — Swift only ever sees valid variants, so its exhaustive
+/// `switch` is safe.
+pub fn notes_entries(core: &[murmur_core::NotesEntry]) -> Vec<NotesEntry> {
+    core.iter()
+        .filter_map(|e| {
+            let bucket = NotesBucket::from_wire(&e.bucket)?;
+            Some(NotesEntry { bucket, label: e.label.clone(), detail: e.detail.clone() })
+        })
+        .collect()
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/ffi/src/document_build.rs
+++ b/crates/ffi/src/document_build.rs
@@ -86,7 +86,7 @@ mod tests {
     }
 
     fn summary_response(text: &str) -> CompletionResponse {
-        tool_use("write_summary", serde_json::json!({"summary": text}))
+        tool_use("write_notes", serde_json::json!({"summary": text}))
     }
 
     /// Drives a walk through `begin_walk` -> `append_transcript` ->

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -19,6 +19,6 @@ pub use convert::{document_payload, partial_document_from_items};
 pub use document::{DocLine, DocumentPayload};
 pub use engine::{EngineConfig, EngineError, MurmurEngine, Providers};
 pub use events::{BoardItem, WalkEvent, WalkEventListener};
-pub use notes::NotesPayload;
+pub use notes::{NotesBucket, NotesEntry, NotesPayload};
 pub use photos::PhotoRef;
 pub use session::WalkSession;

--- a/crates/ffi/src/notes.rs
+++ b/crates/ffi/src/notes.rs
@@ -1,11 +1,47 @@
 //! `NotesPayload` (Plan 13 D2): the exact `finish()` record after the Stage 2
 //! flip. A walk's finish output is items + summary — the document build moves
 //! to the on-demand, engine-keyed `build_document(kind)` (Stage 1, additive).
+//!
+//! Plan 14 D2-14/D5-14: `NotesPayload` grows additively with a `notes: Vec<NotesEntry>`
+//! field — the comprehensive, bucketed coordination detail behind the terse
+//! `items` board. `bucket` is a string in the core-side artifact (tolerant of
+//! drift) but an exhaustive enum here at the FFI boundary — any entry whose
+//! bucket string doesn't map to a known variant is DROPPED (R6: never
+//! fabricate/coerce a bucket), so Swift's exhaustive `switch` is safe.
 
 use murmur_core::CapturedItem;
 
 use crate::convert;
 use crate::events::BoardItem;
+
+/// The three entry buckets (D2-14). The top-level narrative summary is NOT
+/// a bucket — it's `NotesPayload.summary`.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotesBucket {
+    ScopeOfWork,
+    Constraints,
+    ConditionsAndIssues,
+}
+
+impl NotesBucket {
+    /// Maps the core-side wire string -> enum. Returns `None` for anything
+    /// outside the three known buckets — the caller drops that row (R6).
+    pub(crate) fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "scope_of_work" => Some(NotesBucket::ScopeOfWork),
+            "constraints" => Some(NotesBucket::Constraints),
+            "conditions_and_issues" => Some(NotesBucket::ConditionsAndIssues),
+            _ => None,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct NotesEntry {
+    pub bucket: NotesBucket,
+    pub label: String,
+    pub detail: String,
+}
 
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct NotesPayload {
@@ -19,6 +55,10 @@ pub struct NotesPayload {
     /// The authoritative+manual board post-swap, with batched photo_count
     /// (reuses `BoardItem` — no new item record).
     pub items: Vec<BoardItem>,
+    /// Plan 14: the comprehensive, bucketed coordination entries captured at
+    /// summary time (D1-14). Empty for pre-14 sessions, an empty/offline
+    /// finish, or a `write_notes` response with no notes (D6-14 table).
+    pub notes: Vec<NotesEntry>,
     /// `true` when `finish()` degraded offline (D9) — the session did NOT
     /// reach `Processed`; the client disables build-document buttons.
     pub queued: bool,
@@ -32,6 +72,7 @@ pub(crate) fn notes_payload(
     summary: &str,
     items: &[CapturedItem],
     photo_counts: &std::collections::HashMap<String, u32>,
+    notes: &[murmur_core::NotesEntry],
     queued: bool,
 ) -> NotesPayload {
     NotesPayload {
@@ -39,6 +80,23 @@ pub(crate) fn notes_payload(
         doc_kind: doc_kind.to_string(),
         summary: summary.to_string(),
         items: items.iter().map(|item| convert::board_item(item, photo_counts)).collect(),
+        notes: convert::notes_entries(notes),
         queued,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_from_wire_maps_the_three_known_strings() {
+        assert_eq!(NotesBucket::from_wire("scope_of_work"), Some(NotesBucket::ScopeOfWork));
+        assert_eq!(NotesBucket::from_wire("constraints"), Some(NotesBucket::Constraints));
+        assert_eq!(
+            NotesBucket::from_wire("conditions_and_issues"),
+            Some(NotesBucket::ConditionsAndIssues)
+        );
+        assert_eq!(NotesBucket::from_wire("logistics"), None, "unknown bucket -> None, dropped");
     }
 }

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Condvar, Mutex as StdMutex};
 
 use harness::{LlmProvider, Memory, MemoryStore};
 use murmur_core::{
-    doc_kind_for_template, CapturedItem, LiveExtractOutcome, LiveExtractor, SessionProcessor,
-    Store,
+    doc_kind_for_template, parse_notes_artifact, CapturedItem, LiveExtractOutcome, LiveExtractor,
+    SessionProcessor, Store,
 };
 use tokio::sync::Mutex as TokioMutex;
 
@@ -422,14 +422,39 @@ impl WalkSession {
         (items, counts)
     }
 
+    /// Plan 14 D5-14/D6-14: reads the session's latest `kind=="notes"`
+    /// artifact (if any) and tolerant-parses it back to core-side
+    /// `NotesEntry` (`bucket` as a wire string — mapped to the FFI enum by
+    /// `notes_payload`, dropping unknown buckets, R6). ANY failure — no
+    /// artifact (pre-14 session, empty/offline finish that never reached
+    /// `process()`), a poisoned lock, a store error — degrades to `[]`,
+    /// never a panic across FFI.
+    fn session_notes(&self) -> Vec<murmur_core::NotesEntry> {
+        let Ok(store) = self.store.lock() else {
+            return Vec::new();
+        };
+        let Ok(artifacts) = store.list_artifacts_for_session(&self.session_id) else {
+            return Vec::new();
+        };
+        // Newest-first: a reprocess writes a fresh notes artifact after
+        // clear_authoritative_outputs sweeps the prior one, but taking the
+        // last match is defensive against any future multi-write scenario.
+        let Some(artifact) = artifacts.iter().rev().find(|a| a.kind == "notes") else {
+            return Vec::new();
+        };
+        parse_notes_artifact(&artifact.body)
+    }
+
     /// Builds a `NotesPayload` from whatever is on the current board (Plan
-    /// 13 D3). Shared by: the offline-degrade path (`queued: true`, D9), the
-    /// empty-transcript short circuit, and the double-finish/degraded exit
-    /// (all `queued: false` — nothing is pending in those cases).
+    /// 13 D3) plus the stored notes artifact (Plan 14 D6-14). Shared by: the
+    /// offline-degrade path (`queued: true`, D9), the empty-transcript short
+    /// circuit, and the double-finish/degraded exit (all `queued: false` —
+    /// nothing is pending in those cases).
     fn partial_notes(&self, summary: &str, queued: bool) -> NotesPayload {
         let doc_kind = doc_kind_for_template(self.template.as_deref());
         let (items, photo_counts) = self.board_items_and_photo_counts();
-        notes_payload(&self.session_id, doc_kind, summary, &items, &photo_counts, queued)
+        let notes = self.session_notes();
+        notes_payload(&self.session_id, doc_kind, summary, &items, &photo_counts, &notes, queued)
     }
 
     /// Degrade path for a `finish()` call that can't transition the session
@@ -438,7 +463,8 @@ impl WalkSession {
     /// crossed into async/FFI territory, so there is no safe panic here: any
     /// unwind here is fatal to the host app. D3's double-finish row: the
     /// session's already-stored summary (or `""` if unreadable), the current
-    /// board, `queued: false` — there is nothing left pending.
+    /// board, the stored notes artifact (or `[]`), `queued: false` — there is
+    /// nothing left pending.
     fn degraded_notes(&self) -> NotesPayload {
         let summary = {
             let store = self.store.lock().unwrap();
@@ -1514,5 +1540,150 @@ mod tests {
                 assert!(!items.is_empty(), "no snapshot should ever show an empty board (D3b)");
             }
         }
+    }
+
+    // --- Plan 14 Task 5: NotesPayload.notes wiring -------------------------
+
+    fn session_with_transcript(text: &str) -> (Arc<StdMutex<Store>>, String) {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session_row = store.start_session_with_template(None, "landscape").unwrap();
+        let sid = session_row.id.clone();
+        store.append_transcript(&sid, text).unwrap();
+        (Arc::new(StdMutex::new(store)), sid)
+    }
+
+    fn extractor_for(store: Arc<StdMutex<Store>>, memory: Arc<StdMutex<Memory>>, sid: &str) -> LiveExtractor {
+        LiveExtractor::new(Arc::new(MockProvider::new(vec![])), store, memory, sid)
+    }
+
+    /// WE-A: a happy-path `finish()` returns `NotesPayload.notes` mapped to
+    /// the FFI bucket enum; the terse board (`items`) is unchanged by any of
+    /// this.
+    #[tokio::test]
+    async fn finish_returns_notes_entries_with_mapped_buckets() {
+        let (store, sid) = session_with_transcript("mulch the front beds; keep it under $1200");
+        let memory = Arc::new(StdMutex::new(Memory::default()));
+        let extractor = extractor_for(store.clone(), memory.clone(), &sid);
+        let processing_provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![
+            tool_use("add_item", serde_json::json!({"kind": "todo", "text": "mulch front beds"})),
+            end_turn("done"),
+            tool_use(
+                "write_notes",
+                serde_json::json!({
+                    "summary": "Estimate walk on the front yard.",
+                    "notes": [
+                        {"bucket": "scope_of_work", "label": "Mulch", "detail": "Darker than last year."},
+                        {"bucket": "constraints", "label": "Budget", "detail": "Under $1,200."}
+                    ]
+                }),
+            ),
+        ]));
+        let session = test_session(sid, store, extractor, processing_provider, memory);
+        let payload = session.finish().await;
+        assert_eq!(payload.items.len(), 1, "the terse board is unchanged");
+        assert_eq!(
+            payload.notes,
+            vec![
+                crate::notes::NotesEntry {
+                    bucket: crate::notes::NotesBucket::ScopeOfWork,
+                    label: "Mulch".into(),
+                    detail: "Darker than last year.".into(),
+                },
+                crate::notes::NotesEntry {
+                    bucket: crate::notes::NotesBucket::Constraints,
+                    label: "Budget".into(),
+                    detail: "Under $1,200.".into(),
+                },
+            ]
+        );
+        assert!(!payload.queued);
+    }
+
+    /// WE-E: an unknown bucket string in the stored artifact is dropped —
+    /// the valid row survives.
+    #[tokio::test]
+    async fn finish_drops_an_unknown_bucket_row() {
+        let (store, sid) = session_with_transcript("mulch the front beds");
+        let memory = Arc::new(StdMutex::new(Memory::default()));
+        let extractor = extractor_for(store.clone(), memory.clone(), &sid);
+        let processing_provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![
+            end_turn("nothing to extract"),
+            tool_use(
+                "write_notes",
+                serde_json::json!({
+                    "summary": "Walked the front yard.",
+                    "notes": [
+                        {"bucket": "logistics", "label": "x", "detail": "dropped"},
+                        {"bucket": "scope_of_work", "label": "Mulch", "detail": "kept"}
+                    ]
+                }),
+            ),
+        ]));
+        let session = test_session(sid, store, extractor, processing_provider, memory);
+        let payload = session.finish().await;
+        assert_eq!(payload.notes.len(), 1);
+        assert_eq!(payload.notes[0].label, "Mulch");
+    }
+
+    /// D6-14: a pre-14 session (no notes artifact at all, e.g. a `finish()`
+    /// whose `write_notes` response carried no `notes` field) yields `[]`,
+    /// not an error.
+    #[tokio::test]
+    async fn finish_with_no_notes_in_the_response_yields_empty_notes() {
+        let (store, sid) = session_with_transcript("just talking, nothing notable");
+        let memory = Arc::new(StdMutex::new(Memory::default()));
+        let extractor = extractor_for(store.clone(), memory.clone(), &sid);
+        let processing_provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![
+            end_turn("nothing to extract"),
+            summary_response("Walked the site."),
+        ]));
+        let session = test_session(sid, store, extractor, processing_provider, memory);
+        let payload = session.finish().await;
+        assert_eq!(payload.notes, Vec::new());
+        assert!(!payload.queued);
+    }
+
+    /// D6-14: offline/LLM-down — `process()` fails outright, so no notes
+    /// artifact was ever written. `queued: true`, `notes: []`.
+    #[tokio::test]
+    async fn finish_offline_degrade_yields_empty_notes_and_queued_true() {
+        let (store, sid) = session_with_transcript("mulch the front beds");
+        let memory = Arc::new(StdMutex::new(Memory::default()));
+        let extractor = extractor_for(store.clone(), memory.clone(), &sid);
+        // Empty script -> the extraction agent's first call errors immediately
+        // (mock script exhausted) -> process() returns Err -> offline degrade.
+        let processing_provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![]));
+        let session = test_session(sid, store, extractor, processing_provider, memory);
+        let payload = session.finish().await;
+        assert_eq!(payload.notes, Vec::new());
+        assert!(payload.queued, "process() failed outright -> queued: true (D9)");
+    }
+
+    /// D6-14: a double-`finish()` call returns the stored notes artifact from
+    /// the first `finish()`, not `[]`.
+    #[tokio::test]
+    async fn double_finish_returns_the_stored_notes() {
+        let (store, sid) = session_with_transcript("mulch the front beds; keep it under $1200");
+        let memory = Arc::new(StdMutex::new(Memory::default()));
+        let extractor = extractor_for(store.clone(), memory.clone(), &sid);
+        let processing_provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![
+            tool_use("add_item", serde_json::json!({"kind": "todo", "text": "mulch front beds"})),
+            end_turn("done"),
+            tool_use(
+                "write_notes",
+                serde_json::json!({
+                    "summary": "Estimate walk.",
+                    "notes": [
+                        {"bucket": "constraints", "label": "Budget", "detail": "Under $1,200."}
+                    ]
+                }),
+            ),
+        ]));
+        let session = test_session(sid, store, extractor, processing_provider, memory);
+        let first = session.clone().finish().await;
+        assert_eq!(first.notes.len(), 1);
+        let second = session.finish().await;
+        assert_eq!(second.notes, first.notes, "double-finish reads the stored notes artifact");
+        assert!(!second.queued);
     }
 }

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -771,7 +771,7 @@ mod tests {
     }
 
     fn summary_response(text: &str) -> CompletionResponse {
-        tool_use("write_summary", serde_json::json!({"summary": text}))
+        tool_use("write_notes", serde_json::json!({"summary": text}))
     }
 
     /// A provider whose FIRST call blocks on a barrier before answering —

--- a/crates/ffi/tests/bridge_e2e.rs
+++ b/crates/ffi/tests/bridge_e2e.rs
@@ -52,7 +52,7 @@ fn end_turn(text: &str) -> CompletionResponse {
 }
 
 fn summary_response(text: &str) -> CompletionResponse {
-    tool_use("write_summary", serde_json::json!({"summary": text}))
+    tool_use("write_notes", serde_json::json!({"summary": text}))
 }
 
 #[tokio::test]

--- a/crates/murmur-core/src/lib.rs
+++ b/crates/murmur-core/src/lib.rs
@@ -15,6 +15,7 @@ pub use error::CoreError;
 pub use ids::new_id;
 pub use pipeline::document::{BuildDocumentOutcome, DocumentBuilder};
 pub use pipeline::live::{LiveExtractOutcome, LiveExtractor};
+pub use pipeline::notes::{parse_notes_artifact, NotesEntry};
 pub use pipeline::{
     doc_kind_for_template, doc_kinds_for_template, is_pricing_kind, ProcessOutcome,
     SessionProcessor,

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -98,7 +98,11 @@ impl SessionProcessor {
             max_turns: 16,
             max_tokens: 4096,
             transcript_budget_tokens: 12_000,
-            summary_max_tokens: 512,
+            // C2: 512 -> 1024 so the narrative summary + up to 12 notes
+            // entries fit in one write_notes response without truncation.
+            // No new call (D1-14) — this is an output-token budget bump on
+            // the one pass that already ran.
+            summary_max_tokens: 1024,
         }
     }
 
@@ -183,7 +187,7 @@ impl SessionProcessor {
         // Exit: persist outcome + cost atomically, success or not.
         let store = self.locked()?;
         match result {
-            Ok((summary, spoken_total_cents)) => {
+            Ok((summary, spoken_total_cents, buckets)) => {
                 let ids = created_ids
                     .lock()
                     .map_err(|_| CoreError::InvalidState("created-ids lock poisoned".into()))?
@@ -198,6 +202,17 @@ impl SessionProcessor {
                         "session_meta",
                         "session_meta",
                         &serde_json::json!({ "spoken_total_cents": cents }).to_string(),
+                    )?;
+                }
+                // Plan 14 D5-14: persist buckets as a notes artifact BEFORE the
+                // finish swap, only when non-empty (mirrors session_meta above).
+                // clear_authoritative_outputs already sweeps it on reprocess.
+                if !buckets.is_empty() {
+                    store.add_artifact(
+                        session_id,
+                        "notes",
+                        "notes",
+                        &notes::serialize_buckets(&buckets),
                     )?;
                 }
                 let session = store.finish_session_processed(session_id, &summary, &usage, &ids)?;
@@ -219,7 +234,7 @@ impl SessionProcessor {
         memory_prompt: &str,
         usage: &mut Usage,
         created_ids: Arc<Mutex<Vec<String>>>,
-    ) -> Result<(String, Option<i64>), harness::HarnessError> {
+    ) -> Result<(String, Option<i64>, Vec<notes::NotesEntry>), harness::HarnessError> {
         let mut registry = ToolRegistry::new();
         registry.register(AddItemTool::authoritative(
             self.store.clone(),
@@ -258,20 +273,20 @@ impl SessionProcessor {
         };
         usage.add(&outcome.usage);
 
-        let (summary, spoken_total_cents, summary_usage) = prompts::summarize(
+        let (summary, spoken_total_cents, buckets, summary_usage) = prompts::summarize(
             self.provider.clone(),
             assembled_transcript,
             self.summary_max_tokens,
         )
         .await?;
-        // Count the summary call's tokens BEFORE judging its content (R9:
-        // a model that skipped the tool still cost us the call).
+        // Count the summary/notes call's tokens BEFORE judging its content
+        // (R9: a model that skipped the tool still cost us the call).
         usage.add(&summary_usage);
         let summary = summary.ok_or_else(|| {
-            harness::HarnessError::Provider("summary response missing write_summary call".into())
+            harness::HarnessError::Provider("summary response missing write_notes call".into())
         })?;
 
-        Ok((summary, spoken_total_cents))
+        Ok((summary, spoken_total_cents, buckets))
     }
 
     /// Drains the awaiting_processing queue (spec §6: offline sessions queue
@@ -359,7 +374,7 @@ mod tests {
     }
 
     fn summary_response(text: &str) -> CompletionResponse {
-        tool_use("write_summary", serde_json::json!({"summary": text}))
+        tool_use("write_notes", serde_json::json!({"summary": text}))
     }
 
     #[tokio::test]
@@ -758,7 +773,7 @@ mod tests {
         let (processor, store, sid) = processor_with(vec![
             end_turn("nothing to extract"),
             tool_use(
-                "write_summary",
+                "write_notes",
                 serde_json::json!({
                     "summary": "Mulch and railing; keep it under twelve hundred.",
                     "spoken_total_cents": 120000

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -801,4 +801,86 @@ mod tests {
         let artifacts = store.list_artifacts_for_session(&sid).unwrap();
         assert!(!artifacts.iter().any(|a| a.kind == "session_meta"), "no total stated -> no artifact");
     }
+
+    /// Plan 14 D5-14/Task 3: a `write_notes` response carrying buckets
+    /// persists as a `kind="notes"` artifact, parseable back to the same
+    /// entries.
+    #[tokio::test]
+    async fn process_persists_notes_buckets_as_an_artifact() {
+        let (processor, store, sid) = processor_with(vec![
+            end_turn("nothing to extract"),
+            tool_use(
+                "write_notes",
+                serde_json::json!({
+                    "summary": "Estimate walk on the front yard.",
+                    "notes": [
+                        {"bucket": "scope_of_work", "label": "Mulch", "detail": "Darker than last year."},
+                        {"bucket": "constraints", "label": "Budget", "detail": "Under $1,200."}
+                    ]
+                }),
+            ),
+        ]);
+        processor.process(&sid).await.unwrap();
+        let store = store.lock().unwrap();
+        let artifacts = store.list_artifacts_for_session(&sid).unwrap();
+        let notes = artifacts.iter().find(|a| a.kind == "notes").expect("notes artifact written");
+        let parsed = notes::parse_notes_artifact(&notes.body);
+        assert_eq!(
+            parsed,
+            vec![
+                notes::NotesEntry {
+                    bucket: "scope_of_work".into(),
+                    label: "Mulch".into(),
+                    detail: "Darker than last year.".into(),
+                },
+                notes::NotesEntry {
+                    bucket: "constraints".into(),
+                    label: "Budget".into(),
+                    detail: "Under $1,200.".into(),
+                },
+            ]
+        );
+    }
+
+    /// No buckets in the response -> no `notes` artifact at all (mirrors the
+    /// `session_meta` absence test).
+    #[tokio::test]
+    async fn process_writes_no_notes_artifact_when_no_buckets_were_returned() {
+        let (processor, store, sid) = processor_with(vec![
+            end_turn("nothing to extract"),
+            summary_response("Walked the site."),
+        ]);
+        processor.process(&sid).await.unwrap();
+        let store = store.lock().unwrap();
+        let artifacts = store.list_artifacts_for_session(&sid).unwrap();
+        assert!(!artifacts.iter().any(|a| a.kind == "notes"), "no buckets -> no notes artifact");
+    }
+
+    /// R6 pin (D3-14): buckets never become item rows. The extraction agent
+    /// created exactly one item (`add_item`); the notes pass's two buckets
+    /// must add zero rows on top of that.
+    #[tokio::test]
+    async fn process_notes_pass_never_adds_item_rows() {
+        let (processor, store, sid) = processor_with(vec![
+            tool_use("add_item", serde_json::json!({"kind": "todo", "text": "order lumber"})),
+            end_turn("done"),
+            tool_use(
+                "write_notes",
+                serde_json::json!({
+                    "summary": "Estimate walk.",
+                    "notes": [
+                        {"bucket": "scope_of_work", "label": "Mulch", "detail": "Darker."},
+                        {"bucket": "constraints", "label": "Budget", "detail": "Under $1,200."}
+                    ]
+                }),
+            ),
+        ]);
+        processor.process(&sid).await.unwrap();
+        let store = store.lock().unwrap();
+        assert_eq!(
+            store.list_items_for_session(&sid).unwrap().len(),
+            1,
+            "buckets must never become board items"
+        );
+    }
 }

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -9,6 +9,8 @@ pub mod live;
 
 pub mod document;
 
+pub mod notes;
+
 pub(crate) mod prompts;
 
 use std::sync::{Arc, Mutex};

--- a/crates/murmur-core/src/pipeline/notes.rs
+++ b/crates/murmur-core/src/pipeline/notes.rs
@@ -26,19 +26,20 @@ pub fn parse_notes_artifact(body: &str) -> Vec<NotesEntry> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
         return Vec::new();
     };
-    parse_notes_value(&value)
+    let entries = value.get("buckets").cloned().unwrap_or(serde_json::Value::Null);
+    parse_notes_value(&entries)
 }
 
-/// Same tolerant walk as `parse_notes_artifact`, but starting from an
-/// already-parsed `serde_json::Value` — shared by the artifact-body parser
-/// and the `write_notes` tool-call `input.notes` parser (Task 2), so a
-/// truncated/malformed tool response degrades identically to a garbled
-/// stored artifact.
+/// Tolerant walk of a bare entries **array** `Value` — shared by the
+/// artifact-body parser (`buckets` field) and the `write_notes` tool-call
+/// `input.notes` parser (Task 2), so a truncated/malformed tool response
+/// degrades identically to a garbled stored artifact. A non-array `value`
+/// (missing field, wrong type) yields `[]`.
 pub fn parse_notes_value(value: &serde_json::Value) -> Vec<NotesEntry> {
-    let Some(buckets) = value.get("buckets").and_then(|b| b.as_array()) else {
+    let Some(entries) = value.as_array() else {
         return Vec::new();
     };
-    buckets
+    entries
         .iter()
         .filter_map(|row| {
             let bucket = row.get("bucket")?.as_str()?;

--- a/crates/murmur-core/src/pipeline/notes.rs
+++ b/crates/murmur-core/src/pipeline/notes.rs
@@ -1,0 +1,114 @@
+//! Plan 14 D2/D5: the comprehensive-notes artifact. `NotesEntry` is the
+//! core-side (plain serde) shape — `bucket` is a free-form string here
+//! (tolerant of drift), mapped to the `NotesBucket` enum only at the FFI
+//! boundary (`crates/ffi/src/notes.rs`). Persisted as a `kind="notes"`
+//! artifact body `{"buckets":[…]}` (D5-14: no migration, no item columns).
+
+/// The three entry buckets (D2-14). The top-level narrative `summary` is
+/// NOT a bucket — it lives on `session.summary` (unchanged column).
+pub const NOTE_BUCKETS: [&str; 3] = ["scope_of_work", "constraints", "conditions_and_issues"];
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct NotesEntry {
+    pub bucket: String,
+    pub label: String,
+    pub detail: String,
+}
+
+/// Tolerant parse of a notes artifact body (or a raw `notes` tool-call
+/// value — both walk the same `{"buckets":[…]}`-shaped JSON). A missing or
+/// unparseable body yields `[]`, never an error (R7: a garbled artifact
+/// degrades to no notes, not a hard failure). Each candidate row is kept
+/// only if it has all three required string fields AND `bucket` is one of
+/// `NOTE_BUCKETS` — an unknown bucket string is dropped, not coerced (R6:
+/// never fabricate a bucket).
+pub fn parse_notes_artifact(body: &str) -> Vec<NotesEntry> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return Vec::new();
+    };
+    parse_notes_value(&value)
+}
+
+/// Same tolerant walk as `parse_notes_artifact`, but starting from an
+/// already-parsed `serde_json::Value` — shared by the artifact-body parser
+/// and the `write_notes` tool-call `input.notes` parser (Task 2), so a
+/// truncated/malformed tool response degrades identically to a garbled
+/// stored artifact.
+pub fn parse_notes_value(value: &serde_json::Value) -> Vec<NotesEntry> {
+    let Some(buckets) = value.get("buckets").and_then(|b| b.as_array()) else {
+        return Vec::new();
+    };
+    buckets
+        .iter()
+        .filter_map(|row| {
+            let bucket = row.get("bucket")?.as_str()?;
+            let label = row.get("label")?.as_str()?;
+            let detail = row.get("detail")?.as_str()?;
+            if !NOTE_BUCKETS.contains(&bucket) {
+                return None;
+            }
+            Some(NotesEntry { bucket: bucket.to_string(), label: label.to_string(), detail: detail.to_string() })
+        })
+        .collect()
+}
+
+/// Serializes entries back to `{"buckets":[…]}` — round-trips through
+/// `parse_notes_artifact`.
+pub fn serialize_buckets(entries: &[NotesEntry]) -> String {
+    serde_json::json!({ "buckets": entries }).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(bucket: &str, label: &str, detail: &str) -> NotesEntry {
+        NotesEntry { bucket: bucket.to_string(), label: label.to_string(), detail: detail.to_string() }
+    }
+
+    #[test]
+    fn well_formed_body_round_trips() {
+        let entries = vec![
+            entry("scope_of_work", "Mulch", "Darker mulch than last year."),
+            entry("constraints", "Budget", "Keep it under $1,200."),
+        ];
+        let body = serialize_buckets(&entries);
+        assert_eq!(parse_notes_artifact(&body), entries);
+    }
+
+    #[test]
+    fn unknown_bucket_is_dropped() {
+        let body = serde_json::json!({
+            "buckets": [
+                {"bucket": "logistics", "label": "x", "detail": "y"},
+                {"bucket": "scope_of_work", "label": "Mulch", "detail": "…"}
+            ]
+        })
+        .to_string();
+        let parsed = parse_notes_artifact(&body);
+        assert_eq!(parsed, vec![entry("scope_of_work", "Mulch", "…")]);
+    }
+
+    #[test]
+    fn malformed_entry_is_skipped() {
+        let body = serde_json::json!({
+            "buckets": [
+                {"bucket": "constraints", "label": "Budget"},
+                {"bucket": "constraints", "detail": "no label"},
+                "not even an object",
+                {"bucket": "scope_of_work", "label": "Mulch", "detail": "ok"}
+            ]
+        })
+        .to_string();
+        let parsed = parse_notes_artifact(&body);
+        assert_eq!(parsed, vec![entry("scope_of_work", "Mulch", "ok")]);
+    }
+
+    #[test]
+    fn empty_or_absent_body_is_empty() {
+        assert_eq!(parse_notes_artifact(""), Vec::new());
+        assert_eq!(parse_notes_artifact("not json"), Vec::new());
+        assert_eq!(parse_notes_artifact("{}"), Vec::new());
+        assert_eq!(parse_notes_artifact(r#"{"buckets":[]}"#), Vec::new());
+    }
+}

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -9,8 +9,9 @@ use harness::{
 };
 
 use crate::domain::CapturedItem;
+use crate::pipeline::notes::{parse_notes_value, NotesEntry};
 
-const WRITE_SUMMARY: &str = "write_summary";
+const WRITE_NOTES: &str = "write_notes";
 
 /// System prompt for the extraction pass. `memory_prompt` is
 /// `Memory::to_prompt()` output ("" when empty).
@@ -39,20 +40,43 @@ pub(crate) fn extraction_system_prompt(memory_prompt: &str) -> String {
     )
 }
 
-fn summary_tool_spec() -> ToolSpec {
+fn notes_tool_spec() -> ToolSpec {
     ToolSpec {
-        name: WRITE_SUMMARY.into(),
-        description: "Record the session summary for the library list.".into(),
+        name: WRITE_NOTES.into(),
+        description: "Record the session's narrative summary, spoken total (if any), and \
+                       comprehensive coordination notes."
+            .into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
-                "summary": { "type": "string", "description": "1-2 plain sentences: what happened, key outcomes" },
+                "summary": { "type": "string", "description": "2-4 plain sentences: what, why, when" },
                 "spoken_total_cents": {
                     "type": "integer",
                     "description": "The operator's stated target/grand total for the WHOLE job, in cents \
                                      — ONLY when a specific dollar total was clearly spoken (e.g. \"keep it \
                                      under twelve hundred\" -> 120000). Omit entirely if no total was stated \
                                      or you are unsure — never guess."
+                },
+                "notes": {
+                    "type": "array",
+                    "description": "At most 12 entries; prefer fewer, denser entries. Each entry is a \
+                                     client/team coordination detail the terse board doesn't carry — the \
+                                     full spoken context behind a decision, a constraint, or a site \
+                                     condition. Capture only what was said; never invent a budget, \
+                                     deadline, or access detail — a missed note is cheaper than a \
+                                     fabricated constraint.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "bucket": {
+                                "type": "string",
+                                "enum": ["scope_of_work", "constraints", "conditions_and_issues"]
+                            },
+                            "label": { "type": "string", "description": "terse, mirrors a board label" },
+                            "detail": { "type": "string", "description": "the full spoken context" }
+                        },
+                        "required": ["bucket", "label", "detail"]
+                    }
                 }
             },
             "required": ["summary"]
@@ -60,10 +84,12 @@ fn summary_tool_spec() -> ToolSpec {
     }
 }
 
-/// One-shot forced summary call (the Plan 02 reflection-engine pattern).
+/// One-shot forced notes call (the Plan 02 reflection-engine pattern; Plan
+/// 14 D1: the same pass that already returned `spoken_total_cents` now also
+/// returns the narrative summary's richer detail as `notes[]`).
 ///
 /// Provider errors stay `Err` (no tokens were incurred). A successful call
-/// that lacks a `write_summary` block returns `Ok((None, None, usage))` so
+/// that lacks a `write_notes` block returns `Ok((None, None, [], usage))` so
 /// the caller can log the spend (R9) before deciding it's a failure. The
 /// transcript excerpt is passed through as-is — it already carries its own
 /// `## transcript` header from the context assembler.
@@ -72,32 +98,51 @@ fn summary_tool_spec() -> ToolSpec {
 /// that legitimately reads the transcript — and threaded as a scalar hint
 /// into the on-demand pricing pass (`DocumentBuilder::build`) later, so the
 /// pricing prompt itself never needs transcript access.
+///
+/// C2 (R7): a `notes` value that's truncated (model hit `max_tokens` mid-array)
+/// or malformed (non-array, garbled entries) degrades to `buckets: []` — the
+/// parseable `summary` is still returned. `parse_notes_value` is the same
+/// tolerant walk the stored artifact uses, so a garbled tool response and a
+/// garbled stored artifact degrade identically.
 pub(crate) async fn summarize(
     provider: Arc<dyn LlmProvider>,
     transcript_excerpt: &str,
     max_tokens: u32,
-) -> Result<(Option<String>, Option<i64>, Usage), HarnessError> {
+) -> Result<(Option<String>, Option<i64>, Vec<NotesEntry>, Usage), HarnessError> {
     let response = provider
         .complete(CompletionRequest {
-            system: "Summarize one transcribed field-work session in 1-2 plain sentences \
-                     for a session list. Lead with what happened; include key outcomes."
+            system: "You are building a client/team coordination artifact from one transcribed \
+                     field-work session. Write a narrative summary (2-4 plain sentences: what, \
+                     why, when) AND comprehensive notes grouped into three buckets: \
+                     scope_of_work (directives with client detail baked in — \"darker mulch than \
+                     last year\"), constraints (budget, permits, deadline, site access/gate \
+                     codes, client preferences), and conditions_and_issues (site findings \
+                     affecting the work). At most 12 notes entries; prefer fewer, denser entries. \
+                     Capture only what was said; never invent a budget, deadline, or access \
+                     detail — a missed note is cheaper than a fabricated constraint."
                 .into(),
             messages: vec![Message::user_text(transcript_excerpt)],
-            tools: vec![summary_tool_spec()],
+            tools: vec![notes_tool_spec()],
             max_tokens,
-            tool_choice: Some(WRITE_SUMMARY.into()),
+            tool_choice: Some(WRITE_NOTES.into()),
         })
         .await?;
 
     let tool_input = response.content.iter().find_map(|b| match b {
-        ContentBlock::ToolUse { name, input, .. } if name == WRITE_SUMMARY => Some(input),
+        ContentBlock::ToolUse { name, input, .. } if name == WRITE_NOTES => Some(input),
         _ => None,
     });
     let summary =
         tool_input.and_then(|i| i.get("summary").and_then(|s| s.as_str()).map(str::to_string));
     let spoken_total_cents =
         tool_input.and_then(|i| i.get("spoken_total_cents").and_then(|s| s.as_i64()));
-    Ok((summary, spoken_total_cents, response.usage))
+    // C2: a missing/non-array/garbled `notes` field yields [] via
+    // parse_notes_value's tolerant walk — never a panic, never an Err.
+    let buckets = tool_input
+        .and_then(|i| i.get("notes"))
+        .map(parse_notes_value)
+        .unwrap_or_default();
+    Ok((summary, spoken_total_cents, buckets, response.usage))
 }
 
 /// Formats a session's existing items as a newest-first dedup list for a live
@@ -173,25 +218,87 @@ mod tests {
         let provider = Arc::new(MockProvider::new(vec![CompletionResponse {
             content: vec![ContentBlock::ToolUse {
                 id: "tu_1".into(),
-                name: "write_summary".into(),
+                name: "write_notes".into(),
                 input: serde_json::json!({"summary": "Walked the deck; two todos."}),
             }],
             stop_reason: StopReason::ToolUse,
             usage: Usage { input_tokens: 40, output_tokens: 12 },
         }]));
-        let (summary, spoken_total_cents, usage) =
+        let (summary, spoken_total_cents, buckets, usage) =
             summarize(provider.clone(), "transcript text", 512).await.unwrap();
         assert_eq!(summary.as_deref(), Some("Walked the deck; two todos."));
         assert_eq!(spoken_total_cents, None, "no total was stated");
+        assert_eq!(buckets, Vec::new(), "no notes array in the response -> []");
         assert_eq!(usage, Usage { input_tokens: 40, output_tokens: 12 });
         let reqs = provider.requests();
-        assert_eq!(reqs[0].tool_choice.as_deref(), Some("write_summary"));
+        assert_eq!(reqs[0].tool_choice.as_deref(), Some("write_notes"));
         assert!(reqs[0].max_tokens >= 1);
         // the excerpt is the user message verbatim — no extra prefix
         assert_eq!(
             reqs[0].messages[0].content,
             vec![ContentBlock::Text { text: "transcript text".into() }]
         );
+    }
+
+    #[tokio::test]
+    async fn summarize_returns_the_notes_buckets_when_present() {
+        let provider = Arc::new(MockProvider::new(vec![CompletionResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tu_1".into(),
+                name: "write_notes".into(),
+                input: serde_json::json!({
+                    "summary": "Estimate walk on the front yard.",
+                    "notes": [
+                        {"bucket": "scope_of_work", "label": "Mulch", "detail": "Darker than last year."},
+                        {"bucket": "unknown_bucket", "label": "x", "detail": "dropped"}
+                    ]
+                }),
+            }],
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 40, output_tokens: 12 },
+        }]));
+        let (_summary, _spoken_total_cents, buckets, _usage) =
+            summarize(provider, "t", 512).await.unwrap();
+        assert_eq!(
+            buckets,
+            vec![crate::pipeline::notes::NotesEntry {
+                bucket: "scope_of_work".into(),
+                label: "Mulch".into(),
+                detail: "Darker than last year.".into(),
+            }],
+            "unknown bucket dropped, valid entry kept"
+        );
+    }
+
+    #[tokio::test]
+    async fn summarize_degrades_a_malformed_notes_field_to_empty_buckets_not_an_error() {
+        let provider = Arc::new(MockProvider::new(vec![CompletionResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tu_1".into(),
+                name: "write_notes".into(),
+                input: serde_json::json!({
+                    "summary": "Still a valid summary.",
+                    "notes": "not an array — a truncated/garbled response"
+                }),
+            }],
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 40, output_tokens: 12 },
+        }]));
+        let (summary, _spoken_total_cents, buckets, _usage) =
+            summarize(provider, "t", 512).await.unwrap();
+        assert_eq!(summary.as_deref(), Some("Still a valid summary."), "summary is preserved (R7)");
+        assert_eq!(buckets, Vec::new(), "garbled notes -> [] not a hard failure");
+    }
+
+    #[test]
+    fn notes_prompt_carries_r6_and_the_entry_cap() {
+        // The system prompt text is constructed inline in `summarize`; pin the
+        // static tool schema's cap/R6 language instead (schema description is
+        // sent to the model exactly like the system prompt).
+        let spec = notes_tool_spec();
+        let notes_desc = spec.input_schema["properties"]["notes"]["description"].as_str().unwrap();
+        assert!(notes_desc.contains("At most 12 entries"), "entry-count cap");
+        assert!(notes_desc.contains("never invent a budget, deadline"), "R6 clause");
     }
 
     #[test]
@@ -236,9 +343,10 @@ mod tests {
             stop_reason: StopReason::EndTurn,
             usage: Usage { input_tokens: 50, output_tokens: 10 },
         }]));
-        let (summary, spoken_total_cents, usage) = summarize(provider, "t", 512).await.unwrap();
+        let (summary, spoken_total_cents, buckets, usage) = summarize(provider, "t", 512).await.unwrap();
         assert!(summary.is_none(), "missing tool call is not an Err — spend must be loggable");
         assert_eq!(spoken_total_cents, None);
+        assert_eq!(buckets, Vec::new());
         assert_eq!(usage, Usage { input_tokens: 50, output_tokens: 10 });
     }
 
@@ -247,7 +355,7 @@ mod tests {
         let provider = Arc::new(MockProvider::new(vec![CompletionResponse {
             content: vec![ContentBlock::ToolUse {
                 id: "tu_1".into(),
-                name: "write_summary".into(),
+                name: "write_notes".into(),
                 input: serde_json::json!({
                     "summary": "Mulch and railing; keep it under twelve hundred.",
                     "spoken_total_cents": 120000
@@ -256,7 +364,7 @@ mod tests {
             stop_reason: StopReason::ToolUse,
             usage: Usage { input_tokens: 40, output_tokens: 12 },
         }]));
-        let (summary, spoken_total_cents, _usage) =
+        let (summary, spoken_total_cents, _buckets, _usage) =
             summarize(provider, "transcript text", 512).await.unwrap();
         assert!(summary.is_some());
         assert_eq!(spoken_total_cents, Some(120000));

--- a/crates/murmur-core/tests/live_extraction_e2e.rs
+++ b/crates/murmur-core/tests/live_extraction_e2e.rs
@@ -75,7 +75,7 @@ async fn live_board_is_swapped_by_end_of_session_processing() {
             tool_use("add_item", serde_json::json!({"kind": "todo", "text": "order 12 2x10 joists"})),
             tool_use("add_item", serde_json::json!({"kind": "safety", "text": "verify ledger attachment"})),
             end_turn("done"),
-            tool_use("write_summary", serde_json::json!({"summary": "Deck framing: lumber ordered."})),
+            tool_use("write_notes", serde_json::json!({"summary": "Deck framing: lumber ordered."})),
             tool_use(
                 "build_document",
                 serde_json::json!({"total_kind": "sum", "total_label_key": "total", "lines": []}),

--- a/crates/murmur-core/tests/pipeline_e2e.rs
+++ b/crates/murmur-core/tests/pipeline_e2e.rs
@@ -66,7 +66,7 @@ async fn site_walk_end_to_end() {
             tool_use("upsert_contact", serde_json::json!({"name": "Dev", "trade": "framer"})),
             tool_use("write_report", serde_json::json!({"title": "Johnson walk", "body": "## Deck\nSister two joists."})),
             end_turn("done"),
-            tool_use("write_summary", serde_json::json!({"summary": "Deck walk: framing fix planned, lumber ordered."})),
+            tool_use("write_notes", serde_json::json!({"summary": "Deck walk: framing fix planned, lumber ordered."})),
         ])),
         store.clone(),
         memory.clone(),

--- a/crates/murmur-core/tests/source_swap_e2e.rs
+++ b/crates/murmur-core/tests/source_swap_e2e.rs
@@ -19,7 +19,7 @@ fn end_turn(t: &str) -> CompletionResponse {
     CompletionResponse { content: vec![ContentBlock::Text { text: t.into() }],
         stop_reason: StopReason::EndTurn, usage: Usage { input_tokens: 10, output_tokens: 2 } }
 }
-fn summary(t: &str) -> CompletionResponse { tool_use("write_summary", serde_json::json!({"summary": t})) }
+fn summary(t: &str) -> CompletionResponse { tool_use("write_notes", serde_json::json!({"summary": t})) }
 
 #[tokio::test]
 async fn live_board_survives_failure_and_swaps_clean_on_success() {

--- a/docs/superpowers/plans/2026-07-12-rust-core-14-comprehensive-notes.md
+++ b/docs/superpowers/plans/2026-07-12-rust-core-14-comprehensive-notes.md
@@ -1,0 +1,242 @@
+# Murmur Rust Core — Plan 14: comprehensive notes
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. The Rust tasks (1–5) are **hermetic**: in-memory `Store`, `MockProvider`, `SessionProcessor`/`with_providers` — **no model, no `whisper` feature, no network, no camera, no real-photo filesystem**. `cargo test --workspace` must NEVER require the `whisper` feature or a model file (the load-bearing CI invariant). The Swift task (6) is **not CI-gated** (real-core-only, needs the gitignored `MurmurCoreFFI` xcframework) and the **notes-screen visual/grouping/bucket rendering is explicitly sac's** — `// sac:` markers throughout. Run `cargo`/`xcodegen` **inside** the Nix dev shell; run `xcodebuild` **outside** it (Nix linker env breaks Xcode `ld`). Never read `.env` or `project.local.yml`.
+>
+> **⚠ SHIPPABILITY — merging this plan auto-publishes the TestFlight internal lane on real-engine** (CANON 2026-07-10). main must build the **real-core archive** at every merge. Plan 14 is a **single-stage, additive** change (a new `notes` artifact + a grown-but-additive `NotesPayload`), so it is **ONE PR** — but the real-core compile is a **MANDATORY manual gate** (Task 7; CI cannot build real-core). See **§Staging**.
+>
+> **Contract source (dam-confirmed on PR #199 — read before implementing):** Isaac's four buckets ARE the contract. Notes are a **client ↔ team coordination artifact**: **Summary** (narrative 2–4 sentences, replaces the one-liner) / **Scope of work** (directives with client detail baked in — "darker mulch than last year") / **Constraints** (budget, permits, deadline, site access/gate codes, client preferences) / **Conditions & issues** (site findings affecting the work). Each notes entry = `bucket` + terse `label` + full `detail`. **The live board stays terse** — detail is notes-only. Target render: `docs/design/notes-mockup.html` (landscape). Prior plan: `docs/superpowers/plans/2026-07-10-rust-core-13-notes-first.md` (LANDED — this plan builds on the notes-first core it shipped).
+>
+> **Plan review (2026-07-12) — APPROVE WITH CONDITIONS (applied).** All load-bearing invariants recomputed clean: the **Swift contract holds no collision** with #199's actual diff (`NotesPayload.notes` is additive, read by name; the one payload→`NotesModel` map edit is self-contained); the **evals Δ=0 is structural**, not hopeful (the notes pass writes only to the `notes` artifact, which the item-based grader never reads — WE-B); **uniffi additivity is safe** (new field + new `NotesEntry`/`NotesBucket` symbols regenerate cleanly); the **`clear_authoritative_outputs` sweep is free** (it already tombstones all artifacts on reprocess). Three conditions folded in: **C1** — Task 2's `write_summary`→`write_notes` rename must retarget the hardcoded tool-name literal in **6 additional MockProvider-script files** (beyond `prompts.rs`/`mod.rs`/`session.rs` which the plan already edits); an un-renamed script makes `write_notes` find no tool → the summary pass returns nothing → sessions go `Failed` → the workspace gate fails (enumerated in Task 2). **C2** — bump `summary_max_tokens` 512→1024 to fit summary+buckets, cap the entry count in the prompt (≤12, prefer fewer+denser), and pin **graceful degradation** on a truncated/malformed `write_notes` response (`notes:[]`, summary preserved if parseable, never a hard failure — R7); the R9 cost delta is stated honestly (Task 2). **N1** — the PR #199 hard-dep line reworded (OPEN, contract-via-comment; the code doesn't require the merge). dam ruled **HOLD** on the `item_id` link (Open Question 1).
+
+**Goal.** The `finish()` notes screen today returns the terse board (`items`) + a one-line `summary` — glance-able, but it drops the detail that feeds the paperwork ("she wants a *darker* mulch", "gate code #1418", "before the event in 3 weeks"). Plan 14 makes the notes a **comprehensive, structured coordination artifact**: a narrative summary plus **bucketed detailed entries** (Scope of work / Constraints / Conditions & issues), captured **at summary time** from the transcript the summary pass already reads — **no new LLM call, extraction untouched, board provably unchanged**.
+
+**What lands (all in ONE PR):**
+
+1. **murmur-core — the summary pass grows into a notes pass.** `pipeline::summarize` becomes `write_notes`: the same single forced call that already reads the full transcript (and already returns `spoken_total_cents`, Plan 13 D5a) now *also* returns a narrative `summary` (2–4 sentences) + a `Vec<NotesEntry>` (bucket/label/detail). **Zero added LLM calls; extraction agent pass untouched.** (Tasks 1–2.)
+2. **murmur-core — notes persist as a `notes` artifact.** `process()` writes a `kind="notes"` JSON artifact (`{"buckets":[…]}`) on success (additive, no migration — `kind` is free-form, mirrors `session_meta`/`document`). `clear_authoritative_outputs` already sweeps it on reprocess. (Task 3.)
+3. **murmur-core — evals stay green (R6).** The notes pass writes to the notes artifact, **never to items** — the item-based F0.5 grader reads item rows only, so board precision/recall is byte-identical before/after. Pinned. (Task 4.)
+4. **ffi — `NotesPayload` grows additively.** New `notes: Vec<NotesEntry>` field (+ `NotesEntry` uniffi record, `NotesBucket` enum). `finish()`/`partial_notes`/`degraded_notes` read the notes artifact via a new tolerant `session_notes()` helper. (Task 5.)
+5. **apps/ios — minimal seam.** `NotesModel` gains `notes: [NotesEntryFixture]`; `MurmurEngine.finish()` maps `NotesPayload.notes`; `DemoWalkEngine` scripts sample buckets. **Bucket rendering / section grouping / visual design is sac's follow-up** (`// sac:`); this task only guarantees the data reaches Swift. (Task 6.)
+
+**What Plan 14 is NOT (see Non-goals for the full list).** No notes **editing**. No change to `build_document` — the document structure still renders deterministically from **items**, not from notes buckets (Q4/D4-14). No new SQLite migration (notes ride in `artifacts.body` JSON). No per-trade bucket variations beyond the four. No price-book. No vision. No PDF.
+
+---
+
+## Hard dependencies (all DONE, on `main`)
+
+- **Plan 13** (notes-first core — LANDED): `finish()` returns `NotesPayload{ session_id, doc_kind, summary, items, queued }` (`crates/ffi/src/notes.rs`); the on-demand `MurmurEngine::build_document(session_id, kind)` (`crates/murmur-core/src/pipeline/document.rs`) renders structure from items + prices estimate/invoice via one items-only pass. The **summary pass** (`pipeline::summarize`, `prompts.rs:75`) already reads the full assembled transcript and already returns `(Option<String> summary, Option<i64> spoken_total_cents, Usage)` — the D5a precedent that proves the tool schema can grow additively. `process()` already writes a `session_meta` artifact for the spoken total (`pipeline/mod.rs:193–200`) — the exact write pattern Plan 14 reuses for the notes artifact.
+- **Plan 07** (artifact seam): a generated artifact hangs off a session with a free-form `kind` + JSON `body`; `store.add_artifact(session_id, kind, title, body)` (`store/artifacts.rs:28`); `list_artifacts_for_session`; `clear_authoritative_outputs` sweeps **all** artifacts on a (re)process (`sessions.rs`) — so the notes artifact is retry-clean with no extra code. **No migration** (`MIGRATIONS.len()` unchanged, no `user_version` bump).
+- **Plan 06a** (`items.source`): the surviving board after `finish_session_processed` = this-run authoritative + manual items — the terse board the notes screen shows unchanged.
+- **PR #199** (sac, **OPEN** — the four-bucket contract is confirmed via its comment thread, but the *code* here does **not** depend on #199 merging): the notes screen already groups whatever `finish()` returns; it will render the richer `notes` payload under sac's grouping once sac wires the bucket sections (a follow-up). Plan 14's Swift edits are self-contained (Task 6) and don't touch #199's diff.
+
+**Verified API facts (checked against source, not guessed):**
+- **The summary pass is a single forced `provider.complete` call** (`prompts.rs:80–90`), tool `write_summary`, `tool_choice` forced. Growing its schema + return tuple adds **no** call — the token accounting in `pipeline/mod.rs` (`usage.add(&summary_usage)`) is unchanged in *shape* (one summary call), only its output is richer.
+- **`process()` writes `session_meta` only when `spoken_total_cents.is_some()`** (`mod.rs:193–200`), before `finish_session_processed`. The notes-artifact write slots in the same block (write only when `!buckets.is_empty()`).
+- **`ProcessOutcome` is `{ session, usage }`** (`mod.rs:65`) and does NOT need to grow — FFI reads the notes artifact from the store at `finish()` time, exactly as it reads `session.summary` from the outcome. No new field threads across the FFI boundary via `ProcessOutcome`.
+- **The evals grader reads item rows + contacts + `summary_present`** (`crates/evals/src/grade.rs:24–29`, `Observed`), built from the store by `run.rs`. It does **not** read artifacts. `summary_present` is a bool. So a notes artifact + a longer summary string cannot move the F0.5 score. (Confirm no summary-*length* pin exists — Task 4.)
+- **`NotesPayload` is a `uniffi::Record`** (`crates/ffi/src/notes.rs:10`); adding a field regenerates bindings additively (Swift reads fields by name). New `NotesEntry`/`NotesBucket` are new symbols — purely additive.
+- **`add_item`'s enum** (`pipeline/tools.rs:117`) is `todo|decision|note|safety|part|price` — the notes pass does NOT use `add_item` and cannot add to this set; the four buckets are an **orthogonal** taxonomy living only in the notes artifact.
+
+**Spec basis:** R6 (under-extraction bias — the notes pass must not author board items and must not fabricate constraints), R7 (never lose the outcome — a notes-pass parse failure degrades to `notes:[]`, never a hard failure), R9 (spend meter — no new call, so no new cost). Design: notes-first (#189), the four-bucket contract (#199 thread).
+
+---
+
+## Architecture — decisions, justified (reviewers read these first)
+
+### D1-14. Where the depth comes from: **grow the summary pass** (option b)
+
+Three candidates were weighed:
+
+- **(a) Extend the extraction pass** — give `add_item` a `detail`/`bucket`. **Rejected.** The extraction agent runs *live* (latency-sensitive) and its output IS the terse board; baking detail into it either bloats the board (breaks "the board stays terse") or forces a live/finish output split on a hot path. It also puts client/logistics/budget capture on the R6-graded item extractor, muddying the incentive the F0.5 grader pins.
+- **(c) A third dedicated notes pass** — a new LLM call after summarize. **Rejected.** R9: it doubles the finish-time call count for content the summary pass could produce for free. No new information is available to a third call that the summary call doesn't already have (both read the same transcript).
+- **(b) Enrich at summary time — ADOPTED.** The `summarize` pass **already legitimately reads the full assembled transcript** and **already** returns an extra scalar (`spoken_total_cents`, D5a) — the exact precedent. Grow its forced tool from `write_summary` → `write_notes`: one call returns `{ summary (narrative), spoken_total_cents (optional), notes[] (buckets) }`. **Net LLM calls unchanged. Extraction untouched → the board is provably identical → the F0.5 grader is provably unmoved (D3-14).**
+
+The narrative summary and the buckets are two projections of the same transcript read; producing them in one structured call is strictly cheaper than any alternative and keeps transcript access confined to the one pass that already has it.
+
+### D2-14. `NotesEntry` shape + the four buckets
+
+The **Summary** bucket is the top-level narrative string (it replaces Plan 13's one-liner; the mockup renders it as the summary card). The other **three** buckets are entry lists:
+
+```rust
+// crates/murmur-core/src/pipeline/notes.rs  (new; plain serde — core-side)
+pub struct NotesEntry {
+    pub bucket: String,   // "scope_of_work" | "constraints" | "conditions_and_issues"
+    pub label:  String,   // terse (mirrors a board label)
+    pub detail: String,   // the full spoken context ("darker mulch than last year")
+}
+```
+
+```rust
+// crates/ffi/src/notes.rs  (new uniffi types)
+#[derive(uniffi::Enum, …)] pub enum NotesBucket { ScopeOfWork, Constraints, ConditionsAndIssues }
+#[derive(uniffi::Record, …)] pub struct NotesEntry { pub bucket: NotesBucket, pub label: String, pub detail: String }
+```
+
+- **`bucket` is a string in the artifact, an enum across FFI.** Core stores the wire string (tolerant of drift); FFI maps string→enum and **drops** any entry whose bucket isn't one of the three (R6 posture: never fabricate a bucket; a garbled row is dropped, not coerced). So Swift only ever sees valid variants — sac's exhaustive `switch` is safe.
+- **`label` + `detail` are plain `String`s** (both required, `detail` may be empty). Not `Option<String>` — a uniform record is simpler for uniffi and Swift, and an empty detail is a truthful "terse label, no extra context."
+- **Entry count is capped (C2)** — the prompt asks for **≤12 entries, prefer fewer + denser**, and the summary/notes call's output budget is bumped 512→1024 tokens (Task 2) so the full payload fits in one response. A truncated/malformed response degrades to `notes:[]` with the summary preserved (R7), never a hard failure.
+- **No `item_id` link in v1.** The notes pass is fed the **transcript only** (exactly like `summarize` today) — it does NOT receive the extracted items, so its entries carry no board-item foreign key. This keeps the two passes fully decoupled, adds zero tokens, and means the notes pass has **no** board-authoring surface. The board and the notes are parallel views of the same transcript; reconciling them (jump-to-photo from a Scope entry) needs the item-linking seam and is **deferred** (Open Question 1). This is the deliberate v1 trade: cleaner and R6-provable over richer cross-links.
+
+### D3-14. R6 / evals invariance — the load-bearing guarantee
+
+The item-based F0.5 grader (`grade.rs`) scores `Observed.items`, built by `run.rs` from **store item rows**. Plan 14:
+- **does not touch the extraction agent pass** (its prompt, its `add_item` tool, its enum) → the item rows are byte-identical to pre-14;
+- **writes buckets only to the `notes` artifact** (never `add_item`) → zero new item rows;
+- keeps `summary_present == true` (the notes pass still returns a summary).
+
+Therefore, for **every** corpus scenario, `score₁₄ ≡ score₁₃`. This is not "we hope it stays green" — it is a structural invariant, pinned by a test asserting the item-row count/content is unchanged when the notes pass returns buckets (Task 3) plus the existing eval gate (Task 4). The notes prompt carries its **own** R6 clause ("capture only what was said; never invent a budget, deadline, or access detail — a missed note is cheaper than a fabricated constraint") so the *notes* content is conservative too, but that quality is not graded by the item F0.5 — the separation of incentives is the point.
+
+### D4-14. `build_document` is unchanged — notes are display + export only
+
+`DocumentBuilder::build` renders structure from **items** and prices from **items** (Plan 13 D4/D5). Plan 14 does **not** feed notes buckets into document lines. Reasons:
+- Feeding Scope-of-work detail into `render_structure_document` would let the *notes pass* author document content — reopening exactly the transcript→line R6 inflation surface Plan 12/13 closed. The document must stay item-authoritative.
+- The document and the notes are different artifacts for different audiences (priced deliverable vs. crew coordination read).
+- **Future seam (deferred):** once notes entries carry an `item_id` (Open Question 1), a document line could pull its `detail` from the matching Scope entry (richer estimates). Named, not built.
+
+**Constraints ⟷ spoken-total reconciliation (no duplication).** Plan 13 D5a already captures a machine-readable `spoken_total_cents` in the `session_meta` artifact and threads it into the pricing pass as one scalar. The **Constraints** bucket ALSO surfaces the budget — but as a **human-readable display string** ("Budget — keep the whole job under $1,200"), not a second pricing input. Both come from the **same** `write_notes` call (summary + `spoken_total_cents` + buckets in one response), so there is one capture, two projections: `session_meta.spoken_total_cents` drives pricing (unchanged); the Constraints entry is display-only. The pricing pass never reads the notes artifact.
+
+### D5-14. Persistence — a `notes` artifact, tolerant parser, no migration
+
+Buckets persist as a durable per-session artifact `kind="notes"`, body `{"buckets":[{bucket,label,detail},…]}`, written by `process()` on success **only when non-empty** (mirrors the `session_meta` write). Not item columns (buckets aren't items) and not a session-row column (no migration; the narrative summary already rides the existing `summary` column). The parser is **tolerant** field-by-field (like `convert::document_payload`): a missing/garbled entry is skipped, an unknown bucket string is dropped, a pre-14 session with **no** notes artifact yields `notes: []`. `clear_authoritative_outputs` already tombstones it on reprocess (retry re-captures cleanly).
+
+The narrative **summary** stays on `session.summary` (the `write_notes` tool's `summary` field, now instructed to be 2–4 sentences) — no schema change, and the library/history list keeps reading `session.summary` (a slightly longer subtitle; truncation is a sac display concern, Open Question 2).
+
+### D6-14. Empty / offline / double-finish — the D3 table extended
+
+Plan 13's D3 table gains a `notes` column (FFI reads the notes artifact via `session_notes()`; absent → `[]`):
+
+| finish scenario | summary | items | **notes** | queued |
+|---|---|---|---|---|
+| empty/whitespace transcript (process short-circuits) | `"(empty session)"` | manual only (usually `[]`) | **`[]`** (no notes artifact written) | `false` |
+| offline / LLM-down (process `Err`) — degrade | `""` | current live board | **`[]`** (process never completed → no artifact) | `true` |
+| double-`finish()` / post-`cancel()` | stored summary (or `""`) | current board | **stored notes artifact (or `[]`)** | `false` |
+| normal | narrative (2–4 sentences) | authoritative+manual | **buckets from the notes artifact** | `false` |
+
+No branch panics across FFI (`finish()` still returns a bare `NotesPayload`). `session_notes()` is fallible-tolerant: any store/parse error yields `[]`, never an unwind.
+
+### D7-14. Compat / staging — ONE PR
+
+Adding `notes: Vec<NotesEntry>` to the existing `NotesPayload` record + the new `NotesEntry`/`NotesBucket` symbols is **additive** (bindings regenerate; Swift reads the new field by name; existing Swift ignores it until sac renders it). The **one** required Swift edit is the payload→`NotesModel` mapping (set `notes`), co-located with a `NotesModel.notes` field defaulting to `[]` and a `DemoWalkEngine` sample — all trivial and in this PR. Bucket **rendering** (the grouped sections) is sac's follow-up; main is shippable in the meantime (buckets present in data, unrendered → no regression, sac's #199 grouping already tolerates extra payload). A two-stage split (persist first, payload+Swift later) buys nothing here because the payload growth is additive and the Swift mapping edit is tiny — one atomic PR keeps main from ever holding a half-wired notes contract. **Mandatory gate:** dam's local real-core compile + bindings-drift check (Task 7; CI can't build real-core — Plan 13 lesson).
+
+---
+
+## Worked examples (reviewers: hand-recompute against the code)
+
+**WE-A — the notes pass, one call (happy path).** Template `landscape`. Transcript:
+*"Susan wants fresh bark mulch on the front beds — darker than last year, the old stuff faded. Trim the four boxwoods along the walkway. Zone 2 irrigation head is broken, needs replacing. Keep the whole job under twelve hundred. She needs the quote by Friday. Gate code's 1418."*
+
+- **Extraction agent pass (UNCHANGED):** `add_item todo "bark mulch, front beds"`, `todo "trim 4 boxwoods, walkway"`, `part "replace zone-2 irrigation head"` → **board = 3 terse items**. (This is the F0.5 domain — untouched.)
+- **`write_notes` call (the grown summary pass) returns ONE response:**
+  - `summary` = *"Estimate walk on Susan Hollis's front yard. Fresh (darker) bark mulch, boxwood trimming, and a broken zone-2 irrigation head to replace. Target ~$1,200; quote due Friday."* (narrative, 3 sentences)
+  - `spoken_total_cents` = `120000`
+  - `notes` = 6 entries:
+    - `{scope_of_work, "Bark mulch — front beds", "Darker mulch than last year; the old mulch faded."}`
+    - `{scope_of_work, "Trim boxwoods", "Four boxwoods along the walkway; shape + haul clippings."}`
+    - `{conditions_and_issues, "Zone-2 irrigation head broken", "Replace — parts + labor."}`
+    - `{constraints, "Budget", "Keep the whole job under $1,200."}`
+    - `{constraints, "Deadline", "Quote due Friday."}`
+    - `{constraints, "Site access", "Gate code 1418."}`
+- **`process()` writes:** `session.summary` = the narrative; `session_meta` = `{"spoken_total_cents":120000}` (Plan 13, unchanged); **`notes` artifact** = `{"buckets":[…6…]}`.
+- **`finish()` →** `NotesPayload{ doc_kind:"estimate", summary:<narrative>, items:[3 terse board items], notes:[6 entries], queued:false }`.
+- **Cost (R9):** extraction-agent usage + **one** `write_notes` call — **exactly the call count of today's summarize**. Assert `provider.requests()` contains the extraction requests + one `write_notes` forced call and **no** third pass. The board (3 items) is byte-identical to a Plan-13 run of the same transcript.
+
+**WE-B — evals invariance (D3-14).** Take any corpus scenario whose Plan-13 baseline is, say, `TP=3, FP=1, FN=1` → precision `3/4=0.75`, recall `3/4=0.75`, `F0.5 = (1+0.25)·0.75·0.75 / (0.25·0.75 + 0.75) = 0.703125/0.9375 = 0.75`. Under Plan 14, `run.rs` builds `Observed.items` from the **same item rows** (extraction untouched; notes wrote to a different artifact the grader never reads) → `TP/FP/FN` identical → `F0.5 = 0.75`. **Δ = 0** for every scenario. `summary_present` stays `true`. Pinned by the "notes pass adds zero item rows" test (Task 3) + the eval gate (Task 4).
+
+**WE-C — `build_document` untouched by notes.** `build_document(S,"estimate")` on the WE-A session renders **3** lines from the **3 board items** (never the 6 notes entries). The pricing pass is fed those 3 items + the `spoken_total` scalar `$1,200` from `session_meta` (never the Constraints "Budget" entry, never the transcript). Model returns e.g. `{mulch:28500, boxwoods:14000, irrigation:12000}` → priced lines sum `$545.00` (≤ target). **The 6 notes entries appear nowhere in the document.** Proves notes are display/export-only and the document stays item-authoritative; the budget lives in two decoupled projections (pricing scalar vs. display note).
+
+**WE-D — empty / offline / double-finish (D6-14).**
+- *Empty:* silent walk → `finish()` short-circuits → `NotesPayload{ summary:"(empty session)", items:[], notes:[], queued:false }`; no notes artifact written.
+- *Offline (process `Err`):* `NotesPayload{ summary:"", items:<live board>, notes:[], queued:true }`; process never completed, so no notes artifact exists.
+- *Double-finish:* first `finish()` processed the session and wrote a notes artifact; the second `finish()` hits `degraded_notes()` → reads `session.summary` + `session_notes()` (the stored 6 entries) → `notes:[…6…]`, `queued:false`. No reprocess, no panic.
+
+**WE-E — tolerant parse / pre-14 compat (D5-14).**
+- A notes artifact body `{"buckets":[{"bucket":"logistics","label":"x","detail":"y"},{"bucket":"scope_of_work","label":"Mulch","detail":"…"}]}` → FFI parse **drops** the unknown `"logistics"` entry, keeps the one valid Scope entry → `notes:[1 entry]`. No error.
+- A **pre-14** session (finished before this plan) has no notes artifact → `session_notes()` → `[]` → `NotesPayload.notes:[]`. The payload is valid; the notes screen shows summary + terse items exactly as it did in Plan 13. Old `document` artifacts still parse unchanged.
+
+---
+
+## Staging (main stays shippable)
+
+**ONE PR** (`pr/dam/plan-14-comprehensive-notes` → main). All-additive: a new `notes` artifact, a grown `write_notes` tool, a new `NotesPayload.notes` field, new uniffi types, a minimal Swift mapping edit + demo sample. Gated by `cargo test --workspace` + `clippy --workspace --all-targets -- -D warnings` + iOS **demo** build + **the mandatory dam-manual real-core compile + bindings-drift check (Task 7)**. Rust tasks (1–5) are independently `cargo`-testable before the Swift task (6); they merge together. Bucket **rendering** is a **separate sac PR** (not in scope here) — main ships the data first, the chrome follows.
+
+---
+
+## Tasks
+
+### Task 1 — `NotesEntry` core type + tolerant parser (murmur-core)
+- [ ] **RED:** in a new `crates/murmur-core/src/pipeline/notes.rs`, tests for `parse_notes_artifact(body: &str) -> Vec<NotesEntry>`: a well-formed `{"buckets":[…]}` round-trips; an entry with an **unknown bucket** string is **dropped**; a malformed/missing-field entry is **skipped**; an empty/absent body → `[]`. Test `serialize_buckets(&[NotesEntry]) -> String` produces `{"buckets":[…]}` that `parse_notes_artifact` reads back identically.
+- [ ] **GREEN:** add `pub struct NotesEntry { pub bucket: String, pub label: String, pub detail: String }` (`serde`, `Clone`, `PartialEq`); `const NOTE_BUCKETS: [&str;3] = ["scope_of_work","constraints","conditions_and_issues"]`; `pub fn parse_notes_artifact(body: &str) -> Vec<NotesEntry>` (tolerant: `serde_json::from_str` a `Value`, walk `buckets[]`, keep only rows with all three string fields whose `bucket ∈ NOTE_BUCKETS`); `pub fn serialize_buckets(entries: &[NotesEntry]) -> String`. Wire `pub mod notes;` in `pipeline/mod.rs`.
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core`.
+
+### Task 2 — grow the summary pass into `write_notes` (murmur-core; D1-14/D2-14)
+- [ ] **RED (prompts.rs):** rename the forced tool to `write_notes`; extend its schema with an optional `notes` array (`bucket` enum `scope_of_work|constraints|conditions_and_issues`, `label`, `detail`) alongside the existing `summary` (now described "2–4 plain sentences: what, why, when") + `spoken_total_cents`. Change `summarize`'s return to `(Option<String> summary, Option<i64> spoken_total_cents, Vec<NotesEntry> buckets, Usage)`. Update the existing prompts.rs tests to the new tool name; add: a response with a `notes` array → parsed `Vec<NotesEntry>` (unknown buckets dropped via `parse`); a response with **no** `notes` → `buckets: []`; the R6 clause is present in the system prompt ("never invent a budget, deadline, or access detail"); **the entry-count cap clause is present** ("at most 12 entries; prefer fewer, denser entries"). Keep `spoken_total_cents` behavior pinned.
+- [ ] **RED (C1 — rename blast radius):** the tool name `"write_summary"` is **hardcoded in MockProvider scripts across 6 additional files** beyond the three this task/plan already edits (`prompts.rs` defines it; `pipeline/mod.rs` + `ffi/src/session.rs` hold test helpers Tasks 2/3/5 touch). Each of the six holds **one** `"write_summary"` string literal inside a shared `summary_response`/`summary` helper that fans out across many tests — an un-renamed literal makes the forced `write_notes` call find no matching tool → `summarize` returns `None` summary → the session goes **`Failed`** → `cargo test --workspace` fails. Retarget **all six** to `"write_notes"`:
+  - `crates/evals/tests/grader_hermetic.rs` (`:24`)
+  - `crates/murmur-core/tests/source_swap_e2e.rs` (`:22`)
+  - `crates/murmur-core/tests/live_extraction_e2e.rs`
+  - `crates/murmur-core/tests/pipeline_e2e.rs`
+  - `crates/ffi/tests/bridge_e2e.rs` (`:55`)
+  - `crates/ffi/src/document_build.rs` (`:89`, `#[cfg(test)]`)
+
+  (`grep -rn '"write_summary"' crates/` must return **zero** hits after this task — a single missed literal fails the workspace gate silently as a `Failed` session, not a compile error.)
+- [ ] **RED (C2 — graceful degradation, R7):** a `write_notes` response whose `notes` array is **truncated/malformed** (e.g., the model hit `max_tokens` mid-array, or an entry is a bare string) must NOT hard-fail: `summarize` returns the **parseable summary** + `buckets: []` (drop the unparseable tail, never `Err`). Pin: a response with a valid `summary` but a garbled `notes` value → `(Some(summary), _, vec![], usage)`. A response missing `write_notes` entirely stays the existing `(None, None, [], usage)` "loggable spend" path (unchanged).
+- [ ] **GREEN:** rename `WRITE_SUMMARY`→`WRITE_NOTES` (`"write_notes"`); grow `summary_tool_spec`→`notes_tool_spec`; parse the `notes` array through `notes::parse_notes_artifact`-style field-validation (reuse the Task 1 validator on the tool `input`, not just the artifact body — factor a `fn parse_notes_value(&serde_json::Value) -> Vec<NotesEntry>` both call; a non-array / garbled `notes` field yields `[]`, never a panic — C2). Rewrite the system prompt to state the coordination-artifact purpose + the four buckets + the R6 clause + the ≤12-entry "prefer fewer, denser" cap.
+- [ ] **GREEN (C2 — token budget):** bump `SessionProcessor::summary_max_tokens` **512 → 1024** (`pipeline/mod.rs:99`) so summary + buckets fit in one response without truncation. **R9 cost delta, stated honestly:** the summary/notes call's *output* budget doubles (≈512 extra output tokens worst-case, ~one-third of a cent at current pricing); there is **no new call** (D1-14), so per-finish call count is unchanged — the delta is a modest output-token bump on the one pass that already ran, in exchange for the whole comprehensive-notes payload. Acceptable per the notes-first value trade.
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core` (+ `grep -rn '"write_summary"' crates/` returns nothing).
+
+### Task 3 — thread buckets through `process()` + persist the notes artifact (murmur-core; D5-14)
+- [ ] **RED:** `run_llm_phases` returns `(String summary, Option<i64> spoken_total_cents, Vec<NotesEntry> buckets)`. In `pipeline/mod.rs` tests: a `write_notes` response carrying buckets → after `process()`, a `kind=="notes"` artifact exists with the serialized buckets (parse it back, assert entries); a response with **no** buckets → **no** notes artifact (mirrors the `session_meta` absence test). **R6 pin (D3-14):** a `process()` whose `write_notes` returns buckets adds **zero** item rows beyond what `add_item` created — assert `list_items_for_session(sid).len()` equals the count the extraction agent produced (buckets never become items). Update `processes_a_session_end_to_end`'s usage assertion — it is **unchanged** (one summary/notes call, same MockProvider token totals): `Usage { input_tokens: 350, output_tokens: 70 }` still holds because no call was added.
+- [ ] **GREEN:** in `run_llm_phases`, capture the buckets from `summarize`/`write_notes` and return them. In `process()`'s success arm, after the `session_meta` write and **before** `finish_session_processed`, `if !buckets.is_empty() { store.add_artifact(session_id, "notes", "notes", &notes::serialize_buckets(&buckets))?; }`. `ProcessOutcome` stays `{ session, usage }` (buckets reach FFI via the artifact, not the outcome).
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core` + `nix develop -c cargo clippy -p murmur-core --all-targets -- -D warnings`.
+
+### Task 4 — evals stay green + no summary-length pin (murmur-core / evals; D3-14)
+- [ ] **RED/verify:** grep `crates/evals` for any assertion on summary **text/length** (only `summary_present` should be pinned). If a length pin exists, retarget it to presence-only (the narrative is now 2–4 sentences). Confirm the grader's `Observed` is item/contact/`summary_present` only (no artifact read) — document the invariance in a one-line test comment.
+- [ ] **Gate (the real check):** `nix develop -c cargo test -p evals` — the F0.5/precision pins are **byte-identical** to pre-14 (extraction untouched). Exit code 0. If any eval score moved, STOP — the notes pass leaked into item extraction (a design violation), not a test to "fix."
+
+### Task 5 — `NotesPayload.notes` + FFI wiring (ffi; D2-14/D6-14/D7-14)
+- [ ] **RED:** in `crates/ffi/src/notes.rs` + `session.rs` tests (`with_providers`): a happy-path `finish()` (WE-A) returns `NotesPayload.notes` with the mapped entries (bucket enum correct); an unknown-bucket artifact row is dropped (WE-E); a pre-14 / no-artifact session → `notes: []`; the D6-14 table — empty→`[]`, offline(`queued:true`)→`[]`, double-finish→stored buckets. Assert `items` (the terse board) is unchanged by any of this.
+- [ ] **GREEN:** add `#[derive(uniffi::Enum)] NotesBucket { ScopeOfWork, Constraints, ConditionsAndIssues }` + `#[derive(uniffi::Record)] NotesEntry { bucket: NotesBucket, label: String, detail: String }`; add `pub notes: Vec<NotesEntry>` to `NotesPayload`; grow `notes_payload(...)` with a `notes: &[NotesEntry]` param. Add `convert::notes_entries(core: &[murmur_core::…NotesEntry]) -> Vec<NotesEntry>` (map bucket string→enum, **drop** unknowns). Add a `WalkSession::session_notes() -> Vec<NotesEntry>` helper: read the latest `kind=="notes"` artifact via `list_artifacts_for_session`, `parse_notes_artifact`, map; any error → `[]`. Thread `session_notes()` into `partial_notes`/`degraded_notes`/the happy-path `finish()` arms per the D6-14 table.
+- [ ] **Gate:** `nix develop -c cargo test -p ffi` + `nix develop -c cargo clippy -p ffi --all-targets -- -D warnings` + `nix develop -c cargo test --workspace`.
+
+### Task 6 — Swift seam: `NotesModel.notes` + demo sample (apps/ios; `// sac:` rendering deferred)
+- [ ] Add `NotesEntryFixture { bucket: NotesBucket, label: String, detail: String }` + a `NotesBucket` Swift enum (mirrors the uniffi enum); add `notes: [NotesEntryFixture]` (default `[]`) to `NotesModel`. `// sac:` marker — **the grouped bucket sections + visuals are sac's follow-up**; this task only carries the data.
+- [ ] **`MurmurEngine`** (real, `#if canImport`): `finish()` maps `NotesPayload.notes → NotesModel.notes`.
+- [ ] **`DemoWalkEngine`** parity: scripted `finish()` returns a few sample bucket entries (WE-A shape) so the demo build exercises the field. Unknown/empty → `[]`.
+- [ ] **Gate:** iOS **demo** build (xcodebuild OUTSIDE nix) green: `xcodebuild -project SitewalkGallery.xcodeproj -scheme SitewalkGallery -destination 'platform=iOS Simulator,name=iPhone 17' build`.
+
+### Task 7 — real-core compile + bindings drift (dam-manual) + merge  **[MANDATORY GATE]**
+- [ ] dam runs `cd apps/ios && ./build-ffi.sh && ./generate.sh && xcodebuild -project SitewalkGallery.xcodeproj -scheme SitewalkGallery -destination 'platform=iOS Simulator,name=iPhone 17' build` — confirm the real-core archive compiles against the grown `NotesPayload` + new `NotesEntry`/`NotesBucket` bindings (CI cannot do this — Plan 13 lesson).
+- [ ] Bindings-drift check: regenerate the Swift bindings from `crates/ffi`; confirm `MurmurEngine.swift`'s referenced symbols resolve and no unrelated record drifted.
+- [ ] **Merge the PR** — TestFlight internal lane publishes the comprehensive-notes payload on real-engine. (sac's bucket-rendering PR follows independently.)
+
+---
+
+## Gates (every task)
+- `nix develop -c cargo test --workspace` — exit code 0 (never grep counts; run under the Nix shell so the toolchain resolves).
+- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings`.
+- `nix develop -c cargo test -p evals` — F0.5/precision pins byte-identical to pre-14 (Task 4).
+- iOS **demo** build (CI-gated): `xcodebuild … SitewalkGallery … build` — **outside** the Nix shell.
+- **MANDATORY:** real-core compile + bindings-drift (dam-manual, Task 7) — before merge.
+
+## Acceptance criteria
+1. The summary pass makes **one** forced `write_notes` call returning `{ summary (2–4 sentences), spoken_total_cents (optional), notes[] }`; **no** LLM call is added vs. Plan 13; the extraction agent pass is untouched.
+2. `process()` persists buckets as a `kind="notes"` JSON artifact (only when non-empty), no migration; `clear_authoritative_outputs` sweeps it on reprocess.
+3. The evals F0.5/precision scores are **byte-identical** to pre-14 for every corpus scenario (the notes pass writes zero item rows).
+4. `finish()` returns `NotesPayload` with a populated `notes: Vec<NotesEntry>` (bucket/label/detail), buckets grouped Scope/Constraints/Conditions; the terse `items` board is unchanged.
+5. Empty / offline(`queued`) / double-finish / pre-14 sessions follow the D6-14 table (`notes:[]` or stored buckets); no panic across FFI; unknown-bucket rows dropped tolerantly; a truncated/malformed `write_notes` response degrades to `notes:[]` with the summary preserved (R7).
+6. `build_document` is unchanged — document lines still render from **items**, priced from the `session_meta` spoken-total scalar; the Constraints "Budget" entry is display-only.
+7. `NotesPayload` grows additively; one PR; main builds the real-core archive at merge (Task 7 gate green).
+
+## Non-goals (explicit)
+- Notes **editing** (the notes are read-only; edit is future).
+- An `item_id` link between notes entries and board items (deferred seam — Open Question 1); and any document-line enrichment from notes detail (D4-14 future seam).
+- Feeding notes buckets into `build_document` structure or pricing (document stays item-authoritative).
+- Per-trade bucket variations beyond the four; a fifth "People/Logistics/Materials" bucket (folded into Constraints per Isaac, v1).
+- The notes-screen **visual design / bucket section rendering / grouping chrome** (sac's follow-up PR).
+- A price book; a price-book-backed budget reconciliation; PDF export; vision.
+- A new SQLite migration; a `session_transcript(session_id)` getter (still deferred from Plan 13).
+
+## Open questions
+1. **`item_id` link (sac + dam).** v1 keeps notes entries free-text (no board-item foreign key) to keep the passes decoupled and R6-provable. Pulling the link forward would enable jump-to-photo from a Scope entry and document-line enrichment (D4-14) — worth it now, or hold for a later plan? — **recommend: hold.**
+2. **Narrative summary length in the library list (sac).** `session.summary` is now 2–4 sentences (was a one-liner). The history/library subtitle reads it directly — does sac want core to also store a short derived one-liner, or will the list truncate client-side? — **recommend: client-side truncate, no core change.**
+3. **Bucket taxonomy freeze (sac + dam).** The three entry buckets (`scope_of_work`/`constraints`/`conditions_and_issues`) + top-level Summary match Isaac's #199 contract exactly. Confirm before wiring sac's exhaustive Swift `switch`, since adding a fourth entry-bucket later is an additive-but-visible enum change.


### PR DESCRIPTION
## Thinking

**Depth-source argument (D1-14, option b): grow the summary pass, don't add a call or extend extraction.**
Three candidates were on the table: (a) bake bucket/detail into the live extraction agent — rejected, because that pass is latency-sensitive and its output IS the terse board; loading client/logistics/budget detail onto it either bloats the board or forces a live/finish split on a hot path, and it would muddy the R6 incentive the F0.5 grader pins. (c) a third dedicated notes LLM call after summarize — rejected on R9: it doubles the finish-time call count for content the summary pass could produce for free, since both passes read the identical transcript. (b) **adopted**: `pipeline::summarize` already legitimately reads the full assembled transcript and already returns an extra scalar (`spoken_total_cents`, Plan 13 D5a) — the precedent that a forced tool call can grow additively. Renaming `write_summary` → `write_notes` and extending its schema with a narrative `summary` + `notes[]` buckets means **one** call does double duty: net LLM calls are unchanged, and because the extraction agent pass is completely untouched, the board is byte-identical before/after — which is what makes the evals invariance (WE-B) a structural guarantee rather than a hope.

**The four-bucket contract (D2-14).** Isaac's #199 comment thread fixed the taxonomy: Summary (narrative, replaces the one-liner) is NOT a bucket — it lives on `session.summary`. The three entry buckets are `scope_of_work` / `constraints` / `conditions_and_issues`, each entry a `{bucket, label, detail}` triple. Core stores `bucket` as a wire string (tolerant of model drift); the FFI boundary (`convert::notes_entries`) maps string → the `NotesBucket` enum and **drops** any row whose string isn't one of the three known variants — never fabricated or coerced (R6), so Swift's exhaustive `switch` is provably safe. No `item_id` link in v1 (Open Question 1, dam ruled HOLD) — the notes pass reads only the transcript, never the extracted items, keeping the two passes fully decoupled with zero added tokens.

**R9 delta of the token bump (C2).** `summary_max_tokens` moves 512 → 1024 so a narrative summary plus up to 12 notes entries fit one response without truncation — an output-token budget increase on the *one* pass that already ran, not a new call. Roughly a third of a cent per finish at current pricing, in exchange for the whole comprehensive-notes payload. A truncated/malformed `notes` value degrades to `buckets: []` with the summary preserved (R7) — pinned by `summarize_degrades_a_malformed_notes_field_to_empty_buckets_not_an_error`.

**C1 (rename blast radius).** Growing the forced tool name from `write_summary` to `write_notes` meant retargeting the hardcoded string literal in all 8 places it appeared (`prompts.rs` + the 6 enumerated MockProvider-script files + `pipeline/mod.rs`'s own test helper + `ffi/src/session.rs`'s). `grep -rn '"write_summary"' crates/` now returns nothing — verified as an explicit gate, not inferred from green tests (a missed literal would silently degrade a session to `Failed`, not fail to compile).

**Tester-visible delta.** Behind sac's already-merged #199 notes screen, `finish()` now returns a richer `NotesPayload`: a 2–4 sentence narrative summary (was one line) plus `notes: [NotesEntry]` — the client/team coordination detail (budget, deadlines, gate codes, "darker mulch than last year") that the terse board never carried. The terse board (`items`) is byte-identical to Plan 13. Until sac's bucket-rendering follow-up lands, this data is payload-only — inert behind his existing kind-grouped rendering, exercised end-to-end in the demo build via a scripted sample.

## What lands
1. `crates/murmur-core/src/pipeline/notes.rs` — `NotesEntry` + tolerant `parse_notes_artifact`/`parse_notes_value`/`serialize_buckets` (Task 1).
2. `pipeline::summarize` grown into `write_notes`: one forced call now returns `(summary, spoken_total_cents, notes[], usage)`; R6 clause + ≤12-entry cap in the prompt; `summary_max_tokens` 512→1024 (Task 2).
3. `process()` persists non-empty buckets as a `kind="notes"` artifact before the finish swap, mirroring the existing `session_meta` write; R6-pinned zero-item-rows test (Task 3).
4. Evals invariance documented + gated: `cargo test -p evals` is byte-identical to pre-14 for every scenario — the grader never reads artifacts, only `summary_present` (Task 4).
5. `ffi`: `NotesBucket` enum + `NotesEntry`/`NotesPayload.notes` uniffi records; `convert::notes_entries` drops unknown buckets; `WalkSession::session_notes()` reads/tolerant-parses the notes artifact, threaded into `partial_notes`/`degraded_notes`/`finish()` per the D6-14 table (Task 5).
6. `apps/ios`: `NotesModel.notes: [NotesEntryFixture] = []` (additive default), `MurmurEngine` maps `payload.notes`, `DemoWalkEngine` ships a scripted WE-A-shaped sample. Split formatting helpers into `MurmurEngineFormatting.swift` to keep `MurmurEngine.swift` under the file-length lint. Layers cleanly on sac's #199 NotesView — bucket rendering is his follow-up (Task 6).
7. Regenerated `MurmurCoreFFI` Swift bindings (`ffi.swift`) — `check-bindings.sh` confirms no drift.

## Test plan
- [x] `nix develop -c cargo test --workspace` — exit 0 (21 test binaries, all green)
- [x] `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `nix develop -c cargo test -p evals` — exit 0, F0.5/precision pins byte-identical to pre-14
- [x] `grep -rn '"write_summary"' crates/` — zero hits (C1 gate)
- [x] iOS demo build (`xcodegen generate` + `xcodebuild … build`, outside nix) — BUILD SUCCEEDED
- [x] `./build-ffi.sh` regenerated + committed `ffi.swift`; `./check-bindings.sh` — exit 0, no drift
- [x] `./generate.sh` (real-core project) + real-core `xcodebuild … build` (outside nix) — **BUILD SUCCEEDED** (Task 7 mandatory gate — CI cannot build this)

Do not merge — dam will merge after CI + the real-core gate are both confirmed.