### PR TITLE
Retry Failed sessions on app open — make the offline banner's promise true

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -593,6 +593,25 @@ public protocol MurmurEngineProtocol : AnyObject {
     func removeVocabularyTerm(term: String) throws  -> [String]
     
     /**
+     * Retries every `Failed` session once (oldest-first, capped — see
+     * `SessionProcessor::retry_failed_sessions`'s doc comment for the
+     * no-loop / cap-ordering rationale). Returns the count that reached
+     * `Processed` — thin on purpose; the host re-reads its own session
+     * list/history view rather than this call threading payloads back.
+     *
+     * Lock hygiene: `SessionProcessor::retry_failed_sessions` takes the
+     * store lock only for the short synchronous list-query inside its own
+     * loop body, never across a `process().await` — same discipline as
+     * `build_document`, which never holds the engine's `std::sync::Mutex`
+     * across an `.await` either.
+     *
+     * A still-Failed session (still offline, LLM still down) is not an
+     * error here — it's simply not counted in the returned total; only a
+     * poisoned lock or a store fault surfaces as `EngineError::Session`.
+     */
+    func retryFailedSessions() async throws  -> UInt32
+    
+    /**
      * App-open zombie sweep (carry-note, Plan 04): a `Recording` session left
      * behind by a crash or force-quit mid-walk can never resume — there is no
      * live `WalkSession`/STT pump for it after relaunch, `MurmurEngine::new`
@@ -802,6 +821,40 @@ open func removeVocabularyTerm(term: String)throws  -> [String] {
         FfiConverterString.lower(term),$0
     )
 })
+}
+    
+    /**
+     * Retries every `Failed` session once (oldest-first, capped — see
+     * `SessionProcessor::retry_failed_sessions`'s doc comment for the
+     * no-loop / cap-ordering rationale). Returns the count that reached
+     * `Processed` — thin on purpose; the host re-reads its own session
+     * list/history view rather than this call threading payloads back.
+     *
+     * Lock hygiene: `SessionProcessor::retry_failed_sessions` takes the
+     * store lock only for the short synchronous list-query inside its own
+     * loop body, never across a `process().await` — same discipline as
+     * `build_document`, which never holds the engine's `std::sync::Mutex`
+     * across an `.await` either.
+     *
+     * A still-Failed session (still offline, LLM still down) is not an
+     * error here — it's simply not counted in the returned total; only a
+     * poisoned lock or a store fault surfaces as `EngineError::Session`.
+     */
+open func retryFailedSessions()async throws  -> UInt32 {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_ffi_fn_method_murmurengine_retry_failed_sessions(
+                    self.uniffiClonePointer()
+                    
+                )
+            },
+            pollFunc: ffi_ffi_rust_future_poll_u32,
+            completeFunc: ffi_ffi_rust_future_complete_u32,
+            freeFunc: ffi_ffi_rust_future_free_u32,
+            liftFunc: FfiConverterUInt32.lift,
+            errorHandler: FfiConverterTypeEngineError.lift
+        )
 }
     
     /**
@@ -2294,8 +2347,10 @@ public enum EngineError {
     
     /**
      * A session-lifecycle operation outside `begin_walk`/`WalkSession` failed
-     * (currently: the app-open zombie sweep). A poisoned store lock or a
-     * store error — recoverable, surface don't crash.
+     * (the app-open zombie sweep, or `retry_failed_sessions`). A poisoned
+     * store lock or a store error — recoverable, surface don't crash. A
+     * still-Failed session after a retry attempt is NOT this variant — it's
+     * simply not counted in `retry_failed_sessions`'s return value.
      */
     case Session(message: String)
     
