### PR TITLE
Editable items: core CRUD seam — corrections reach the document (Plan 16)

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -535,6 +535,14 @@ fileprivate struct FfiConverterString: FfiConverter {
 public protocol MurmurEngineProtocol : AnyObject {
     
     /**
+     * Adds a manual line at review time. `source = Manual` (survives any
+     * future reprocess) and a fresh UUIDv7 id, which sorts AFTER every
+     * existing item — the new line is last in every list and every rebuilt
+     * document (D4-16/WE-D). `right` may be `""` ("no quantity").
+     */
+    func addItem(sessionId: String, kind: String, text: String, right: String) throws  -> BoardItem
+    
+    /**
      * Attaches a photo to a session, optionally to a specific captured item.
      * The shell writes the bytes FIRST (Plan 11 D4 write order), then calls
      * this with the resulting filename. `captured_at` is `None` → core
@@ -579,6 +587,16 @@ public protocol MurmurEngineProtocol : AnyObject {
      * across FFI beyond the clone.
      */
     func listVocabulary() throws  -> [String]
+    
+    /**
+     * Retraction, distinct from `done` (keeper D-#4): tombstones the item
+     * (photos demoted to session-level, Plan 11 D3), dropping it from
+     * `list_items_for_session`, `list_open_todos`, AND every rebuilt
+     * document — where a `done` item stays in the document and only leaves
+     * the open-todos glance (WE-C pins the contrast). A second remove of
+     * the same id errors (the store's tombstone `NotFound`).
+     */
+    func removeItem(sessionId: String, itemId: String) throws 
     
     /**
      * Tombstones a photo's metadata row. The bytes are reclaimed by the
@@ -643,6 +661,18 @@ public protocol MurmurEngineProtocol : AnyObject {
      * the number of sessions swept, `0` on a clean relaunch.
      */
     func sweepZombieSessions() throws  -> UInt64
+    
+    /**
+     * Partial update of an item's editable fields (text / kind / right —
+     * keeper D-#1). A `None` field is left unchanged; an all-`None` call is
+     * a harmless no-op that still bumps the row's `updated_at`. `right` is
+     * the free-form quantity/unit string ("3 CU YD") — NOT price — and any
+     * value including `""` is accepted (D5-16). Returns the fresh
+     * `BoardItem` echo (with its honest `photo_count`) — an OPTIMISTIC
+     * display aid only: the notes/edit screen must re-read from the engine
+     * after any mutation (keeper D-#7), never rebuild state from this echo.
+     */
+    func updateItem(sessionId: String, itemId: String, text: String?, kind: String?, right: String?) throws  -> BoardItem
     
 }
 
@@ -712,6 +742,23 @@ public convenience init(config: EngineConfig)throws  {
 
     
 
+    
+    /**
+     * Adds a manual line at review time. `source = Manual` (survives any
+     * future reprocess) and a fresh UUIDv7 id, which sorts AFTER every
+     * existing item — the new line is last in every list and every rebuilt
+     * document (D4-16/WE-D). `right` may be `""` ("no quantity").
+     */
+open func addItem(sessionId: String, kind: String, text: String, right: String)throws  -> BoardItem {
+    return try  FfiConverterTypeBoardItem.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_add_item(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),
+        FfiConverterString.lower(kind),
+        FfiConverterString.lower(text),
+        FfiConverterString.lower(right),$0
+    )
+})
+}
     
     /**
      * Attaches a photo to a session, optionally to a specific captured item.
@@ -813,6 +860,22 @@ open func listVocabulary()throws  -> [String] {
 }
     
     /**
+     * Retraction, distinct from `done` (keeper D-#4): tombstones the item
+     * (photos demoted to session-level, Plan 11 D3), dropping it from
+     * `list_items_for_session`, `list_open_todos`, AND every rebuilt
+     * document — where a `done` item stays in the document and only leaves
+     * the open-todos glance (WE-C pins the contrast). A second remove of
+     * the same id errors (the store's tombstone `NotFound`).
+     */
+open func removeItem(sessionId: String, itemId: String)throws  {try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_remove_item(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),
+        FfiConverterString.lower(itemId),$0
+    )
+}
+}
+    
+    /**
      * Tombstones a photo's metadata row. The bytes are reclaimed by the
      * shell's reconciling sweep (Plan 11 D4), not deleted here.
      */
@@ -911,6 +974,28 @@ open func seedVocabulary(trade: String, version: UInt32, terms: [String])throws 
 open func sweepZombieSessions()throws  -> UInt64 {
     return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
     uniffi_ffi_fn_method_murmurengine_sweep_zombie_sessions(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Partial update of an item's editable fields (text / kind / right —
+     * keeper D-#1). A `None` field is left unchanged; an all-`None` call is
+     * a harmless no-op that still bumps the row's `updated_at`. `right` is
+     * the free-form quantity/unit string ("3 CU YD") — NOT price — and any
+     * value including `""` is accepted (D5-16). Returns the fresh
+     * `BoardItem` echo (with its honest `photo_count`) — an OPTIMISTIC
+     * display aid only: the notes/edit screen must re-read from the engine
+     * after any mutation (keeper D-#7), never rebuild state from this echo.
+     */
+open func updateItem(sessionId: String, itemId: String, text: String?, kind: String?, right: String?)throws  -> BoardItem {
+    return try  FfiConverterTypeBoardItem.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_update_item(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),
+        FfiConverterString.lower(itemId),
+        FfiConverterOptionString.lower(text),
+        FfiConverterOptionString.lower(kind),
+        FfiConverterOptionString.lower(right),$0
     )
 })
 }
@@ -2498,6 +2583,15 @@ public enum EngineError {
      */
     case Document(message: String)
     
+    /**
+     * An item CRUD call (`update_item`/`add_item`/`remove_item`, Plan 16)
+     * failed: a missing/tombstoned item, an unknown `kind`, empty text, a
+     * non-`Processed` session (D3-16 — edits are review-surface only), a
+     * poisoned lock, or a store error. Recoverable — surface, don't crash.
+     * Contains store/validation strings only (never an api key).
+     */
+    case Item(message: String)
+    
 }
 
 
@@ -2542,6 +2636,10 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 8: return .Item(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2567,6 +2665,8 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(6))
         case .Document(_ /* message is ignored*/):
             writeInt(&buf, Int32(7))
+        case .Item(_ /* message is ignored*/):
+            writeInt(&buf, Int32(8))
 
         
         }
