### PR TITLE
release: fix TF walk failures — key/host mismatch (Anthropic key vs ppq.ai host)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,11 +259,14 @@ jobs:
             "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
             "CURRENT_PROJECT_VERSION=${{ github.run_number }}"
             "PPQ_API_KEY=$PPQ_API_KEY"
-            # A PPQ key against the default Anthropic host 401s silently and
-            # the app LOOKS like the demo engine (sac's #173 icon-tap bug,
-            # release-lane edition). Key = PPQ_API_KEY repo secret; the host
-            # is not secret-sensitive so it lives here in the clear.
-            "ANTHROPIC_BASE_URL=https://api.ppq.ai"
+            # NO ANTHROPIC_BASE_URL override: the key in the PPQ_API_KEY secret
+            # is a direct Anthropic key (sk-ant-…), verified live against
+            # api.anthropic.com and REJECTED (401) by api.ppq.ai. Builds #24–#32
+            # shipped with the ppq.ai override and every walk degraded to
+            # "saved offline" — the key/host pair must match; empty here means
+            # the provider default (api.anthropic.com), which this key wants.
+            # If the account ever moves to a PPQ-issued key, restore the
+            # override AND rotate the secret together.
           )
           if [ -n "$MARKETING_VERSION_OVERRIDE" ]; then
             BUILD_SETTINGS+=("MARKETING_VERSION=$MARKETING_VERSION_OVERRIDE")


### PR DESCRIPTION
## Thinking

Field bug (dam's screenshot, TF build ~#32): every walk — demo included — lands on 'Nothing was captured / SAVED OFFLINE' with disabled buttons. Diagnosis (debug lane, full evidence on file): the shipped plist expansion is CORRECT (key present, base URL present, compliance key present) — but the key VALUE in the PPQ_API_KEY secret is a genuine Anthropic-direct key (sk-ant-… prefix), verified HTTP 200 against api.anthropic.com and 401 'API key not found' against api.ppq.ai. My #193 wired the ppq.ai override assuming a PPQ-issued key; the assumption was inverted, so every LLM call from every TF build 401'd → process() Err → the offline degrade path (working exactly as designed — the only honest UI in the chain).

Fix: remove the base-URL override; the provider defaults to api.anthropic.com, which this key wants. Comment rewritten to carry the key/host-pair invariant and the restore path if the account ever moves to PPQ. Local walks were never affected (they always hit Anthropic directly). Merging publishes build #33 — the first TF build where real walks actually work; dam's saved walk retries via the Failed→Processed path.

actionlint exit 0. One line of behavior, ~9 lines of comment.