@@ -2869,6 +2924,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_remove_vocabulary_term() != 40682) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_retry_failed_sessions() != 46346) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_sweep_zombie_sessions() != 29924) {

--- a/apps/ios/Sources/App/AppModel+Photos.swift
+++ b/apps/ios/Sources/App/AppModel+Photos.swift
@@ -143,7 +143,14 @@ extension AppModel {
     /// sac: this is a good hook for a badge/history refresh once the count
     /// comes back, if a recovered walk should surface anywhere in the UI.
     private func retryFailedSessionsInBackground() {
+        // Review #206 should-fix: `.task` can re-fire on scene re-appearance;
+        // overlapping runs would double-spend LLM calls on the same Failed
+        // sessions (second attempt loses at the state machine, but the tokens
+        // are already burnt). One in-flight retry per app process.
+        guard !isRetryingFailedSessions else { return }
+        isRetryingFailedSessions = true
         Task {
+            defer { isRetryingFailedSessions = false }
             let recovered = (try? await engine.retryFailedSessions()) ?? 0
             if recovered > 0 {
                 photoLogger.notice("retried and recovered \(recovered, privacy: .public) failed session(s)")

--- a/apps/ios/Sources/App/AppModel+Photos.swift
+++ b/apps/ios/Sources/App/AppModel+Photos.swift
@@ -112,6 +112,43 @@ extension AppModel {
     func runAppOpenSweeps() {
         sweepPhotoBytes()
         sweepZombieSessions()
+        retryFailedSessionsInBackground()
+    }
+
+    /// The offline banner ("SAVED OFFLINE — DOCUMENTS UNLOCK WHEN YOU
+    /// RECONNECT") makes a promise; this is what keeps it. Fired as a
+    /// separate, NOT-awaited `Task` after the two synchronous sweeps above
+    /// return — it must never delay `runAppOpenSweeps()` itself (invariant 1
+    /// on that function: fully synchronous, no suspension point before a
+    /// walk can start) and never sit in front of the start-walk path, since
+    /// `retryFailedSessions()` is slow (real LLM calls, one per Failed
+    /// session).
+    ///
+    /// Not `Task.detached`: `WalkEngine` is `@MainActor`-isolated, so a
+    /// literal detached task would just hop back to the main actor for the
+    /// `await engine.retryFailedSessions()` call anyway — this follows the
+    /// same plain, unstructured `Task { }` precedent already used for other
+    /// fire-and-forget engine calls in this file (`capturePhoto`'s attach
+    /// step). "Separate" is the property that matters: this task is never
+    /// awaited by `runAppOpenSweeps()`, so it runs concurrently with
+    /// whatever the user does next.
+    ///
+    /// Safe even if a retry completes mid-walk: the state machine guarantees
+    /// a live walk's session is `Recording`, and `retry_failed_sessions`
+    /// only ever queries and processes `Failed` sessions — it cannot touch
+    /// the session the user is currently walking. Picks up zombies from
+    /// `sweepZombieSessions()` above for free (crash-orphaned `Recording`
+    /// rows just became `Failed`).
+    ///
+    /// sac: this is a good hook for a badge/history refresh once the count
+    /// comes back, if a recovered walk should surface anywhere in the UI.
+    private func retryFailedSessionsInBackground() {
+        Task {
+            let recovered = (try? await engine.retryFailedSessions()) ?? 0
+            if recovered > 0 {
+                photoLogger.notice("retried and recovered \(recovered, privacy: .public) failed session(s)")
+            }
+        }
     }
 
     /// Reconciling sweep (Plan 11 D4): delete every file in <Documents>/photos/

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -81,6 +81,14 @@ final class AppModel {
     // extension in a different file — Swift's `private` is file-scoped.)
     var photos: [PhotoModel] = []
     var photoError: String?
+    /// In-flight guard for the app-open Failed-session retry (review #206
+    /// should-fix): SwiftUI can re-run the launching `.task` on scene
+    /// re-appearance, and two overlapping retry runs would each drive
+    /// process() on the same Failed session — the second loses harmlessly at
+    /// the state machine but burns a real duplicate LLM call (R9). One retry
+    /// run per app process at a time. Not `private`: mutated from
+    /// AppModel+Photos.swift (same-module extension, different file).
+    var isRetryingFailedSessions = false
     /// Chains capture calls (PR #176 should-fix, AppModel+Photos.swift) so
     /// rapid taps run their off-main bytes-write + attach sequentially, in
     /// tap order, rather than interleaving. Not `private`: mutated from

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -135,6 +135,11 @@ final class DemoWalkEngine: WalkEngine {
         0
     }
 
+    // Nothing ever reaches Failed in the scripted demo — nothing to retry.
+    func retryFailedSessions() -> UInt32 {
+        0
+    }
+
     // Plan 13: finish() = scripted NOTES (items + a canned summary line), no
     // document. `buildDocument(kind:)` below returns the canned DocumentModel
     // this used to return directly — the demo mirrors the real engine's

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -276,6 +276,10 @@ final class MurmurEngine: WalkEngine {
         try engine.sweepZombieSessions()
     }
 
+    func retryFailedSessions() async throws -> UInt32 {
+        try await engine.retryFailedSessions()
+    }
+
     private nonisolated static func photo(_ ref: MurmurCoreFFI.PhotoRef) -> PhotoModel {
         PhotoModel(
             id: ref.id,

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -200,6 +200,19 @@ protocol WalkEngine: AnyObject {
     /// scripted demo).
     func sweepZombieSessions() throws -> UInt64
 
+    /// Retries every `Failed` session (offline drop, LLM error, or a
+    /// zombie-swept crash-orphan — indistinguishable once they're `Failed`)
+    /// once each, oldest first. This is what makes the offline banner
+    /// ("SAVED OFFLINE — DOCUMENTS UNLOCK WHEN YOU RECONNECT") true: without
+    /// it, nothing ever revisited a `Failed` session. `async` because it
+    /// makes real LLM calls — callers must NOT await it inline on the
+    /// app-open path (see `AppModel+Photos.runAppOpenSweeps`, which fires
+    /// this from a separate detached `Task` AFTER the synchronous sweeps).
+    /// Returns the count that reached `Processed`; a still-Failed session
+    /// (still offline) is not an error, just uncounted. `DemoWalkEngine`
+    /// no-ops (nothing is ever `Failed` in the scripted demo).
+    func retryFailedSessions() async throws -> UInt32
+
     /// The active walk's session id, so the capture UI can call
     /// `attachPhoto(sessionId:...)` mid-walk (Plan 11 D7). `nil` when there is
     /// no live session (not walking, or the real engine has none yet).

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -37,8 +37,10 @@ pub enum EngineError {
     #[error("photo error: {0}")]
     Photo(String),
     /// A session-lifecycle operation outside `begin_walk`/`WalkSession` failed
-    /// (currently: the app-open zombie sweep). A poisoned store lock or a
-    /// store error — recoverable, surface don't crash.
+    /// (the app-open zombie sweep, or `retry_failed_sessions`). A poisoned
+    /// store lock or a store error — recoverable, surface don't crash. A
+    /// still-Failed session after a retry attempt is NOT this variant — it's
+    /// simply not counted in `retry_failed_sessions`'s return value.
     #[error("session error: {0}")]
     Session(String),
     /// An on-demand `build_document(kind)` call failed (Plan 13 D1/D8): a

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -13,6 +13,7 @@ pub mod events;
 pub mod notes;
 pub mod photos;
 pub mod session;
+pub mod session_retry;
 pub mod vocabulary;
 
 pub use convert::{document_payload, partial_document_from_items};

--- a/crates/ffi/src/session_retry.rs
+++ b/crates/ffi/src/session_retry.rs
@@ -1,0 +1,194 @@
+//! `MurmurEngine::retry_failed_sessions` — the offline banner ("SAVED
+//! OFFLINE — DOCUMENTS UNLOCK WHEN YOU RECONNECT") makes a promise that,
+//! until this file, no code path kept: nothing ever re-drove a `Failed`
+//! session back through the pipeline. `process_pending` only drains
+//! `AwaitingProcessing` (its own no-retry pin stays exactly as-is); this is
+//! the separate, explicit retry call the Swift app-open hook invokes.
+//!
+//! Engine-keyed (not `WalkSession`-scoped), same precedent as
+//! `build_document`: a `Failed` session's `WalkSession` handle is long gone
+//! by the time the user reopens the app.
+
+use murmur_core::SessionProcessor;
+
+use crate::engine::{EngineError, MurmurEngine};
+
+#[uniffi::export(async_runtime = "tokio")]
+impl MurmurEngine {
+    /// Retries every `Failed` session once (oldest-first, capped — see
+    /// `SessionProcessor::retry_failed_sessions`'s doc comment for the
+    /// no-loop / cap-ordering rationale). Returns the count that reached
+    /// `Processed` — thin on purpose; the host re-reads its own session
+    /// list/history view rather than this call threading payloads back.
+    ///
+    /// Lock hygiene: `SessionProcessor::retry_failed_sessions` takes the
+    /// store lock only for the short synchronous list-query inside its own
+    /// loop body, never across a `process().await` — same discipline as
+    /// `build_document`, which never holds the engine's `std::sync::Mutex`
+    /// across an `.await` either.
+    ///
+    /// A still-Failed session (still offline, LLM still down) is not an
+    /// error here — it's simply not counted in the returned total; only a
+    /// poisoned lock or a store fault surfaces as `EngineError::Session`.
+    pub async fn retry_failed_sessions(&self) -> Result<u32, EngineError> {
+        let processor = SessionProcessor::new(
+            self.providers.processing.clone(),
+            self.store.clone(),
+            self.memory.clone(),
+            self.memory_store.clone(),
+        );
+        let results = processor
+            .retry_failed_sessions()
+            .await
+            .map_err(|e| EngineError::Session(e.to_string()))?;
+        Ok(results.iter().filter(|(_, r)| r.is_ok()).count() as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use harness::{
+        CompletionResponse, ContentBlock, HarnessError, Memory, MemoryStore, MockProvider,
+        StopReason, Usage,
+    };
+    use murmur_core::{SessionStatus, Store};
+
+    use crate::engine::Providers;
+
+    use super::*;
+
+    struct NullMemoryStore;
+    impl MemoryStore for NullMemoryStore {
+        fn load(&self) -> Result<Memory, HarnessError> {
+            Ok(Memory::default())
+        }
+        fn save(&self, _m: &Memory) -> Result<(), HarnessError> {
+            Ok(())
+        }
+    }
+
+    fn end_turn(text: &str) -> CompletionResponse {
+        CompletionResponse {
+            content: vec![ContentBlock::Text { text: text.into() }],
+            stop_reason: StopReason::EndTurn,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+        }
+    }
+
+    fn summary_response(text: &str) -> CompletionResponse {
+        CompletionResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tu".into(),
+                name: "write_notes".into(),
+                input: serde_json::json!({"summary": text}),
+            }],
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+        }
+    }
+
+    fn engine_with(
+        store: Store,
+        processing_responses: Vec<CompletionResponse>,
+    ) -> Arc<MurmurEngine> {
+        MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(processing_responses)),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn retry_failed_sessions_recovers_and_counts_a_failed_session() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        store.append_transcript(&session.id, "we need lumber").unwrap();
+        store.end_and_record_session(&session.id).unwrap();
+        store.mark_session_failed(&session.id).unwrap();
+
+        let engine =
+            engine_with(store, vec![end_turn("nothing to extract"), summary_response("recovered")]);
+
+        let recovered = engine.retry_failed_sessions().await.unwrap();
+        assert_eq!(recovered, 1);
+
+        let store = engine.store.lock().unwrap();
+        assert_eq!(store.get_session(&session.id).unwrap().status, SessionStatus::Processed);
+    }
+
+    #[tokio::test]
+    async fn retry_failed_sessions_zero_when_still_failing() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        store.append_transcript(&session.id, "we need lumber").unwrap();
+        store.end_and_record_session(&session.id).unwrap();
+        store.mark_session_failed(&session.id).unwrap();
+
+        let engine = engine_with(
+            store,
+            vec![end_turn("nothing to extract"), end_turn("still no summary tool")],
+        );
+
+        let recovered = engine.retry_failed_sessions().await.unwrap();
+        assert_eq!(recovered, 0, "a still-failing retry is not an EngineError, just not counted");
+
+        let store = engine.store.lock().unwrap();
+        assert_eq!(store.get_session(&session.id).unwrap().status, SessionStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn retry_failed_sessions_zero_with_nothing_failed() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let engine = engine_with(store, vec![]);
+        assert_eq!(engine.retry_failed_sessions().await.unwrap(), 0);
+    }
+
+    /// Zombie-recovery-for-free: a crash-orphaned `Recording` session, once
+    /// swept by `sweep_zombie_sessions`, is a `Failed` session like any
+    /// other — a retry picks it up in the same app-open.
+    #[tokio::test]
+    async fn retry_failed_sessions_recovers_a_zombie_swept_session() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        store.append_transcript(&session.id, "we need lumber").unwrap();
+        // still Recording — simulates a crash mid-walk
+
+        let engine =
+            engine_with(store, vec![end_turn("nothing to extract"), summary_response("recovered")]);
+        let swept = engine.sweep_zombie_sessions().unwrap();
+        assert_eq!(swept, 1);
+
+        let recovered = engine.retry_failed_sessions().await.unwrap();
+        assert_eq!(recovered, 1);
+
+        let store = engine.store.lock().unwrap();
+        assert_eq!(store.get_session(&session.id).unwrap().status, SessionStatus::Processed);
+    }
+
+    /// The empty-transcript zombie case (a crash before any speech was
+    /// captured) must hit the existing empty-session contract, not panic.
+    #[tokio::test]
+    async fn retry_failed_sessions_empty_zombie_session_never_panics() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap(); // no transcript
+
+        let engine = engine_with(store, vec![]);
+        let swept = engine.sweep_zombie_sessions().unwrap();
+        assert_eq!(swept, 1);
+
+        let recovered = engine.retry_failed_sessions().await.unwrap();
+        assert_eq!(recovered, 1);
+
+        let store = engine.store.lock().unwrap();
+        let s = store.get_session(&session.id).unwrap();
+        assert_eq!(s.status, SessionStatus::Processed);
+        assert_eq!(s.summary.as_deref(), Some("(empty session)"));
+    }
+}

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -310,6 +310,44 @@ impl SessionProcessor {
         }
         Ok(results)
     }
+
+    /// The offline-banner promise, made true: retries every `Failed` session
+    /// (offline drop, LLM error, or a `sweep_zombie_sessions` crash-orphan —
+    /// they land in the same bucket and are indistinguishable here) once per
+    /// call. Separate from `process_pending` on purpose — that drain's
+    /// no-retry pin (`process_pending_does_not_retry_failed_sessions`) stays
+    /// exactly as written; this is a distinct, explicit call site (the app's
+    /// app-open hook), not a weakening of that guarantee.
+    ///
+    /// One attempt per session per call — a session that fails again STAYS
+    /// Failed for the next app-open to try, never looped on and never
+    /// silently dropped (`process()`'s own Failed-marking + cost logging,
+    /// R9, is unchanged).
+    ///
+    /// Capped at `MAX_RETRIES_PER_CALL`, oldest-first: an app-open is a
+    /// latency-sensitive moment (this must not turn into a dozen serial LLM
+    /// calls blocking the UI), and R9 means a huge backlog isn't retried for
+    /// free — the longest-waiting walk gets first crack, the rest wait for a
+    /// future app-open.
+    pub async fn retry_failed_sessions(
+        &self,
+    ) -> Result<Vec<(String, Result<ProcessOutcome, CoreError>)>, CoreError> {
+        const MAX_RETRIES_PER_CALL: usize = 5;
+
+        // `list_session_summaries_by_status` is newest-first (started_at DESC);
+        // reverse to oldest-first before capping so the cap drops the NEWEST
+        // stragglers, not the ones that have been waiting longest.
+        let mut failed = self.locked()?.list_session_summaries_by_status(SessionStatus::Failed)?;
+        failed.reverse();
+        failed.truncate(MAX_RETRIES_PER_CALL);
+
+        let mut results = Vec::with_capacity(failed.len());
+        for summary in failed {
+            let outcome = self.process(&summary.id).await;
+            results.push((summary.id, outcome));
+        }
+        Ok(results)
+    }
 }
 
 #[cfg(test)]
@@ -635,6 +673,189 @@ mod tests {
             results2.is_empty(),
             "failed session must not be re-pulled by a second process_pending call"
         );
+    }
+
+    /// The offline-banner promise: a `Failed` session (offline / LLM error)
+    /// is picked back up and can reach `Processed` — without `process_pending`
+    /// having to weaken its own no-retry pin (that test above stays as-is).
+    #[tokio::test]
+    async fn retry_failed_sessions_recovers_a_failed_session() {
+        let (processor, store, sid) = processor_with(vec![
+            end_turn("nothing to extract"),
+            end_turn("no summary tool"), // summary call returns no tool → Provider error
+        ]);
+        let results = processor.process_pending().await.unwrap();
+        assert!(results[0].1.is_err());
+        assert_eq!(
+            store.lock().unwrap().get_session(&sid).unwrap().status,
+            SessionStatus::Failed
+        );
+
+        // Reconnect: this time the LLM cooperates.
+        let retry_processor = SessionProcessor::new(
+            Arc::new(MockProvider::new(vec![
+                end_turn("nothing to extract"),
+                summary_response("recovered on retry"),
+            ])),
+            store.clone(),
+            Arc::new(Mutex::new(Memory::default())),
+            Arc::new(NullMemoryStore),
+        );
+        let retried = retry_processor.retry_failed_sessions().await.unwrap();
+        assert_eq!(retried.len(), 1);
+        assert_eq!(retried[0].0, sid);
+        assert!(retried[0].1.is_ok());
+        assert_eq!(
+            store.lock().unwrap().get_session(&sid).unwrap().status,
+            SessionStatus::Processed
+        );
+
+        // Nothing left in Failed → a second call is a no-op.
+        let again = retry_processor.retry_failed_sessions().await.unwrap();
+        assert!(again.is_empty());
+    }
+
+    /// A still-offline retry makes exactly ONE attempt per app-open — it does
+    /// not loop, and the session stays Failed (not silently dropped) for the
+    /// next app-open to try again.
+    #[tokio::test]
+    async fn retry_failed_sessions_leaves_a_still_failing_session_failed() {
+        let (processor, store, sid) = processor_with(vec![
+            end_turn("nothing to extract"),
+            end_turn("no summary tool"),
+        ]);
+        processor.process_pending().await.unwrap();
+        assert_eq!(
+            store.lock().unwrap().get_session(&sid).unwrap().status,
+            SessionStatus::Failed
+        );
+
+        let retry_processor = SessionProcessor::new(
+            Arc::new(MockProvider::new(vec![
+                end_turn("nothing to extract"),
+                end_turn("still no summary tool"),
+            ])),
+            store.clone(),
+            Arc::new(Mutex::new(Memory::default())),
+            Arc::new(NullMemoryStore),
+        );
+        let results = retry_processor.retry_failed_sessions().await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.is_err());
+        assert_eq!(
+            store.lock().unwrap().get_session(&sid).unwrap().status,
+            SessionStatus::Failed,
+            "a failed retry leaves the session Failed, not lost"
+        );
+    }
+
+    /// App-open latency + R9 (cost is measured, not free): a reconnect
+    /// backlog is capped per call, oldest-first — the longest-waiting walk
+    /// gets first crack, and a huge backlog can't turn one app-open into a
+    /// dozen LLM calls.
+    #[tokio::test]
+    async fn retry_failed_sessions_caps_at_five_oldest_first() {
+        let counter = Arc::new(std::sync::atomic::AtomicU64::new(1000));
+        let clock_counter = counter.clone();
+        let store = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(move || {
+            clock_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        }));
+        let mut ids = Vec::new();
+        for _ in 0..6 {
+            let session = store.start_session(None).unwrap();
+            store.append_transcript(&session.id, "we need lumber").unwrap();
+            store.end_and_record_session(&session.id).unwrap();
+            store.mark_session_failed(&session.id).unwrap();
+            ids.push(session.id);
+        }
+        let store = Arc::new(Mutex::new(store));
+
+        let mut responses = Vec::new();
+        for _ in 0..5 {
+            responses.push(end_turn("nothing to extract"));
+            responses.push(summary_response("recovered"));
+        }
+        let processor = SessionProcessor::new(
+            Arc::new(MockProvider::new(responses)),
+            store.clone(),
+            Arc::new(Mutex::new(Memory::default())),
+            Arc::new(NullMemoryStore),
+        );
+        let results = processor.retry_failed_sessions().await.unwrap();
+        assert_eq!(results.len(), 5, "capped at 5 per call");
+        let retried_ids: Vec<_> = results.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(retried_ids, ids[0..5], "oldest five retried, oldest first");
+        assert!(results.iter().all(|(_, r)| r.is_ok()));
+
+        let locked = store.lock().unwrap();
+        for id in &ids[0..5] {
+            assert_eq!(locked.get_session(id).unwrap().status, SessionStatus::Processed);
+        }
+        assert_eq!(
+            locked.get_session(&ids[5]).unwrap().status,
+            SessionStatus::Failed,
+            "the newest session is left for a future app-open, untouched by this call's cap"
+        );
+    }
+
+    /// Crash-recovery for free: `sweep_zombie_sessions` marks a crash-orphaned
+    /// `Recording` session `Failed`; a retry run afterward (same app-open)
+    /// picks it up like any other Failed session.
+    #[tokio::test]
+    async fn retry_failed_sessions_recovers_a_zombie_swept_session() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        store.append_transcript(&session.id, "we need lumber").unwrap();
+        // No end_and_record_session: this session is still Recording, i.e. a
+        // crash left the app mid-walk.
+        let swept = store.sweep_zombie_sessions().unwrap();
+        assert_eq!(swept, 1);
+        assert_eq!(
+            store.get_session(&session.id).unwrap().status,
+            SessionStatus::Failed
+        );
+
+        let store = Arc::new(Mutex::new(store));
+        let processor = SessionProcessor::new(
+            Arc::new(MockProvider::new(vec![
+                end_turn("nothing to extract"),
+                summary_response("recovered from a crash"),
+            ])),
+            store.clone(),
+            Arc::new(Mutex::new(Memory::default())),
+            Arc::new(NullMemoryStore),
+        );
+        let results = processor.retry_failed_sessions().await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.is_ok());
+        assert_eq!(
+            store.lock().unwrap().get_session(&session.id).unwrap().status,
+            SessionStatus::Processed
+        );
+    }
+
+    /// The empty-session contract holds for a zombie-swept session too — an
+    /// interrupted walk with no captured transcript never panics or reaches
+    /// the LLM; it resolves to Processed with the placeholder summary.
+    #[tokio::test]
+    async fn retry_failed_sessions_empty_zombie_session_never_panics() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let _session = store.start_session(None).unwrap(); // no transcript appended
+        let swept = store.sweep_zombie_sessions().unwrap();
+        assert_eq!(swept, 1);
+
+        let store = Arc::new(Mutex::new(store));
+        let processor = SessionProcessor::new(
+            Arc::new(MockProvider::new(vec![])),
+            store.clone(),
+            Arc::new(Mutex::new(Memory::default())),
+            Arc::new(NullMemoryStore),
+        );
+        let results = processor.retry_failed_sessions().await.unwrap();
+        assert_eq!(results.len(), 1);
+        let outcome = results[0].1.as_ref().unwrap();
+        assert_eq!(outcome.session.status, SessionStatus::Processed);
+        assert_eq!(outcome.session.summary.as_deref(), Some("(empty session)"));
     }
 
     /// Empty (or whitespace-only) transcripts never reach the LLM — the real