@@ -3034,6 +3134,9 @@ private var initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_add_item() != 26329) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_add_photo() != 53149) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -3055,6 +3158,9 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ffi_checksum_method_murmurengine_list_vocabulary() != 10809) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_remove_item() != 65496) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_remove_photo() != 8364) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -3068,6 +3174,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_sweep_zombie_sessions() != 29924) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_update_item() != 53674) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_walkeventlistener_on_event() != 10314) {

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -40,12 +40,32 @@ final class DemoWalkEngine: WalkEngine {
         "inspection": ["shingles", "attic", "gfci", "furnace", "grading"]
     ]
 
+    // MARK: Item CRUD (Plan 16) — in-memory demo conformance.
+    // The Processed-only gate (D3-16) is NEW demo state: the demo had no
+    // session-status concept before this seam, so it introduces the minimum
+    // status enum needed to make the gate exercisable — begin() -> .recording,
+    // finish() -> .processed. This is NOT the real-core status machine (no
+    // AwaitingProcessing/Failed): just enough that an edit control wired
+    // before DONE fails here the same way it fails on the real engine.
+    enum DemoSessionStatus { case recording, processed }
+    private var sessionStatus: [String: DemoSessionStatus] = [:]
+    /// Demo-side kind bookkeeping (CapturedFixture carries a display tag,
+    /// not a core kind) so update/add can validate and re-tag.
+    private var itemKinds: [UUID: String] = [:]
+    /// // sac: keep in sync with murmur-core VALID_ITEM_KINDS
+    /// (crates/murmur-core/src/domain.rs) — the one shared allowlist.
+    private static let validItemKinds = ["todo", "decision", "note", "safety", "part", "price"]
+
+    enum DemoEditError: Error { case rejected(String) }
+
     func begin(trade: TradeFixture) -> AsyncStream<WalkEvent> {
         continuation?.finish()
         self.trade = trade
         seenText = ""
         firedItems = []
         board = []
+        itemKinds = [:]
+        sessionStatus[demoSessionId] = .recording
         var cont: AsyncStream<WalkEvent>.Continuation!
         let stream = AsyncStream<WalkEvent> { cont = $0 }
         continuation = cont
@@ -185,6 +205,9 @@ final class DemoWalkEngine: WalkEngine {
     func finish() async -> NotesModel {
         continuation?.finish()
         continuation = nil
+        // Plan 16: the demo session reaches its terminal state — edits are
+        // allowed from here on (the D3-16 gate mirror).
+        sessionStatus[demoSessionId] = .processed
         // Simulate the notes-compute beat (the real engine targets < 8 s).
         try? await Task.sleep(for: .seconds(0.8))
         let itemWord = board.count == 1 ? "item" : "items"
@@ -217,6 +240,86 @@ final class DemoWalkEngine: WalkEngine {
             detail: "Replace — parts + labor."
         )
     ]
+
+    // MARK: Item CRUD (Plan 16) — mirrors the Rust semantics loosely:
+    // partial-apply update, kind validated against the shared six-kind
+    // allowlist, empty text rejected, Processed-only, add appends, remove
+    // drops. Enough to exercise the edit UI with no backend; the REAL
+    // semantics (and the WE-A..WE-D worked examples) live in
+    // crates/ffi/src/items.rs.
+
+    private func requireEditable(_ sessionId: String) throws {
+        guard sessionId == demoSessionId, sessionStatus[sessionId] == .processed else {
+            throw DemoEditError.rejected("cannot edit items on a non-processed session")
+        }
+    }
+
+    /// Demo copy of MurmurEngineFormatting.tag(for:) — that one is behind
+    /// the canImport(MurmurCoreFFI) gate, inert on the demo build.
+    private static func tag(for kind: String) -> TagFixture {
+        switch kind {
+        case "safety": return TagFixture(kind: .red, label: "SAFETY")
+        case "price": return TagFixture(kind: .green, label: "PRICE")
+        case "part": return TagFixture(kind: .yellow, label: "PART")
+        case "decision": return TagFixture(kind: .plain, label: "DECISION")
+        default: return TagFixture(kind: .plain, label: "ITEM")
+        }
+    }
+
+    func updateItem(
+        sessionId: String, itemId: String, text: String?, kind: String?, right: String?
+    ) throws -> CapturedFixture {
+        try requireEditable(sessionId)
+        guard let uuid = UUID(uuidString: itemId),
+              let index = board.firstIndex(where: { $0.id == uuid }) else {
+            throw DemoEditError.rejected("no such item: \(itemId)")
+        }
+        if let text, text.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw DemoEditError.rejected("item text is empty")
+        }
+        if let kind {
+            guard Self.validItemKinds.contains(kind) else {
+                throw DemoEditError.rejected("invalid kind '\(kind)'")
+            }
+            itemKinds[uuid] = kind
+        }
+        let old = board[index]
+        let updated = CapturedFixture(
+            id: uuid,
+            tag: kind.map(Self.tag(for:)) ?? old.tag,
+            text: text ?? old.text,
+            right: right ?? old.right,
+            photos: old.photos
+        )
+        board[index] = updated
+        return updated
+    }
+
+    func addItem(
+        sessionId: String, kind: String, text: String, right: String
+    ) throws -> CapturedFixture {
+        try requireEditable(sessionId)
+        guard Self.validItemKinds.contains(kind) else {
+            throw DemoEditError.rejected("invalid kind '\(kind)'")
+        }
+        guard !text.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw DemoEditError.rejected("item text is empty")
+        }
+        let fixture = CapturedFixture(tag: Self.tag(for: kind), text: text, right: right)
+        itemKinds[fixture.id] = kind
+        board.append(fixture)   // append — mirrors the UUIDv7 ordering rule
+        return fixture
+    }
+
+    func removeItem(sessionId: String, itemId: String) throws {
+        try requireEditable(sessionId)
+        guard let uuid = UUID(uuidString: itemId),
+              let index = board.firstIndex(where: { $0.id == uuid }) else {
+            throw DemoEditError.rejected("no such item: \(itemId)")
+        }
+        itemKinds.removeValue(forKey: uuid)
+        board.remove(at: index)
+    }
 
     // Plan 13 D1: the on-demand build, engine-keyed. The demo has no real
     // per-kind rendering — it returns the trade's canned document rows

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -287,6 +287,29 @@ final class MurmurEngine: WalkEngine {
         try engine.listLivePhotoFilenames()
     }
 
+    // MARK: - Item CRUD (Plan 16): engine-keyed, Processed-gated in Rust
+    // (D3-16). The returned CapturedFixture is an optimistic echo only —
+    // after any mutation the screen must re-read from the engine (the
+    // // sac: contract's clause (b) in WalkEngine.swift).
+
+    func updateItem(
+        sessionId: String, itemId: String, text: String?, kind: String?, right: String?
+    ) throws -> CapturedFixture {
+        Self.board(try engine.updateItem(
+            sessionId: sessionId, itemId: itemId, text: text, kind: kind, right: right
+        ))
+    }
+
+    func addItem(
+        sessionId: String, kind: String, text: String, right: String
+    ) throws -> CapturedFixture {
+        Self.board(try engine.addItem(sessionId: sessionId, kind: kind, text: text, right: right))
+    }
+
+    func removeItem(sessionId: String, itemId: String) throws {
+        try engine.removeItem(sessionId: sessionId, itemId: itemId)
+    }
+
     func sweepZombieSessions() throws -> UInt64 {
         try engine.sweepZombieSessions()
     }

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -242,4 +242,60 @@ protocol WalkEngine: AnyObject {
     /// `attachPhoto(sessionId:...)` mid-walk (Plan 11 D7). `nil` when there is
     /// no live session (not walking, or the real engine has none yet).
     var currentSessionId: String? { get }
+
+    // Item CRUD (Plan 16) — the edit-at-review seam. Engine-keyed (the walk
+    // is over at review; finish() already dropped its session handle) and
+    // Processed-gated in core (D3-16, build_document's exact rule): a session
+    // you can build a document for is precisely a session you can edit.
+    // Throwing: the real FFI methods are fallible (non-Processed session,
+    // unknown kind, empty text, missing/tombstoned item) — the caller
+    // surfaces the error and leaves the screen unchanged, never crashes.
+    //
+    // // sac: the edit UI — tap-to-edit inline field editors for text/qty, a
+    // // sac: kind re-file control, an "＋ add line" affordance, swipe/✕ to
+    // // sac: remove — is YOURS; this seam only guarantees the data path.
+    // // sac: Three binding clauses (Plan 16 Rev 2):
+    // // sac:
+    // // sac: (a) Edit affordances render only when `!notes.queued`. The notes
+    // // sac:     screen CAN host a Failed/queued session (finish() returns a
+    // // sac:     NotesPayload WITH items even on a process() failure, and
+    // // sac:     NotesView renders them with the build buttons disabled via
+    // // sac:     `if notes.queued`). Edits on a queued session error by
+    // // sac:     design (the core gate is Processed-only; a retry sweep
+    // // sac:     re-runs process()). Gate the edit affordances on the exact
+    // // sac:     same `!notes.queued` predicate the build buttons already
+    // // sac:     follow — don't offer an edit control that will only throw.
+    // // sac:
+    // // sac: (b) After an edit, re-read from the engine — the fresh read is
+    // // sac:     the ONLY sanctioned post-edit path. Never reconstruct screen
+    // // sac:     state from the returned item, and never patch local state in
+    // // sac:     place: the returned record is an echo for optimistic
+    // // sac:     feedback, not a source of truth (it deliberately omits
+    // // sac:     sibling items and any list-membership cascade like
+    // // sac:     list_open_todos). This is keeper D-#7, the one-source-of-
+    // // sac:     truth rule that motivates the whole design.
+    // // sac:
+    // // sac: (c) Core `right` is quantity, NOT price — narrower than the demo
+    // // sac:     fixtures' free-chrome usage. Fixtures.swift puts prices
+    // // sac:     ("$1,200"), verbs ("REPLACE", "CLEAN"), and locations
+    // // sac:     ("S SLOPE") in `right`; core `right` is the quantity/unit
+    // // sac:     string only ("3 CU YD", "× 4"). The fixtures stay as-is —
+    // // sac:     do NOT "fix" them to quantity-only; they are demo chrome,
+    // // sac:     not core data. Just don't assume a round-trip through
+    // // sac:     updateItem(right:) preserves a price the way the fixture
+    // // sac:     displays it.
+    //
+    // A nil field on updateItem = leave unchanged. `right` accepts any string
+    // including "" ("no quantity"). addItem appends — the new line is LAST in
+    // every list and every rebuilt document (fresh UUIDv7, Manual source,
+    // survives reprocess). removeItem is retraction (tombstone), distinct
+    // from marking done: done keeps the line in the document and only drops
+    // it from open todos; remove deletes the line everywhere.
+    func updateItem(
+        sessionId: String, itemId: String, text: String?, kind: String?, right: String?
+    ) throws -> CapturedFixture
+    func addItem(
+        sessionId: String, kind: String, text: String, right: String
+    ) throws -> CapturedFixture
+    func removeItem(sessionId: String, itemId: String) throws
 }

--- a/crates/ffi/src/convert.rs
+++ b/crates/ffi/src/convert.rs
@@ -9,8 +9,9 @@ use crate::document::{DocLine, DocumentPayload};
 use crate::events::BoardItem;
 use crate::notes::{NotesBucket, NotesEntry};
 
-/// `CapturedItem` -> `BoardItem`. `right` has no core equivalent yet (board
-/// chrome text the Swift layer owns) and stays empty. `photo_count` is looked
+/// `CapturedItem` -> `BoardItem`. `right` projects the core quantity/unit
+/// string (`items.right_text`, Plan 16 D2-16) — `""` for un-edited items,
+/// exactly the pre-Plan-16 stub behavior. `photo_count` is looked
 /// up from a batched per-session map (`Store::count_live_photos_by_item_for_session`,
 /// the photo_count fast-follow) — a missing key (no live photos attached to
 /// this item) defaults to `0`. Callers load the map ONCE per snapshot, never
@@ -20,7 +21,7 @@ pub fn board_item(item: &CapturedItem, photo_counts: &HashMap<String, u32>) -> B
         id: item.id.clone(),
         kind: item.kind.clone(),
         text: item.text.clone(),
-        right: String::new(),
+        right: item.right.clone(),
         photo_count: photo_counts.get(&item.id).copied().unwrap_or(0),
     }
 }
