### PR TITLE
fix(ios): lock light appearance — dark mode no longer whites out text (#220)

### DIFF
--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -33,6 +33,10 @@ targets:
         # the key; empty => provider default (api.anthropic.com).
         ANTHROPIC_BASE_URL: "$(ANTHROPIC_BASE_URL)"
         CFBundleDisplayName: Sitewalk
+        # Fixed paper-and-ink theme: lock light appearance so system dark mode
+        # never falls un-styled Text back to the white system label color on the
+        # always-light paper (issue #220 — invisible board title / vocab / rows).
+        UIUserInterfaceStyle: Light
         # App uses only exempt (HTTPS/TLS) encryption — no custom crypto. Without
         # this, every TestFlight build sits on a manual "Missing Compliance"
         # answer in ASC before testers can install it.


### PR DESCRIPTION
Closes #220.

**Bug (build-44 beta feedback):** the app paints a fixed light paper theme, but nothing forced a color scheme — so in **system dark mode**, every `Text` without an explicit `.foregroundStyle` fell back to the white system label color on the light paper. Board title, vocab editor title/terms, and document rows all went near-invisible (also the root cause dam cross-referenced for the 'blank' work order, #222).

**Fix:** `UIUserInterfaceStyle = Light` in the Info.plist (via project.yml). It's the canonical declaration for a fixed-theme app — locks the whole app to light, including system UI (share sheet, keyboard, alerts), which a root `.preferredColorScheme(.light)` wouldn't fully cover. Also the right posture for App Store review.

**Verified:** built + launched on the iPhone 17 sim with the simulator set to **dark mode** — 'Ready to walk' and the rows render ink-on-paper, no white ghost text.

Follow-up (not here): a deliberate dark paper variant someday, if wanted; until then this is correct.