### PR DESCRIPTION
## Thinking

**The diagnosis.** The offline banner tells the user: "SAVED OFFLINE —
DOCUMENTS UNLOCK WHEN YOU RECONNECT." That is a promise about a future
event (reconnecting) triggering a retry. No code path ever kept it.
`process_pending()` only drains `AwaitingProcessing` — a session that
reaches `Failed` (offline drop mid-`process()`, or an LLM error) had
`Failed → Processed` as a *legal* store transition (`store/sessions.rs:185-188`)
but nothing ever called `process()` on it again. The FFI exposed no retry
entry point, and Swift's app-open hook only ran `sweepZombieSessions()`.
A walk could sit in `Failed` forever, with a banner lying to the user about
what "reconnecting" would do.

**No-loop semantics, and why `process_pending` is untouched.**
`process_pending_does_not_retry_failed_sessions` pins, deliberately, that
the reconnect drain never re-pulls `Failed` rows — that test is exactly
right and stays exactly as written. The fix is a *separate*, explicit call,
`SessionProcessor::retry_failed_sessions()`, invoked from a distinct call
site (app-open). It attempts each `Failed` session exactly once per call —
a session that fails again simply stays `Failed` for the next app-open to
try. No retry loop, no silent drop, no duplicate work: `process()`'s own
authoritative-output sweep (`clear_authoritative_outputs`) already makes a
repeated `Failed → Failed` cycle non-duplicating (pinned by
`repeated_failed_retries_do_not_accumulate_authoritative_dupes`).

