### PR TITLE
skill: asc-feedback — fetch TestFlight beta feedback via the ASC API

### DIFF
--- a/.claude/skills/asc-feedback/SKILL.md
+++ b/.claude/skills/asc-feedback/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: asc-feedback
+description: Fetch TestFlight beta feedback (screenshots, comments, crashes) for Jefe via the App Store Connect API. Use when someone says they left TestFlight feedback, or when debugging a field report from a beta build.
+---
+
+# ASC Beta Feedback — fetch
+
+Pull TestFlight beta feedback submissions straight from the App Store Connect API
+using the damsac team key. Fetching only — triage/issues/fixes are the caller's
+business.
+
+## Prerequisites
+
+A team ASC API key (App Manager role suffices) seeded at `~/secrets/apple/`:
+
+- `asc_key_id` — the key id (10 chars)
+- `asc_issuer_id` — the issuer UUID
+- `AuthKey.p8` — the private key
+
+dam's machine has these; sac: ask dam for the trio once, seed the dir, never
+commit them. The script reads them itself and never prints key material.
+
+Python needs the `cryptography` package (`pip3 install cryptography` if missing).
+
+## The tool
+
+`asc-feedback.py` (this directory) — a minimal authenticated GET client for any
+App Store Connect v1 endpoint:
+
+```bash
+python3 .claude/skills/asc-feedback/asc-feedback.py "<ASC API path>" [--raw]
+```
+
+## Recipe
+
+1. **Resolve Jefe's app id** (bundle id `com.isaacwm.murmur`):
+
+```bash
+python3 asc-feedback.py "/v1/apps?filter[bundleId]=com.isaacwm.murmur" | jq -r '.data[0].id'
+```
+
+2. **List screenshot-feedback submissions** (comments + device metadata + image URLs):
+
+```bash
+python3 asc-feedback.py "/v1/apps/<APP_ID>/betaFeedbackScreenshotSubmissions?limit=50"
+```
+
+Useful fields per submission: `.attributes.comment`, `.attributes.createdDate`,
+`.attributes.deviceModel` / `.osVersion`, `.attributes.screenshots[]` (each has a
+signed `url` with an `expirationDate` — about a week), `.relationships.build.data.id`.
+
+3. **List crash-feedback submissions**:
+
+```bash
+python3 asc-feedback.py "/v1/apps/<APP_ID>/betaFeedbackCrashSubmissions?limit=50"
+```
+
+4. **Download screenshots** (plain signed URLs, no auth header needed):
+
+```bash
+jq -r '.data[] | .id as $id | (.attributes.screenshots // [])[] | "\($id) \(.url)"' subs.json |
+while read -r id url; do curl -sL "$url" -o "${id}.jpg"; done
+```
+
+5. **Resolve a build id to its build number** (feedback references builds by UUID):
+
+```bash
+python3 asc-feedback.py "/v1/builds/<BUILD_ID>" | jq -r '.data.attributes.version'
+```
+
+## Notes
+
+- Screenshot URLs expire — download promptly.
+- Works for any app on the team key (Athanor `com.damsac.athanor`, Weave
+  `com.damsac.weave`) — just swap the bundle id.
+- Precedent: dam's 9-submission build-44 batch became issues #220–#228 via this
+  flow; screenshots for issues live on the `feedback-assets` orphan branch.

--- a/.claude/skills/asc-feedback/asc-feedback.py
+++ b/.claude/skills/asc-feedback/asc-feedback.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Minimal App Store Connect API client. Prints API responses only; never prints key material."""
+import base64, json, sys, time, urllib.request
+from pathlib import Path
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+SEC = Path.home() / "secrets" / "apple"
+KEY_ID = (SEC / "asc_key_id").read_text().strip()
+ISSUER = (SEC / "asc_issuer_id").read_text().strip()
+PKEY = serialization.load_pem_private_key((SEC / "AuthKey.p8").read_bytes(), password=None)
+
+def b64u(b): return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+def token():
+    now = int(time.time())
+    header = b64u(json.dumps({"alg": "ES256", "kid": KEY_ID, "typ": "JWT"}).encode())
+    payload = b64u(json.dumps({"iss": ISSUER, "iat": now, "exp": now + 900,
+                               "aud": "appstoreconnect-v1"}).encode())
+    signing_input = f"{header}.{payload}".encode()
+    der = PKEY.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(der)
+    sig = b64u(r.to_bytes(32, "big") + s.to_bytes(32, "big"))
+    return f"{header}.{payload}.{sig}"
+
+def get(path, raw=False):
+    url = path if path.startswith("http") else f"https://api.appstoreconnect.apple.com{path}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token()}"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            body = r.read()
+            return body if raw else json.loads(body)
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code} for {url}\n{e.read().decode()[:2000]}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    out = get(sys.argv[1], raw="--raw" in sys.argv)
+    if isinstance(out, bytes):
+        sys.stdout.buffer.write(out)
+    else:
+        print(json.dumps(out, indent=1))


### PR DESCRIPTION
## Thinking

The field-feedback loop proved itself this week (dam's 9 build-44 submissions → ground-truthed issues #220–#228, plus two factory-app bugs found from operator screenshots), but the fetch tooling lived only on dam's machine. This puts the fetch skill in the repo so sac's sessions have it too: a minimal JWT'd ASC GET client + the five-step recipe (app id → screenshot/crash submissions → image download → build-number resolution).

Fetch-only by design — what to do with feedback stays the caller's call. sac: you need the team ASC key trio in `~/secrets/apple/` once (ask dam — never committed; the script never prints key material).

Docs/skill-only; no publish fires (`.claude/` isn't in the app).