### PR TITLE
iOS: render Plan 14 comprehensive-notes buckets on the notes screen

### DIFF
--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -39,13 +39,19 @@ struct NotesView: View {
                         skeleton
                     } else {
                         summaryCard
-                        if isEmpty {
+                        // Plan 14: the comprehensive coordination buckets sit
+                        // ABOVE the terse tag-grouped board (additive — the board
+                        // still carries the priced line items).
+                        bucketSections
+                        if notes.items.isEmpty && notes.notes.isEmpty {
                             emptyState
                         } else {
-                            ForEach(grouped, id: \.0) { kind, items in
-                                SectionHead(left: sectionTitle(kind), right: "\(items.count)", heavyRule: false)
-                                    .padding(.top, 4)
-                                ForEach(items) { CapturedRow(item: $0) }
+                            if !notes.items.isEmpty {
+                                ForEach(grouped, id: \.0) { kind, items in
+                                    SectionHead(left: sectionTitle(kind), right: "\(items.count)", heavyRule: false)
+                                        .padding(.top, 4)
+                                    ForEach(items) { CapturedRow(item: $0) }
+                                }
                             }
                             transcriptRow
                         }
@@ -267,6 +273,61 @@ struct NotesView: View {
         .opacity(disabled ? 0.4 : 1)
     }
 
+    // MARK: Comprehensive notes — Plan 14 coordination buckets
+
+    // The rich client↔team detail behind the terse board: each entry is a
+    // label + the spoken context. Buckets render in a fixed scope→constraints→
+    // conditions order; empty ones are omitted. Rendered additively above the
+    // tag-grouped board (dam's plumbing note: the board stays the priced items).
+    private let bucketOrder: [NotesBucket] = [.scopeOfWork, .constraints, .conditionsAndIssues]
+
+    private func bucketTitle(_ b: NotesBucket) -> String {
+        switch b {
+        case .scopeOfWork:         return "SCOPE OF WORK"
+        case .constraints:         return "CONSTRAINTS"
+        case .conditionsAndIssues: return "CONDITIONS & ISSUES"
+        }
+    }
+
+    private var bucketed: [(NotesBucket, [NotesEntryFixture])] {
+        bucketOrder.compactMap { b in
+            let entries = notes.notes.filter { $0.bucket == b }
+            return entries.isEmpty ? nil : (b, entries)
+        }
+    }
+
+    // Empty `bucketed` emits nothing — no guard needed at the call site.
+    @ViewBuilder private var bucketSections: some View {
+        ForEach(bucketed, id: \.0) { bucket, entries in
+            SectionHead(left: bucketTitle(bucket), right: "\(entries.count)", heavyRule: false)
+                .padding(.top, 4)
+            ForEach(entries) { notesEntryRow($0) }
+        }
+    }
+
+    private func notesEntryRow(_ entry: NotesEntryFixture) -> some View {
+        HStack(alignment: .top, spacing: 9) {
+            Rectangle().fill(Theme.C.ink35).frame(width: 5, height: 5).padding(.top, 5)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(entry.label)
+                    .font(Theme.F.cond(13.5, .semibold))
+                    .foregroundStyle(Theme.C.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                if !entry.detail.isEmpty {
+                    Text(entry.detail)
+                        .font(Theme.F.cond(11.5, .medium))
+                        .foregroundStyle(Theme.C.ink60)
+                        .lineSpacing(1.5)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.vertical, 8)
+        .overlay(alignment: .bottom) { Theme.C.hairlineSoft.frame(height: 1) }
+    }
+
     // MARK: Grouping (trade-aware headers, attention-first)
 
     private let order: [TagKind] = [.red, .yellow, .plain, .green]
@@ -305,6 +366,14 @@ struct NotesView: View {
         lines.append("Walk notes — \(Date().formatted(.dateTime.month().day().year()))")
         lines.append("")
         if !notes.summary.isEmpty { lines.append(notes.summary); lines.append("") }
+        for (bucket, entries) in bucketed {
+            lines.append(bucketTitle(bucket))
+            for e in entries {
+                lines.append("  • \(e.label)")
+                if !e.detail.isEmpty { lines.append("      \(e.detail)") }
+            }
+            lines.append("")
+        }
         for (kind, items) in grouped {
             lines.append(sectionTitle(kind))
             for it in items {

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -27,7 +27,7 @@ struct NotesView: View {
             // stays a stable skeleton, so nothing shifts when the notes land
             // (dam's UX note: navigate once, fill in place).
             if model.notesLoading {
-                ProgressView().progressViewStyle(.linear).tint(Theme.C.orange).frame(height: 2)
+                ProgressView().progressViewStyle(.linear).tint(Theme.C.orangeDeep).frame(height: 2)
             } else {
                 Theme.C.paper.frame(height: 2)
             }
@@ -113,7 +113,7 @@ struct NotesView: View {
     private var summaryCard: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 0) {
-                Rectangle().fill(Theme.C.orange).frame(width: 3)
+                Rectangle().fill(Theme.C.orangeDeep).frame(width: 3)
                 VStack(alignment: .leading, spacing: 6) {
                     Text("SUMMARY")
                         .font(Theme.F.mono(8, .semibold)).tracking(2.0)


### PR DESCRIPTION
## Thinking

Plan 14 (#203) made the notes the real "meat" — a client↔team coordination artifact — by growing `NotesPayload` with the bucketed `notes` and wiring the app-side plumbing (`NotesModel.notes`), with the explicit hand-off *"// sac: unrendered until the bucket-section follow-up lands."* This is that follow-up: the rendering.

**Additive, not a replacement.** dam's plumbing note is clear that the terse tag-grouped board still carries the priced line items, and the buckets sit on top. Isaac confirmed the same layout choice: Summary → the three coordination buckets → the existing board → action row. So this adds the bucket sections between the summary card and the board without disturbing the working document pipeline (the board's amounts still feed `buildDocument(kind:)`). Keeps it a small, reversible change; we can evolve toward the fuller mockup later if we want the buckets to fully own the screen.

**Faithful to the model.** The three sections map 1:1 to the `NotesBucket` enum (`.scopeOfWork` / `.constraints` / `.conditionsAndIssues`), rendered in a fixed scope→constraints→conditions order with empty buckets omitted. Each entry is `label` (title) + `detail` (the spoken context) — the mockup's bullet + Barlow Semi-Condensed title + ink-60 sub-line treatment. The narrative `summary` stays the top card (it's `NotesPayload.summary`, not a bucket).

## What changed

`NotesView.swift` only (+74/−5):
- `bucketSections` / `bucketed` / `bucketTitle` — group `notes.notes` by bucket, attention-ordered, empty ones dropped.
- `notesEntryRow` — the label + detail row.
- Inserted `bucketSections` between the summary card and the tag-grouped board; the board now renders only when `items` is non-empty, and the empty-state shows only when both `items` and `notes` are empty.
- `exportNotes()` now includes the bucket entries in the plain-text copy.

No FFI/model changes — pure SwiftUI over the `NotesModel.notes` dam already plumbed.

## Testing

Built and ran the **real-core** app on the iPhone 17 simulator (demo path → `DemoWalkEngine.sampleNotes`). The three buckets render correctly above the board — SCOPE OF WORK / CONSTRAINTS / CONDITIONS & ISSUES, each with label + detail — under the Jefe amber theme. Device (real-core, codesigned) build verified separately.

Note for dam: the sim real-core path is green again end-to-end with the Plan 14 buckets. (Two local staleness gotchas I hit and fixed on my side, not in this diff: my `.xcodeproj` predated `MurmurEngineFormatting.swift` so it wasn't compiled — a `xcodegen --spec project-real.yml` regen fixed it; and my local xcframework was still #198 — a full `build-ffi.sh` refreshed it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
