### PR TITLE
Delete the never-constructed SpeechSource fallback + its plist key (dam ruling)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -419,7 +419,7 @@ final class AppModel {
         Task {
             // Flush before finish (issue #155 / CANON: flush over speed —
             // the last words of a walk are often the price). `stop()` lets a
-            // final speech result land (grace-bounded in SpeechSource); the
+            // final speech result land (grace-bounded by the source); the
             // pump ends when the source's stream finishes, so awaiting it
             // guarantees every flushed chunk reached engine.append first.
             _ = await pumpTask?.value

--- a/apps/ios/Sources/App/Info.plist
+++ b/apps/ios/Sources/App/Info.plist
@@ -28,8 +28,6 @@
 	<string>Photos you take during a walk pin to the item you're describing and land in the finished document.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Sitewalk records your walk-and-talk so it can turn it into paperwork.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Sitewalk transcribes your walk on-device to build your document.</string>
 	<key>PPQ_API_KEY</key>
 	<string>$(PPQ_API_KEY)</string>
 	<key>UIAppFonts</key>

--- a/apps/ios/Sources/Engine/AudioCaptureSource.swift
+++ b/apps/ios/Sources/Engine/AudioCaptureSource.swift
@@ -16,8 +16,8 @@ protocol PCMAudioSource: AnyObject {
 }
 
 // Live mic capture for the STT-in-Rust path (Plan 08 D1). The audio session,
-// permissions, and interruption handling stay in Swift (exactly as SpeechSource
-// does today); an AVAudioEngine tap + AVAudioConverter down-mix/resample to
+// permissions, and interruption handling stay in Swift (exactly as the old
+// SpeechSource fallback did); an AVAudioEngine tap + AVAudioConverter down-mix/resample to
 // 16 kHz mono f32 (what whisper wants — SttConfig.sample_rate), and the PCM is
 // pushed across FFI OFF the render thread. Rust never touches the mic.
 //
@@ -92,8 +92,8 @@ final class AudioCaptureSource: PCMAudioSource {
         let hwFormat = input.outputFormat(forBus: 0)
         guard let converter = AVAudioConverter(from: hwFormat, to: targetFormat) else { return }
 
-        // Capture only Sendable locals in the render-thread closure (mirrors
-        // SpeechSource) so nothing hops the @MainActor boundary on the hot path.
+        // Capture only Sendable locals in the render-thread closure so nothing
+        // hops the @MainActor boundary on the hot path.
         let target = targetFormat
         let deliver = deliveryQueue
         let push = pushSamples

--- a/apps/ios/Sources/Engine/TranscriptSource.swift
+++ b/apps/ios/Sources/Engine/TranscriptSource.swift
@@ -1,21 +1,18 @@
 import Foundation
-import AVFoundation
-import Speech
 
-// TranscriptSource feeds TEXT to the engine (the scripted/demo path). Two
-// sources share one interface:
+// TranscriptSource feeds TEXT to the engine (the scripted/demo path):
 //
 //   ScriptedSource — deterministic canned walk for demos, simulator work, and
 //                    screenshot verification. Also the operator-facing demo mode.
-//   SpeechSource   — AVAudioEngine + SFSpeechRecognizer, on-device when available.
 //
-// Plan 08 note: STT for the LIVE walk (`live=1`) is now RUST-side whisper —
+// Plan 08 note: STT for the LIVE walk (`live=1`) is RUST-side whisper —
 // `AudioCaptureSource` captures mic PCM and pushes it across FFI via
 // `WalkSession.push_audio`, and the transcript arrives back as
-// `WalkEvent.transcriptCommitted`. `SpeechSource` (SFSpeechRecognizer) is
-// retained as a fallback and is no longer the live default (delete nothing,
-// D10). `AudioCaptureSource` is intentionally NOT a `TranscriptSource` — it
-// produces PCM, not text.
+// `WalkEvent.transcriptCommitted`. `SpeechSource` (the SFSpeechRecognizer
+// fallback retained under Plan 08 D10 "delete nothing") was never constructed
+// anywhere and was deleted — together with the NSSpeechRecognitionUsageDescription
+// plist key — per dam's 2026-07-14 ruling. `AudioCaptureSource` is
+// intentionally NOT a `TranscriptSource` — it produces PCM, not text.
 
 @MainActor
 protocol TranscriptSource: AnyObject {
@@ -83,101 +80,4 @@ final class ScriptedSource: TranscriptSource {
         continuation.finish()
     }
     func abort() { stop() }
-}
-
-// MARK: - Live microphone source
-
-@MainActor
-final class SpeechSource: TranscriptSource {
-    let chunks: AsyncStream<String>
-    private let continuation: AsyncStream<String>.Continuation
-
-    private let audioEngine = AVAudioEngine()
-    private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
-    private var request: SFSpeechAudioBufferRecognitionRequest?
-    private var recognition: SFSpeechRecognitionTask?
-    private var delivered = ""
-
-    init() {
-        var cont: AsyncStream<String>.Continuation!
-        chunks = AsyncStream { cont = $0 }
-        continuation = cont
-    }
-
-    static func requestPermissions() async -> Bool {
-        let mic = await AVAudioApplication.requestRecordPermission()
-        let speech = await withCheckedContinuation { cont in
-            SFSpeechRecognizer.requestAuthorization { cont.resume(returning: $0 == .authorized) }
-        }
-        return mic && speech
-    }
-
-    func start() {
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        if recognizer?.supportsOnDeviceRecognition == true {
-            request.requiresOnDeviceRecognition = true
-        }
-        self.request = request
-
-        let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.record, mode: .measurement, options: .duckOthers)
-        try? session.setActive(true, options: .notifyOthersOnDeactivation)
-
-        let input = audioEngine.inputNode
-        let format = input.outputFormat(forBus: 0)
-        input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
-            request.append(buffer)
-        }
-        audioEngine.prepare()
-        try? audioEngine.start()
-
-        recognition = recognizer?.recognitionTask(with: request) { [weak self] result, _ in
-            guard let self, let result else { return }
-            let text = result.bestTranscription.formattedString
-            // Deliver only the newly appended tail.
-            Task { @MainActor in
-                if text.count > self.delivered.count, text.hasPrefix(self.delivered) {
-                    let tail = String(text.dropFirst(self.delivered.count))
-                    self.delivered = text
-                    self.continuation.yield(tail)
-                } else if text != self.delivered {
-                    self.delivered = text
-                    self.continuation.yield(" " + text)
-                }
-                // Final result after a flush → close immediately rather than
-                // waiting out stop()'s grace ceiling.
-                if result.isFinal {
-                    self.continuation.finish()
-                }
-            }
-        }
-    }
-
-    func pause() { audioEngine.pause() }
-    func resume() { try? audioEngine.start() }
-
-    /// Flush: stop the mic but let recognition FINISH the audio it already
-    /// has — `cancel()` here dropped the final utterance (issue #155; CANON:
-    /// flush over speed). The stream closes when the final result lands, with
-    /// a 1.5s grace ceiling so a stalled recognizer can't hang finishWalk().
-    func stop() {
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
-        request?.endAudio()
-        recognition?.finish()
-        Task { [weak self] in
-            try? await Task.sleep(for: .seconds(1.5))
-            self?.continuation.finish()
-        }
-    }
-
-    /// Drop everything in flight — discard path, nothing is kept.
-    func abort() {
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
-        request?.endAudio()
-        recognition?.cancel()
-        continuation.finish()
-    }
 }

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -39,7 +39,6 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: "Sitewalk records your walk-and-talk so it can turn it into paperwork."
-        NSSpeechRecognitionUsageDescription: "Sitewalk transcribes your walk on-device to build your document."
         NSCameraUsageDescription: "Photos you take during a walk pin to the item you're describing and land in the finished document."
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## Thinking

dam's ruling (2026-07-14): delete the SFSpeechRecognizer fallback, class and plist key together. `SpeechSource` was retained under Plan 08 D10's "delete nothing" posture but has never been constructed — whisper is field-proven across TF builds 34–41 — and the #211 sweep established the two halves must go as one (removing only `NSSpeechRecognitionUsageDescription` would have left a crash trap if anything ever constructed the class).

Verification before deletion: zero constructions anywhere in apps/ios (all references outside the definition were comments); `import Speech`/`SFSpeechRecognizer` lived only inside the class; the plist key existed in project.yml + Info.plist only (real/release ymls compose the base config, so one removal covers all three projects). Mic permissions (`AVAudioApplication`) untouched — that's a different framework.

Diff is purely subtractive (+12/−115): class + both now-unused imports deleted, key removed from project.yml and Info.plist, the D10 header note rewritten to record the ruling, three comments retensed so they stop describing a deleted class as live. `TranscriptSource` protocol and `ScriptedSource` remain — still in use.

## Gates

cargo test --workspace 0 · demo build SUCCEEDED. No FFI surface, no Rust changes — demo CI fully covers this.