@@ -100,7 +101,13 @@ mod tests {
         assert_eq!(board.id, item.id);
         assert_eq!(board.kind, "todo");
         assert_eq!(board.text, "order lumber");
+        assert_eq!(board.right, "", "an un-edited item projects the empty core right");
         assert_eq!(board.photo_count, 0, "no entry in the counts map defaults to 0");
+
+        // Plan 16 D2-16: `right` now projects the core quantity string.
+        store.update_item(&item.id, None, None, Some("3 CU YD")).unwrap();
+        let item = store.get_item(&item.id).unwrap();
+        assert_eq!(board_item(&item, &HashMap::new()).right, "3 CU YD");
     }
 
     #[test]

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -50,6 +50,13 @@ pub enum EngineError {
     /// unpriced document instead (R7); this variant is validation/store only.
     #[error("document build error: {0}")]
     Document(String),
+    /// An item CRUD call (`update_item`/`add_item`/`remove_item`, Plan 16)
+    /// failed: a missing/tombstoned item, an unknown `kind`, empty text, a
+    /// non-`Processed` session (D3-16 — edits are review-surface only), a
+    /// poisoned lock, or a store error. Recoverable — surface, don't crash.
+    /// Contains store/validation strings only (never an api key).
+    #[error("item error: {0}")]
+    Item(String),
 }
 
 /// Config crossing the FFI boundary. `api_key` is an opaque `String` from the

