### PR TITLE
fix(ios): review screen had no way back to notes — add the back arrow

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -427,6 +427,10 @@ final class AppModel {
     /// when idle. `isBuildingDocument` stays as the any-build flag.
     var buildingKind: String?
 
+    /// The kind whose document is on the review screen — labels the review
+    /// header ("ESTIMATE" / "INVOICE" …) so the back arrow reads clearly.
+    var reviewKind: String?
+
     /// Build the finished document for an explicit `kind` (Plan 13 Stage-1 FFI
     /// `build_document`) and route to the existing ReviewView. Engine-keyed
     /// via `currentSessionId` (snapshotted at walk start, kept through review —
@@ -443,8 +447,13 @@ final class AppModel {
             do {
                 let doc = try await engine.buildDocument(sessionId: sessionId, kind: kind)
                 self.document = doc
+                self.reviewKind = kind
                 self.phase = .review
-                self.path = [.review]
+                // Push review ONTO the notes screen (not replace) so it has a
+                // real back to notes — the operator can pick a different document
+                // or re-read. Was `[.review]`, which dropped notes and left
+                // Send/Discard as the only exits (the reported dead-end).
+                self.path = [.notes, .review]
             } catch {
                 Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "document")
                     .error("buildDocument(\(kind, privacy: .public)) failed: \(error, privacy: .public)")
@@ -454,6 +463,16 @@ final class AppModel {
     }
 
     func buildPrimaryDocument() { buildDocument(kind: DocKinds.primaryKind(for: trade.key)) }
+
+    /// Review → back to notes (the review screen's back arrow). Keeps the
+    /// session and the built notes intact so the operator can build a different
+    /// document or re-read; the last document stays in memory until the next
+    /// build overwrites it. Pops just the review frame (board → notes).
+    func backToNotes() {
+        documentBuildError = nil
+        phase = .notes
+        path = [.notes]
+    }
 
     // MARK: Vocabulary (Plan 10) — the write half of the vocabulary → STT
     // biasing loop. Defensive: a thrown FFI error becomes a logged breadcrumb +

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -12,8 +12,34 @@ struct ReviewView: View {
     // wires PhotosPicker → bytes → engine.attachPhoto.
     @State private var photoPickerItem: PhotosPickerItem?
 
+    // Back to the notes screen (the reported gap: review previously had only
+    // Send / Discard). The doc-kind on the right reads what you're reviewing.
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Button { model.backToNotes() } label: {
+                Text("‹ NOTES")
+                    .font(Theme.F.mono(9, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            Spacer()
+            Text(model.reviewKind.map { DocKinds.label(for: $0).uppercased() } ?? "REVIEW")
+                .font(Theme.F.mono(9, .semibold))
+                .tracking(2.0)
+                .foregroundStyle(Theme.C.orangeDeep)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 12)
+        .padding(.bottom, 10)
+        .background(Theme.C.paper)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
+            header
             ScrollView {
                 if let doc = model.document {
                     VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
## Thinking

Reported from TestFlight: finish a walk → tap **Estimate** → you land on the review screen with only **Send / Discard**, no way back. Root cause: the flow builds navigation by **replacing** `path` each transition, and `buildDocument()` did `path = [.review]` — which *dropped* the notes screen. So review had no parent to go back to.

Audited the whole flow; this was the **only** dead-end. Everything else is intentionally one-way: a live recording exits via Discard (confirm), a sent/discarded doc returns to the board.

## Change

- `buildDocument()` now **pushes** review onto notes: `path = [.notes, .review]`.
- New `backToNotes()` action.
- `ReviewView` gains a header: **`‹ NOTES`** back arrow + the built doc-kind label (ESTIMATE / INVOICE / …). Back keeps the session + notes intact so you can build a different document or re-read.

App-side only, no core/FFI. Verified on-sim (board → notes → estimate → review shows the back arrow; back returns to notes).

## Noticed for later (not this PR)

The `.building` phase / `BuildView` appears to be dead code since notes-first landed — candidate for a cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)