**The cap, and R9.** App-open is latency-sensitive — this must not turn
into a dozen serial LLM calls blocking the UI, and R9 (cost is measured
from day one) means a large backlog shouldn't get retried for free just
because the user happened to open the app. `retry_failed_sessions` caps at
5 per call, oldest-first (the list is naturally newest-first from
`list_session_summaries_by_status`; it's reversed then truncated) — the
longest-waiting walk gets first crack, the newest stragglers wait for a
future app-open. Pinned by
`retry_failed_sessions_caps_at_five_oldest_first`, which hand-computes the
ordering with a deterministic injected clock (`Store::with_clock`) rather
than relying on wall-clock ordering.

**The sync-sweep invariant, preserved.** `runAppOpenSweeps()` carries a
hard invariant: it must be fully synchronous with no suspension point
before any start-walk path, because a resumed sweep after a walk started
would `Fail` the *live* session. `retryFailedSessions()` is `async` and
slow (real LLM calls) by nature, so it cannot live inside that function.
It's fired as a separate, not-awaited `Task` immediately after the two
synchronous sweeps return — `runAppOpenSweeps()` itself still returns with
zero `await`s. It's safe even if a retry completes mid-walk: the state
machine guarantees a live walk's session is `Recording`, and
`retry_failed_sessions` only ever queries/processes `Failed` sessions — it
is structurally incapable of touching the session the user is currently
walking.

**The zombie-recovery freebie.** `sweepZombieSessions()` already marks a
crash-orphaned `Recording` session `Failed` at app open. Because the retry
now runs right after the sweeps (same app-open), a session that survives a
force-quit gets swept to `Failed` and then immediately retried in the same
open — crash recovery falls out of the ordering for free, no separate code
path needed. Pinned at both layers
(`retry_failed_sessions_recovers_a_zombie_swept_session` in core and ffi),
including the empty-transcript zombie case hitting the existing
"`(empty session)`" placeholder contract rather than reaching the LLM or
panicking.

## What changed

- **Core** (`crates/murmur-core/src/pipeline/mod.rs`): new
  `SessionProcessor::retry_failed_sessions()` — pulls `Failed` sessions
  oldest-first, capped at 5, attempts `process()` once each.
  `process_pending`'s no-retry pin is untouched.
- **FFI** (`crates/ffi/src/session_retry.rs`, new file): async
  `MurmurEngine::retry_failed_sessions() -> u32` (uniffi `tokio` runtime,
  same shape as `build_document`). Returns the recovered count; a
  still-Failed session is not an error, just uncounted. Regenerated Swift
  bindings (`check-bindings.sh` green).
- **iOS**: `WalkEngine.retryFailedSessions()` added to the protocol; real
  core forwards to FFI, demo no-ops (nothing is ever `Failed` in the
  scripted demo). `AppModel+Photos.runAppOpenSweeps()` fires it as a
  separate `Task` after the two synchronous sweeps.

## Test plan

- [x] `cargo test --workspace` — all green (6 new core tests, 5 new ffi
      tests: recovery, still-failing stays Failed, cap+ordering, zombie
      recovery, empty-zombie no-panic)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Demo `xcodegen generate` + `xcodebuild` (outside nix) — BUILD
      SUCCEEDED
- [x] `./build-ffi.sh` regenerated + committed bindings; `./check-bindings.sh`
      — exit 0
- [x] Real-core `./generate.sh` + `xcodebuild` (outside nix) — BUILD
      SUCCEEDED