--- a/crates/ffi/src/items.rs
+++ b/crates/ffi/src/items.rs
@@ -1,0 +1,428 @@
+//! Item CRUD across UniFFI (Plan 16): `update_item` / `add_item` /
+//! `remove_item`. Engine-keyed by `session_id` (NOT `WalkSession`-scoped —
+//! the walk is over at review time; the photos.rs / build_document
+//! precedent) and **`Processed`-gated** (D3-16, `build_document`'s exact
+//! rule): a session you can build a document for is precisely a session you
+//! can edit. The status check and the mutation happen under ONE store lock
+//! with no intervening await, so there is no TOCTOU window (the
+//! `add_item_if_status` discipline).
+//!
+//! NO correction-learning side effect lands here (Rev 2): neither
+//! `record_correction` nor the vocab suggest-card — both are deferred to
+//! Plan 17 as one content-carrying signal (a bare counter could snap an
+//! earlier reflection over an activity summary that still holds the
+//! mis-heard term). A test below pins the counter untouched across every
+//! edit path.
+//!
+//! Every method is panic-free across FFI (Plan 07 CANON): a poisoned lock or
+//! a store/validation error surfaces as `EngineError::Item`, never a panic.
+
+use murmur_core::{SessionStatus, Store, VALID_ITEM_KINDS};
+
+use crate::convert;
+use crate::engine::{EngineError, MurmurEngine};
+use crate::events::BoardItem;
+
+impl MurmurEngine {
+    fn item_err(msg: impl Into<String>) -> EngineError {
+        EngineError::Item(msg.into())
+    }
+
+    /// D3-16: mutations are allowed on `Processed` sessions only — the
+    /// review surface. `Recording`/`AwaitingProcessing` edits race the
+    /// authoritative sweep; `Failed` edits race a retry's re-process. Takes
+    /// the already-locked store so the check shares the mutation's lock
+    /// (no check-then-write window).
+    fn require_processed(store: &Store, session_id: &str) -> Result<(), EngineError> {
+        let session = store.get_session(session_id).map_err(|e| Self::item_err(e.to_string()))?;
+        if session.status != SessionStatus::Processed {
+            return Err(Self::item_err(format!(
+                "cannot edit items on a {} session (edits are review-only)",
+                session.status.as_str()
+            )));
+        }
+        Ok(())
+    }
+
+    /// D5-16: `kind` must be in the ONE shared allowlist (R6: reject
+    /// unknowns, never store them) — the same const the agent `AddItemTool`
+    /// validates and advertises.
+    fn require_valid_kind(kind: &str) -> Result<(), EngineError> {
+        if !VALID_ITEM_KINDS.contains(&kind) {
+            return Err(Self::item_err(format!(
+                "invalid kind '{kind}'; must be one of: {}",
+                VALID_ITEM_KINDS.join(", ")
+            )));
+        }
+        Ok(())
+    }
+
+    /// The honest echo (Rev 2): the returned `BoardItem` carries the item's
+    /// TRUE live `photo_count`, read under the same lock — never an empty
+    /// counts map (a 0-count echo would invite the Swift layer to patch
+    /// local state and vanish a real photo badge).
+    fn echo_board_item(
+        store: &Store,
+        session_id: &str,
+        item: &murmur_core::CapturedItem,
+    ) -> Result<BoardItem, EngineError> {
+        let counts = store
+            .count_live_photos_by_item_for_session(session_id)
+            .map_err(|e| Self::item_err(e.to_string()))?;
+        Ok(convert::board_item(item, &counts))
+    }
+}
+
+#[uniffi::export]
+impl MurmurEngine {
+    /// Partial update of an item's editable fields (text / kind / right —
+    /// keeper D-#1). A `None` field is left unchanged; an all-`None` call is
+    /// a harmless no-op that still bumps the row's `updated_at`. `right` is
+    /// the free-form quantity/unit string ("3 CU YD") — NOT price — and any
+    /// value including `""` is accepted (D5-16). Returns the fresh
+    /// `BoardItem` echo (with its honest `photo_count`) — an OPTIMISTIC
+    /// display aid only: the notes/edit screen must re-read from the engine
+    /// after any mutation (keeper D-#7), never rebuild state from this echo.
+    pub fn update_item(
+        &self,
+        session_id: String,
+        item_id: String,
+        text: Option<String>,
+        kind: Option<String>,
+        right: Option<String>,
+    ) -> Result<BoardItem, EngineError> {
+        let store = self.store.lock().map_err(|_| Self::item_err("store lock poisoned"))?;
+        Self::require_processed(&store, &session_id)?;
+        if let Some(t) = &text {
+            if t.trim().is_empty() {
+                return Err(Self::item_err("item text is empty"));
+            }
+        }
+        if let Some(k) = &kind {
+            Self::require_valid_kind(k)?;
+        }
+        let updated = store
+            .update_item(&item_id, text.as_deref(), kind.as_deref(), right.as_deref())
+            .map_err(|e| Self::item_err(e.to_string()))?;
+        Self::echo_board_item(&store, &session_id, &updated)
+    }
+
+    /// Adds a manual line at review time. `source = Manual` (survives any
+    /// future reprocess) and a fresh UUIDv7 id, which sorts AFTER every
+    /// existing item — the new line is last in every list and every rebuilt
+    /// document (D4-16/WE-D). `right` may be `""` ("no quantity").
+    pub fn add_item(
+        &self,
+        session_id: String,
+        kind: String,
+        text: String,
+        right: String,
+    ) -> Result<BoardItem, EngineError> {
+        let store = self.store.lock().map_err(|_| Self::item_err("store lock poisoned"))?;
+        Self::require_processed(&store, &session_id)?;
+        Self::require_valid_kind(&kind)?;
+        if text.trim().is_empty() {
+            return Err(Self::item_err("item text is empty"));
+        }
+        let item = store
+            .add_item(&session_id, &kind, &text)
+            .map_err(|e| Self::item_err(e.to_string()))?;
+        // Set `right` through the ONE existing write path (same locked
+        // scope; it bumps updated_at once more, harmless) rather than
+        // growing a second insert signature.
+        let item = store
+            .update_item(&item.id, None, None, Some(&right))
+            .map_err(|e| Self::item_err(e.to_string()))?;
+        Self::echo_board_item(&store, &session_id, &item)
+    }
+
+    /// Retraction, distinct from `done` (keeper D-#4): tombstones the item
+    /// (photos demoted to session-level, Plan 11 D3), dropping it from
+    /// `list_items_for_session`, `list_open_todos`, AND every rebuilt
+    /// document — where a `done` item stays in the document and only leaves
+    /// the open-todos glance (WE-C pins the contrast). A second remove of
+    /// the same id errors (the store's tombstone `NotFound`).
+    pub fn remove_item(&self, session_id: String, item_id: String) -> Result<(), EngineError> {
+        let store = self.store.lock().map_err(|_| Self::item_err("store lock poisoned"))?;
+        Self::require_processed(&store, &session_id)?;
+        store.delete_item(&item_id).map_err(|e| Self::item_err(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use harness::{
+        CompletionResponse, ContentBlock, HarnessError, Memory, MemoryStore, MockProvider,
+        StopReason, Usage,
+    };
+
+    use crate::engine::Providers;
+
+    use super::*;
+
+    // Inline SpyStore + literal Providers — the photos.rs/vocabulary.rs
+    // pattern (no shared helpers exist in this crate by design).
+    struct SpyStore {
+        saved: StdMutex<Vec<Memory>>,
+    }
+    impl MemoryStore for SpyStore {
+        fn load(&self) -> Result<Memory, HarnessError> {
+            Ok(Memory::default())
+        }
+        fn save(&self, m: &Memory) -> Result<(), HarnessError> {
+            self.saved.lock().unwrap().push(m.clone());
+            Ok(())
+        }
+    }
+
+    fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
+        CompletionResponse {
+            content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+        }
+    }
+
+    fn end_turn(text: &str) -> CompletionResponse {
+        CompletionResponse {
+            content: vec![ContentBlock::Text { text: text.into() }],
+            stop_reason: StopReason::EndTurn,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+        }
+    }
+
+    fn engine_with(store: murmur_core::Store, processing: Vec<CompletionResponse>) -> Arc<MurmurEngine> {
+        MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(SpyStore { saved: StdMutex::new(Vec::new()) }),
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(processing)),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        )
+    }
+
+    /// Drives `begin_walk -> append_transcript -> finish()` (the
+    /// document_build.rs::processed_landscape_session shape) with one
+    /// scripted `add_item` per fixture row, leaving the session `Processed`
+    /// with exactly those authoritative items, in order.
+    async fn processed_session_with_items(
+        items: &[(&str, &str)],
+    ) -> (Arc<MurmurEngine>, String) {
+        let store = murmur_core::Store::open_in_memory("device-a").unwrap();
+        let mut responses: Vec<CompletionResponse> = items
+            .iter()
+            .map(|(kind, text)| {
+                tool_use("add_item", serde_json::json!({"kind": kind, "text": text}))
+            })
+            .collect();
+        responses.push(end_turn("done"));
+        responses.push(tool_use("write_notes", serde_json::json!({"summary": "Walked the site."})));
+        let engine = engine_with(store, responses);
+        let session = engine.clone().begin_walk(None, "landscape".into()).unwrap();
+        session.clone().append_transcript("site walk".into());
+        let sid = session.session_id();
+        let _notes = session.finish().await;
+        (engine, sid)
+    }
+
+    /// The session's live item ids, insertion order (UUIDv7 = creation order).
+    fn item_ids(engine: &MurmurEngine, sid: &str) -> Vec<String> {
+        engine
+            .store
+            .lock()
+            .unwrap()
+            .list_items_for_session(sid)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.id)
+            .collect()
+    }
+
+    fn open_todo_ids(engine: &MurmurEngine) -> Vec<String> {
+        engine
+            .store
+            .lock()
+            .unwrap()
+            .list_open_todos()
+            .unwrap()
+            .into_iter()
+            .map(|i| i.id)
+            .collect()
+    }
+
+    // ---- Task 3: status gate (D3-16) ------------------------------------
+
+    #[tokio::test]
+    async fn mutations_are_rejected_on_a_recording_session() {
+        let engine = engine_with(murmur_core::Store::open_in_memory("device-a").unwrap(), vec![]);
+        let session = engine.clone().begin_walk(None, "landscape".into()).unwrap();
+        let sid = session.session_id();
+        assert!(matches!(
+            engine.update_item(sid.clone(), "any".into(), Some("x".into()), None, None),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(
+            engine.add_item(sid.clone(), "todo".into(), "x".into(), "".into()),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(engine.remove_item(sid, "any".into()), Err(EngineError::Item(_))));
+    }
+
+    #[tokio::test]
+    async fn mutations_are_rejected_on_an_awaiting_processing_session() {
+        let store = murmur_core::Store::open_in_memory("device-a").unwrap();
+        let sid = store.start_session_with_template(None, "landscape").unwrap().id;
+        let item = store.add_item(&sid, "todo", "order lumber").unwrap();
+        store.end_and_record_session(&sid).unwrap(); // Recording -> AwaitingProcessing
+        let engine = engine_with(store, vec![]);
+        assert!(matches!(
+            engine.update_item(sid.clone(), item.id.clone(), Some("x".into()), None, None),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(
+            engine.add_item(sid.clone(), "todo".into(), "x".into(), "".into()),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(engine.remove_item(sid, item.id), Err(EngineError::Item(_))));
+        // Nothing was written or tombstoned while gated.
+    }
+
+    #[tokio::test]
+    async fn mutations_succeed_on_a_processed_session() {
+        let (engine, sid) = processed_session_with_items(&[("todo", "Power edger")]).await;
+        let id = item_ids(&engine, &sid).remove(0);
+        engine.update_item(sid.clone(), id.clone(), Some("Mower".into()), None, None).unwrap();
+        engine.add_item(sid.clone(), "safety".into(), "cracked walkway".into(), "".into()).unwrap();
+        engine.remove_item(sid, id).unwrap();
+    }
+
+    // ---- Task 3: validation (D5-16) --------------------------------------
+
+    #[tokio::test]
+    async fn update_item_validates_and_returns_the_fresh_board_item() {
+        let (engine, sid) = processed_session_with_items(&[("todo", "Power edger")]).await;
+        let id = item_ids(&engine, &sid).remove(0);
+
+        assert!(matches!(
+            engine.update_item(sid.clone(), id.clone(), Some("   ".into()), None, None),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(
+            engine.update_item(sid.clone(), id.clone(), None, Some("bogus".into()), None),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(
+            engine.update_item(sid.clone(), "no-such-item".into(), Some("x".into()), None, None),
+            Err(EngineError::Item(_))
+        ));
+
+        let board = engine
+            .update_item(sid, id.clone(), Some("Mower".into()), Some("part".into()), Some("× 1".into()))
+            .unwrap();
+        assert_eq!(board.id, id);
+        assert_eq!(board.text, "Mower");
+        assert_eq!(board.kind, "part");
+        assert_eq!(board.right, "× 1");
+    }
+
+    #[tokio::test]
+    async fn add_item_validates_kind_and_text() {
+        let (engine, sid) = processed_session_with_items(&[]).await;
+        assert!(matches!(
+            engine.add_item(sid.clone(), "bogus".into(), "x".into(), "".into()),
+            Err(EngineError::Item(_))
+        ));
+        assert!(matches!(
+            engine.add_item(sid.clone(), "todo".into(), "  ".into(), "".into()),
+            Err(EngineError::Item(_))
+        ));
+        assert!(item_ids(&engine, &sid).is_empty(), "nothing written on rejection");
+    }
+
+    #[tokio::test]
+    async fn update_item_right_projects_through_the_board_item() {
+        let (engine, sid) = processed_session_with_items(&[("part", "bark mulch")]).await;
+        let id = item_ids(&engine, &sid).remove(0);
+        let board =
+            engine.update_item(sid, id, None, None, Some("3 CU YD".into())).unwrap();
+        assert_eq!(board.right, "3 CU YD", "board_item now reads item.right");
+    }
+
+    // ---- Task 3: no correction wiring (Rev 2 negative pin) ---------------
+
+    #[tokio::test]
+    async fn no_edit_path_touches_the_correction_counter() {
+        let (engine, sid) =
+            processed_session_with_items(&[("todo", "Power edger"), ("part", "bark mulch")]).await;
+        let ids = item_ids(&engine, &sid);
+        engine.update_item(sid.clone(), ids[0].clone(), Some("Mower".into()), None, None).unwrap();
+        engine.update_item(sid.clone(), ids[0].clone(), None, Some("part".into()), None).unwrap();
+        engine.update_item(sid.clone(), ids[1].clone(), None, None, Some("3 CU YD".into())).unwrap();
+        engine.add_item(sid.clone(), "safety".into(), "cracked walkway".into(), "".into()).unwrap();
+        engine.remove_item(sid, ids[1].clone()).unwrap();
+        let corrections = engine
+            .store
+            .lock()
+            .unwrap()
+            .reflection_signals()
+            .unwrap()
+            .corrections_since_reflection;
+        assert_eq!(
+            corrections, 0,
+            "Plan 16 wires NO record_correction — the content-carrying signal is Plan 17's \
+             (a bare counter could snap a reflection that re-learns the mis-heard term)"
+        );
+    }
+
+    // ---- Task 3: add appends / remove tombstones at the FFI layer --------
+
+    #[tokio::test]
+    async fn add_item_appends_and_remove_item_tombstones() {
+        let (engine, sid) = processed_session_with_items(&[("todo", "call supplier")]).await;
+        let first = item_ids(&engine, &sid).remove(0);
+
+        let added = engine
+            .add_item(sid.clone(), "safety".into(), "cracked walkway".into(), "× 2".into())
+            .unwrap();
+        assert_eq!(added.text, "cracked walkway");
+        assert_eq!(added.right, "× 2", "a line can be added with a quantity in one call");
+        assert_eq!(
+            item_ids(&engine, &sid),
+            vec![first.clone(), added.id.clone()],
+            "the fresh UUIDv7 sorts after every existing item — append"
+        );
+        {
+            let store = engine.store.lock().unwrap();
+            let item = store.get_item(&added.id).unwrap();
+            assert_eq!(item.source, murmur_core::ItemSource::Manual, "survives reprocess");
+        }
+
+        engine.remove_item(sid.clone(), added.id.clone()).unwrap();
+        assert_eq!(item_ids(&engine, &sid), vec![first]);
+        assert!(
+            matches!(engine.remove_item(sid, added.id), Err(EngineError::Item(_))),
+            "a second remove of the tombstoned id errors"
+        );
+    }
+
+    // ---- Task 3: honest photo_count echo (Rev 2) --------------------------
+
+    #[tokio::test]
+    async fn update_item_echo_carries_the_honest_photo_count() {
+        let (engine, sid) = processed_session_with_items(&[("todo", "Power edger")]).await;
+        let id = item_ids(&engine, &sid).remove(0);
+        engine.add_photo(sid.clone(), Some(id.clone()), "a.jpg".into(), None).unwrap();
+        engine.add_photo(sid.clone(), Some(id.clone()), "b.jpg".into(), None).unwrap();
+        let board = engine.update_item(sid, id, Some("Mower".into()), None, None).unwrap();
+        assert_eq!(
+            board.photo_count, 2,
+            "the echo reads count_live_photos_by_item_for_session under the same lock — \
+             never an empty counts map"
+        );
+    }
+}

--- a/crates/ffi/src/items.rs
+++ b/crates/ffi/src/items.rs
@@ -425,4 +425,128 @@ mod tests {
              never an empty counts map"
         );
     }
+
+    // ---- Task 4: propagation pinned end-to-end (WE-A..WE-D) ---------------
+
+    #[tokio::test]
+    async fn we_a_we_b_update_propagates_to_the_rebuilt_document() {
+        // F1: [A1 todo "Power edger", A2 safety "loose railing", A3 part "bark mulch"]
+        let (engine, sid) = processed_session_with_items(&[
+            ("todo", "Power edger"),
+            ("safety", "loose railing"),
+            ("part", "bark mulch"),
+        ])
+        .await;
+        let ids = item_ids(&engine, &sid);
+        assert_eq!(ids.len(), 3);
+        assert_eq!(open_todo_ids(&engine), vec![ids[0].clone()], "A1 is the one open todo");
+
+        // WE-A: text + kind on one item.
+        engine
+            .update_item(sid.clone(), ids[0].clone(), Some("Mower".into()), Some("part".into()), None)
+            .unwrap();
+        assert_eq!(
+            open_todo_ids(&engine),
+            Vec::<String>::new(),
+            "the todo -> part re-tag drops A1 from the morning glance"
+        );
+        // work_order: non-pricing, deterministic, zero LLM calls.
+        let doc = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines.len(), 3, "the re-tag does NOT change the document structure");
+        let titles: Vec<&str> = doc.lines.iter().map(|l| l.title.as_str()).collect();
+        assert_eq!(titles, vec!["Mower", "loose railing", "bark mulch"],
+            "order [A1, A2, A3]; only L1's title changed — the corrected text reached the document");
+        let line_item_ids: Vec<Option<&str>> =
+            doc.lines.iter().map(|l| l.item_id.as_deref()).collect();
+        assert_eq!(
+            line_item_ids,
+            ids.iter().map(|i| Some(i.as_str())).collect::<Vec<_>>()
+        );
+        assert!(doc.lines.iter().all(|l| l.qty.is_empty()), "no right set yet — every qty empty");
+
+        // WE-B: the right edit propagates as qty.
+        engine
+            .update_item(sid.clone(), ids[2].clone(), None, None, Some("3 CU YD".into()))
+            .unwrap();
+        let doc = engine.build_document(sid, "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines[2].qty, "3 CU YD", "the quantity edit reached the qty column");
+        assert_eq!(doc.lines[0].qty, "");
+        assert_eq!(doc.lines[1].qty, "");
+    }
+
+    #[tokio::test]
+    async fn we_c_remove_cascades_and_we_d_add_appends() {
+        // F2: [B1 todo "call supplier", B2 todo "order sod", B3 part "bark mulch"]
+        let (engine, sid) = processed_session_with_items(&[
+            ("todo", "call supplier"),
+            ("todo", "order sod"),
+            ("part", "bark mulch"),
+        ])
+        .await;
+        let ids = item_ids(&engine, &sid);
+        let (b1, b2, b3) = (ids[0].clone(), ids[1].clone(), ids[2].clone());
+        assert_eq!(open_todo_ids(&engine), vec![b1.clone(), b2.clone()]);
+
+        // WE-C: remove tombstones and cascades to the glance.
+        engine.remove_item(sid.clone(), b2.clone()).unwrap();
+        assert_eq!(item_ids(&engine, &sid), vec![b1.clone(), b3.clone()]);
+        assert_eq!(open_todo_ids(&engine), vec![b1.clone()],
+            "the tombstoned todo drops out of the morning glance");
+        let doc = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines.len(), 2, "B2's line is gone from the rebuilt document");
+        let titles: Vec<&str> = doc.lines.iter().map(|l| l.title.as_str()).collect();
+        assert_eq!(titles, vec!["call supplier", "bark mulch"]);
+        assert!(matches!(
+            engine.remove_item(sid.clone(), b2),
+            Err(EngineError::Item(_))
+        ));
+
+        // WE-D: add appends — the last line of the rebuilt document.
+        let added = engine
+            .add_item(sid.clone(), "safety".into(), "cracked walkway".into(), "".into())
+            .unwrap();
+        assert_eq!(item_ids(&engine, &sid), vec![b1, b3, added.id.clone()]);
+        let doc = engine.build_document(sid, "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines.len(), 3);
+        assert_eq!(doc.lines[2].title, "cracked walkway", "appended last");
+        assert_eq!(doc.lines[2].item_id.as_deref(), Some(added.id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn we_c_contrast_done_keeps_the_line_where_remove_deletes_it() {
+        let (engine, sid) = processed_session_with_items(&[
+            ("todo", "call supplier"),
+            ("todo", "order sod"),
+            ("part", "bark mulch"),
+        ])
+        .await;
+        let ids = item_ids(&engine, &sid);
+        // done instead of remove: B2 stays everywhere except the glance.
+        engine.store.lock().unwrap().set_item_done(&ids[1], true).unwrap();
+        assert_eq!(item_ids(&engine, &sid), ids, "done keeps the item in the session");
+        assert_eq!(open_todo_ids(&engine), vec![ids[0].clone()], "but drops it from the glance");
+        let doc = engine.build_document(sid, "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines.len(), 3, "done keeps the line in the document; remove deletes it");
+    }
+
+    #[tokio::test]
+    async fn we_c_kind_retag_cascades_to_open_todos_both_directions() {
+        let (engine, sid) = processed_session_with_items(&[
+            ("todo", "call supplier"),
+            ("todo", "order sod"),
+        ])
+        .await;
+        let ids = item_ids(&engine, &sid);
+        let (b1, b2) = (ids[0].clone(), ids[1].clone());
+        assert_eq!(open_todo_ids(&engine), vec![b1.clone(), b2.clone()]);
+
+        engine.update_item(sid.clone(), b1.clone(), None, Some("part".into()), None).unwrap();
+        assert_eq!(open_todo_ids(&engine), vec![b2.clone()], "todo -> part drops B1 from the glance");
+        assert_eq!(item_ids(&engine, &sid).len(), 2, "re-filed, not removed");
+        let doc = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines.len(), 2, "B1 still renders in the document");
+
+        engine.update_item(sid, b1.clone(), None, Some("todo".into()), None).unwrap();
+        assert_eq!(open_todo_ids(&engine), vec![b1, b2], "part -> todo re-adds B1");
+    }
 }

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -10,6 +10,7 @@ pub mod document;
 pub mod document_build;
 pub mod engine;
 pub mod events;
+pub mod items;
 pub mod notes;
 pub mod photos;
 pub mod session;

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -157,6 +157,12 @@ pub struct CapturedItem {
     pub session_id: String,
     pub kind: String,
     pub text: String,
+    /// Quantity/unit display string ("3 CU YD", "× 4") — NOT price (pricing
+    /// stays a document-build concern, keeper D-#2). Free-form by design
+    /// (R6: coercing it would fabricate). Defaults `""` = "no quantity".
+    /// Backed by the `items.right_text` column (Plan 16; `RIGHT` is a SQL
+    /// keyword, hence the column rename — the field matches `BoardItem.right`).
+    pub right: String,
     pub source: ItemSource,
     pub done: bool,
     pub created_at: u64,

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -148,6 +148,15 @@ impl ItemSource {
     }
 }
 
+/// The item-kind allowlist (Plan 16 Task 2, the Plan 15 SEED_MAX
+/// "don't fork the constant" discipline). Item `kind` stays a free `String`
+/// at the domain/DB layer by design (new kinds must not require a
+/// migration) — this const is the VALIDATION boundary, shared by the agent
+/// `AddItemTool` (both its `execute` check and its advertised JSON-schema
+/// enum) and the FFI edit seam (`update_item`/`add_item`), so the two can't
+/// drift (R6: reject unknown kinds, never store them).
+pub const VALID_ITEM_KINDS: [&str; 6] = ["todo", "decision", "note", "safety", "part", "price"];
+
 /// A typed item extracted from (or manually added to) a session.
 /// `kind` is a free string by design — conventions: "todo", "decision",
 /// "note", "safety", "part", "price". New kinds must not require a migration.

--- a/crates/murmur-core/src/lib.rs
+++ b/crates/murmur-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod store;
 pub use coordinator::ReflectionCoordinator;
 pub use domain::{
     Artifact, CapturedItem, Contact, Job, JobStatus, ItemSource, LlmUsageRow, NewJob, Photo,
-    Session, SessionStatus, SessionSummary,
+    Session, SessionStatus, SessionSummary, VALID_ITEM_KINDS,
 };
 pub use error::CoreError;
 pub use ids::new_id;

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -49,7 +49,8 @@ pub(crate) enum GapPolicy {
 /// notes-first left it caller-less): calling this
 /// with `GapPolicy::AllGap` produces lines with IDENTICAL
 /// title/detail/qty/amount_cents/section/item_id/is_gap semantics — title =
-/// item.text, detail = "", qty = "", amount_cents = None, section = None,
+/// item.text, detail = "", qty = item.right (which for the removed offline
+/// fallback's un-`right` items was ""), amount_cents = None, section = None,
 /// is_gap = true, item_id = Some(item.id) — waiving only the `id` field (the
 /// offline fallback legacy-sets `line.id = item.id`; this render uses a
 /// fresh id). The two implementations are kept in lockstep by this
@@ -72,7 +73,7 @@ pub(crate) fn render_structure_document(
                 "id": crate::ids::new_id(),
                 "title": item.text,
                 "detail": "",
-                "qty": "",
+                "qty": item.right,
                 "amount_cents": null,
                 "section": null,
                 "is_gap": is_gap,
@@ -474,6 +475,22 @@ mod tests {
         assert_eq!(line["item_id"], item.id);
         // id is deliberately NOT compared — the offline fallback sets
         // line.id = item.id; this render always mints a fresh id.
+    }
+
+    /// Plan 16 Task 2 (D2-16): a quantity edit reaches every rebuilt
+    /// document — `qty = item.right` — while un-edited items (right == "")
+    /// keep today's `qty == ""` exactly (behavior-preserving).
+    #[test]
+    fn qty_renders_from_item_right() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let session = store.start_session(None).unwrap();
+        let its = items(&store, &session.id, &[("part", "bark mulch"), ("todo", "order lumber")]);
+        store.update_item(&its[0].id, None, None, Some("3 CU YD")).unwrap();
+        let its = store.list_items_for_session(&session.id).unwrap();
+
+        let lines = render_structure_document("estimate", &its, GapPolicy::PerPricingKind);
+        assert_eq!(lines[0]["qty"], "3 CU YD", "the right edit propagates as qty");
+        assert_eq!(lines[1]["qty"], "", "an un-edited item keeps today's empty qty");
     }
 
     // ---- Task 3: price_items echo-validate ------------------------------

--- a/crates/murmur-core/src/pipeline/tools.rs
+++ b/crates/murmur-core/src/pipeline/tools.rs
@@ -43,7 +43,7 @@ fn req_nonempty_str<'a>(
     Ok(value)
 }
 
-const VALID_KINDS: [&str; 6] = ["todo", "decision", "note", "safety", "part", "price"];
+use crate::domain::VALID_ITEM_KINDS;
 
 pub struct AddItemTool {
     store: Arc<Mutex<Store>>,
@@ -114,7 +114,9 @@ impl Tool for AddItemTool {
         serde_json::json!({
             "type": "object",
             "properties": {
-                "kind": { "type": "string", "enum": ["todo", "decision", "note", "safety", "part", "price"], "minLength": 1 },
+                // Built from the shared const (Plan 16 Task 2) — the advertised
+                // enum can never drift from the `execute` validation below.
+                "kind": { "type": "string", "enum": VALID_ITEM_KINDS, "minLength": 1 },
                 "text": { "type": "string", "minLength": 1, "description": "one short item, in the speaker's own terms" }
             },
             "required": ["kind", "text"]
@@ -123,10 +125,10 @@ impl Tool for AddItemTool {
 
     async fn execute(&self, input: serde_json::Value) -> Result<String, HarnessError> {
         let kind = req_str(&input, "kind", "add_item")?;
-        if !VALID_KINDS.contains(&kind) {
+        if !VALID_ITEM_KINDS.contains(&kind) {
             return Err(tool_err(
                 "add_item",
-                format!("invalid kind '{kind}'; must be one of: {}", VALID_KINDS.join(", ")),
+                format!("invalid kind '{kind}'; must be one of: {}", VALID_ITEM_KINDS.join(", ")),
             ));
         }
         let text = req_nonempty_str(&input, "text", "add_item")?;
@@ -518,6 +520,28 @@ mod tests {
             "error should name the valid kinds, got: {err}"
         );
         assert!(store.lock().unwrap().list_items_for_session(&sid).unwrap().is_empty());
+    }
+
+    /// Plan 16 Task 2 (Rev 2): the advertised JSON-schema `kind.enum` is
+    /// BUILT FROM the shared `VALID_ITEM_KINDS` const — the third hard-coded
+    /// copy is gone, so the schema can't silently drift from the validation
+    /// boundary the `execute` path enforces.
+    #[test]
+    fn input_schema_kind_enum_matches_the_shared_const() {
+        let (store, sid) = shared_store_with_session();
+        let tool = super::AddItemTool::new(store, &sid);
+        let schema = tool.input_schema();
+        let advertised: Vec<&str> = schema["properties"]["kind"]["enum"]
+            .as_array()
+            .expect("kind.enum is an array")
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            advertised,
+            crate::domain::VALID_ITEM_KINDS.to_vec(),
+            "the advertised enum must equal the one shared allowlist"
+        );
     }
 
     #[tokio::test]

--- a/crates/murmur-core/src/store/items.rs
+++ b/crates/murmur-core/src/store/items.rs
@@ -6,7 +6,7 @@ use crate::ids::new_id;
 use crate::store::Store;
 
 const ITEM_COLS: &str =
-    "id, session_id, kind, text, source, done, created_at, updated_at, device_id";
+    "id, session_id, kind, text, right_text, source, done, created_at, updated_at, device_id";
 
 fn item_from_row(row: &Row) -> Result<CapturedItem, CoreError> {
     Ok(CapturedItem {
@@ -14,6 +14,7 @@ fn item_from_row(row: &Row) -> Result<CapturedItem, CoreError> {
         session_id: row.get("session_id").map_err(CoreError::Sqlite)?,
         kind: row.get("kind").map_err(CoreError::Sqlite)?,
         text: row.get("text").map_err(CoreError::Sqlite)?,
+        right: row.get("right_text").map_err(CoreError::Sqlite)?,
         source: {
             let raw: String = row.get("source").map_err(CoreError::Sqlite)?;
             ItemSource::parse(&raw)?
@@ -78,6 +79,7 @@ impl Store {
             session_id: session_id.to_string(),
             kind: kind.to_string(),
             text: text.to_string(),
+            right: String::new(),
             source,
             done: false,
             created_at: now,
@@ -85,14 +87,42 @@ impl Store {
             device_id: self.device_id.clone(),
         };
         self.conn.execute(
-            "INSERT INTO items (id, session_id, kind, text, source, done, created_at, updated_at, device_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7, ?8)",
+            "INSERT INTO items (id, session_id, kind, text, right_text, source, done, created_at, updated_at, device_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8, ?9)",
             rusqlite::params![
-                item.id, item.session_id, item.kind, item.text, item.source.as_str(),
+                item.id, item.session_id, item.kind, item.text, item.right,
+                item.source.as_str(),
                 item.created_at as i64, item.updated_at as i64, item.device_id,
             ],
         )?;
         Ok(item)
+    }
+
+    /// Partial update of an item's editable fields (Plan 16). Mirrors
+    /// `set_item_done`: tombstone-guarded, bumps `updated_at`, preserves
+    /// id/created_at/source/done. A `None` field is left unchanged.
+    /// Ungated at the store layer (exactly like `set_item_done`/
+    /// `delete_item`) — the session-status gate is a boundary concern and
+    /// lives in the FFI layer (Plan 16 D1-16/D3-16).
+    pub fn update_item(
+        &self,
+        id: &str,
+        text: Option<&str>,
+        kind: Option<&str>,
+        right: Option<&str>,
+    ) -> Result<CapturedItem, CoreError> {
+        // COALESCE keeps None fields untouched in one statement — no
+        // read-modify-write.
+        let changed = self.conn.execute(
+            "UPDATE items SET text = COALESCE(?1, text), kind = COALESCE(?2, kind),
+                              right_text = COALESCE(?3, right_text), updated_at = ?4
+             WHERE id = ?5 AND deleted_at IS NULL",
+            rusqlite::params![text, kind, right, self.now() as i64, id],
+        )?;
+        if changed == 0 {
+            return Err(CoreError::NotFound { entity: "item", id: id.to_string() });
+        }
+        self.get_item(id)
     }
 
     pub fn set_item_done(&self, id: &str, done: bool) -> Result<CapturedItem, CoreError> {
@@ -172,6 +202,7 @@ impl Store {
 mod tests {
     use std::sync::Arc;
 
+    use crate::domain::CapturedItem;
     use crate::error::CoreError;
     use crate::store::Store;
 
@@ -299,6 +330,114 @@ mod tests {
         // net for a still-processing / failed session (decision recorded in plan).
         let open: Vec<_> = s.list_open_todos().unwrap().into_iter().map(|i| i.text).collect();
         assert_eq!(open, vec!["live todo".to_string()]);
+    }
+
+    // ---- Plan 16: right_text column + update_item -----------------------
+
+    #[test]
+    fn fresh_store_is_at_schema_v6() {
+        let (s, _) = store_with_session();
+        let v: i64 =
+            s.conn.pragma_query_value(None, "user_version", |r| r.get(0)).unwrap();
+        assert_eq!(v, 6, "v6 added items.right_text (Plan 16)");
+    }
+
+    #[test]
+    fn legacy_rows_without_right_text_read_back_empty_right() {
+        // simulate a pre-migration row: raw insert without a right_text value
+        let (s, sid) = store_with_session();
+        s.conn.execute(
+            "INSERT INTO items (id, session_id, kind, text, done, created_at, updated_at, device_id)
+             VALUES ('legacy', ?1, 'todo', 'old', 0, 1, 1, 'device-a')",
+            [&sid],
+        ).unwrap();
+        let legacy = s.get_item("legacy").unwrap();
+        assert_eq!(legacy.right, "",
+            "the column DEFAULT backfills rows that predate right_text");
+    }
+
+    #[test]
+    fn add_item_yields_empty_right() {
+        let (s, sid) = store_with_session();
+        let item = s.add_item(&sid, "todo", "order lumber").unwrap();
+        assert_eq!(item.right, "");
+        // round-trips through the DB read
+        assert_eq!(s.list_items_for_session(&sid).unwrap()[0].right, "");
+    }
+
+    #[test]
+    fn update_item_sets_text_and_kind_and_preserves_the_rest() {
+        let (s, sid) = store_with_session();
+        let item = s.add_item(&sid, "todo", "Power edger").unwrap();
+        let s = s.with_clock(Arc::new(|| 2000));
+        let updated = s.update_item(&item.id, Some("Mower"), Some("part"), None).unwrap();
+        assert_eq!(updated.text, "Mower");
+        assert_eq!(updated.kind, "part");
+        assert_eq!(updated.right, "");
+        assert_eq!(updated.done, item.done, "done preserved");
+        assert_eq!(updated.id, item.id, "id preserved");
+        assert_eq!(updated.created_at, item.created_at, "created_at preserved");
+        assert_eq!(updated.source, item.source, "source preserved");
+        assert_eq!(updated.updated_at, 2000, "updated_at bumped");
+        // the DB read reflects the same fields, not just the returned echo
+        assert_eq!(s.get_item(&item.id).unwrap(), updated);
+    }
+
+    #[test]
+    fn update_item_right_only_leaves_text_and_kind_alone() {
+        let (s, sid) = store_with_session();
+        let item = s.add_item(&sid, "part", "bark mulch").unwrap();
+        let updated = s.update_item(&item.id, None, None, Some("3 CU YD")).unwrap();
+        assert_eq!(updated.right, "3 CU YD");
+        assert_eq!(updated.text, "bark mulch");
+        assert_eq!(updated.kind, "part");
+        assert_eq!(s.get_item(&item.id).unwrap().right, "3 CU YD", "right round-trips");
+    }
+
+    #[test]
+    fn all_none_update_bumps_updated_at_and_changes_nothing_else() {
+        let (s, sid) = store_with_session();
+        let item = s.add_item(&sid, "todo", "order lumber").unwrap();
+        let s = s.with_clock(Arc::new(|| 3000));
+        let updated = s.update_item(&item.id, None, None, None).unwrap();
+        assert_eq!(updated.updated_at, 3000);
+        assert_eq!(
+            CapturedItem { updated_at: item.updated_at, ..updated },
+            item,
+            "everything except updated_at is unchanged"
+        );
+    }
+
+    #[test]
+    fn update_item_on_tombstoned_id_is_not_found() {
+        let (s, sid) = store_with_session();
+        let item = s.add_item(&sid, "todo", "x").unwrap();
+        s.delete_item(&item.id).unwrap();
+        assert!(matches!(
+            s.update_item(&item.id, Some("y"), None, None),
+            Err(CoreError::NotFound { entity: "item", .. })
+        ));
+    }
+
+    #[test]
+    fn kind_retag_moves_item_in_and_out_of_open_todos() {
+        // The WE-A/WE-C cascade, both directions: a kind edit re-files the
+        // item for the morning glance without removing it from the session.
+        let (s, sid) = store_with_session();
+        let b1 = s.add_item(&sid, "todo", "call supplier").unwrap();
+        let b2 = s.add_item(&sid, "todo", "order sod").unwrap();
+        let open = |s: &Store| -> Vec<String> {
+            s.list_open_todos().unwrap().into_iter().map(|i| i.id).collect()
+        };
+        assert_eq!(open(&s), vec![b1.id.clone(), b2.id.clone()]);
+
+        s.update_item(&b1.id, None, Some("part"), None).unwrap();
+        assert_eq!(open(&s), vec![b2.id.clone()], "todo -> part drops B1 from the glance");
+        assert_eq!(s.list_items_for_session(&sid).unwrap().len(), 2,
+            "re-filed, not removed — B1 stays in the session");
+
+        s.update_item(&b1.id, None, Some("todo"), None).unwrap();
+        assert_eq!(open(&s), vec![b1.id, b2.id], "part -> todo re-adds B1");
     }
 
     #[test]

--- a/crates/murmur-core/src/store/migrations.rs
+++ b/crates/murmur-core/src/store/migrations.rs
@@ -140,6 +140,15 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     CREATE UNIQUE INDEX idx_photos_filename_live ON photos(filename) WHERE deleted_at IS NULL;
     CREATE INDEX idx_photos_session ON photos(session_id) WHERE deleted_at IS NULL;
     "#,
+    // v6: items.right_text (Plan 16) — the quantity/unit string ("3 CU YD",
+    // "× 4"). Named right_text, NOT right: RIGHT is a SQL keyword (SQLite
+    // ≥3.39 RIGHT JOIN), a reserved-word footgun in a bare SELECT column
+    // list; the domain field stays `right` (matches BoardItem.right).
+    // Quantity, never price — pricing stays document-only (keeper D-#2).
+    // ADD COLUMN with NOT NULL requires the DEFAULT (the v2 precedent).
+    r#"
+    ALTER TABLE items ADD COLUMN right_text TEXT NOT NULL DEFAULT '';
+    "#,
 ];
 
 pub(crate) fn migrate(conn: &Connection) -> Result<(), CoreError> {

--- a/crates/murmur-core/src/store/photos.rs
+++ b/crates/murmur-core/src/store/photos.rs
@@ -194,7 +194,7 @@ mod tests {
     fn migrates_to_v5() {
         let s = Store::open_in_memory("device-a").unwrap();
         let v: i64 = s.conn.pragma_query_value(None, "user_version", |r| r.get(0)).unwrap();
-        assert_eq!(v, 5, "photos migration bumps user_version to 5");
+        assert!(v >= 5, "photos migration bumps user_version to at least 5 (v6 added items.right_text, Plan 16)");
     }
 
     #[test]


### PR DESCRIPTION
## Thinking

Implements Plan 16 Rev 2 (#216) — the item CRUD seam from sac's editable-notes design (#215). The design's one-source-of-truth thesis is now enforced end-to-end: `update_item` / `add_item` / `remove_item` mutate the core store, so every later `buildDocument` reflects the correction for free — the misheard "Power edger" can finally become "Mower" on the actual PDF.

Review-won invariants, all landed with pins: migration v6 adds `right_text` (quantity, not price) under the transactional per-migration discipline; ONE kind allowlist (the review found a third copy hiding in the agent tool's JSON schema — all three now build from a single const, with a test pinning schema == const); edits are Processed-only via a same-lock status-check-then-write; the update echo returns honest photo counts (an empty-counts echo would have invited UI-side state patching); tombstone remove is distinct from done, with the kind-re-tag ↔ open-todos cascade pinned in both directions; NO `record_correction` — deferred whole to Plan 17 per the Rev 2 decision (a negative test pins the counter stays 0 across all five mutations).

Worked examples WE-A..WE-D are exact-count tests against the real DocumentBuilder. `// sac:` contract carries the three Rev 2 clauses: edit affordances gate on `!notes.queued` (a Failed session's notes screen shows items the engine will refuse to edit — same rule as your build buttons), fresh-read from the engine is the only post-edit path, and core `right` = quantity (narrower than the demo fixtures' chrome — fixtures untouched).

Flagged divergence, deliberate: the Swift protocol returns `CapturedFixture` (the app's BoardItem mirror), not FFI `BoardItem` — that type doesn't exist on the demo build; same pattern as `attachPhoto` returning `PhotoModel`.

## Gates

cargo test --workspace 0 (murmur-core 201, ffi 67) · clippy -D warnings 0 · demo build SUCCEEDED · VocabPackTests SUCCEEDED · bindings regen additive (+109: three methods + EngineError.Item), drift gate 0. FFI surface changed → Task 6 manual real-core gate runs before merge.
