### PR TITLE
feat(ios): first-run coach marks — START WALK + DONE

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -49,6 +49,11 @@ struct AppRoot: View {
         // screenshots — no taps available in simctl).
         let args = ProcessInfo.processInfo.arguments
         if args.contains("resetprofile=1") { BusinessProfile.clear() }
+        // resetcoach=1 re-arms the first-run coach marks (parallel to
+        // resetprofile) so they can be captured/verified on a warm sim.
+        if args.contains("resetcoach=1") {
+            for key in CoachMarks.allKeys { UserDefaults.standard.removeObject(forKey: key) }
+        }
         if args.contains("autoprofile=1") {
             BusinessProfile.save(BusinessProfile(
                 businessName: "Testflight Lawn Co",
@@ -78,6 +83,9 @@ struct AppRoot: View {
         // screen and needs a SKIP/DONE tap, so mark it shown for autoflow runs.
         if autoflowRounds > 0 {
             UserDefaults.standard.set(true, forKey: NotesView.vocabCardShownKey)
+            // Coach marks are non-blocking, but keep the scripted screenshots
+            // clean by marking them shown for autoflow runs.
+            for key in CoachMarks.allKeys { UserDefaults.standard.set(true, forKey: key) }
         }
         _needsOnboarding = State(initialValue: BusinessProfile.current == nil && autoflowRounds == 0)
         // Mode is a USER choice (persisted, board chip) unless a launch arg

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -10,6 +10,8 @@ struct BoardView: View {
     // call; a gear → .sheet is a functional default, not a design decision.
     @State private var showVocabulary = false
     @State private var showLetterhead = false
+    // First-run coach mark, one-shot (survives relaunch). Cleared by resetcoach=1.
+    @AppStorage(CoachMarks.startWalkKey) private var coachStartShown = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -183,7 +185,20 @@ struct BoardView: View {
 
             Spacer(minLength: 0)
 
+            // First-run coach mark: point a brand-new operator at the one thing
+            // to do. Only on a fresh board (profile set, no walks yet); the
+            // START button below stays fully tappable (non-blocking hint).
+            if !coachStartShown && model.profile != nil && model.sessionWalks.isEmpty {
+                CoachCallout(text: "Ready? Tap START WALK and just talk — walk the job like you're telling a helper.") {
+                    coachStartShown = true
+                }
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.bottom, 4)
+                .transition(.opacity)
+            }
+
             Button {
+                coachStartShown = true
                 model.startWalk()
             } label: {
                 WalkButton()
@@ -192,6 +207,7 @@ struct BoardView: View {
             .padding(.horizontal, Theme.S.screenPad)
             .padding(.bottom, 10)
         }
+        .animation(.easeOut(duration: 0.25), value: coachStartShown)
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
         .sheet(isPresented: $showVocabulary) {
@@ -205,6 +221,60 @@ struct BoardView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
                 .presentationBackground(Theme.C.paper)
+        }
+    }
+}
+
+// MARK: - Coach marks (first-run hints)
+
+/// Persisted one-shot flags for the first-run coach marks. Centralized so the
+/// GalleryApp QA hooks (resetcoach / autoflow) and the call sites agree.
+enum CoachMarks {
+    static let startWalkKey = "coach.startWalk.shown"
+    static let doneKey = "coach.done.shown"
+    static let allKeys = [startWalkKey, doneKey]
+}
+
+/// A soft amber callout that points at the button directly beneath it. Chosen
+/// over a dark spotlight overlay on purpose: it stays in the field-instrument
+/// grammar (paper + amber, not a flashy tour) and it's non-blocking — the
+/// target button underneath stays tappable, so it never traps the flow. One-
+/// shot gating lives at the call site (an @AppStorage flag).
+struct CoachCallout: View {
+    let text: String
+    /// Where the downward caret sits, so it aims at the real target (a full-
+    /// width button → .center; DONE in a control row → .trailing).
+    var pointer: Alignment = .center
+    var dismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(text)
+                    .font(Theme.F.cond(13.5, .semibold))
+                    .foregroundStyle(Theme.C.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Button(action: dismiss) {
+                    Text("GOT IT")
+                        .font(Theme.F.mono(9, .semibold))
+                        .tracking(1.0)
+                        .foregroundStyle(Theme.C.orangeDeep)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 13)
+            .padding(.vertical, 11)
+            .background(Theme.C.orangeTint)
+            .overlay(Rectangle().stroke(Theme.C.orange, lineWidth: 1.5))
+
+            Text("▾")
+                .font(Theme.F.ui(15, .bold))
+                .foregroundStyle(Theme.C.orange)
+                .frame(maxWidth: .infinity, alignment: pointer)
+                .padding(.horizontal, 34)
+                .offset(y: -2)
         }
     }
 }

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -9,6 +9,8 @@ struct WalkView: View {
     @State private var showCamera = false
     @State private var pickerItem: PhotosPickerItem?
     @State private var showDiscardConfirm = false
+    // First-run DONE hint, one-shot (survives relaunch). Cleared by resetcoach=1.
+    @AppStorage(CoachMarks.doneKey) private var coachDoneShown = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -47,6 +49,17 @@ struct WalkView: View {
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
                 }
+            }
+
+            // First-run DONE hint: appears once anything is captured (so it
+            // shows exactly when DONE becomes tappable), pointing at DONE.
+            if !coachDoneShown && !(model.transcript.isEmpty && model.items.isEmpty) {
+                CoachCallout(text: "All done talking? Tap DONE — Jefe writes up your notes and paperwork.", pointer: .trailing) {
+                    coachDoneShown = true
+                }
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.bottom, 2)
+                .transition(.opacity)
             }
 
             VStack(spacing: 12) {
@@ -106,7 +119,7 @@ struct WalkView: View {
                     // gating on items alone stranded the user on a stuck screen
                     // whenever items hadn't landed yet. Transcript-or-items.
                     let nothingCaptured = model.transcript.isEmpty && model.items.isEmpty
-                    Button { model.finishWalk() } label: { DoneButton() }
+                    Button { coachDoneShown = true; model.finishWalk() } label: { DoneButton() }
                         .buttonStyle(.plain)
                         .frame(maxWidth: .infinity)
                         .disabled(nothingCaptured)
@@ -118,6 +131,7 @@ struct WalkView: View {
             .padding(.bottom, 10)
             .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
         }
+        .animation(.easeOut(duration: 0.25), value: coachDoneShown)
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
## Thinking

The onboarding intro (#236) teaches *what the app does*. Coach marks close the last gap: the moment a brand-new operator lands on a real screen and has to actually **do** something. Two beats, one per screen, matching the two things a first-timer has to learn:

1. **START WALK** — on the fresh board, "the one thing to do."
2. **DONE** — during the walk, "how you finish."

Design call: these are **soft amber callouts with a caret**, not a dark spotlight tour. Two reasons. First, it stays in the field-instrument grammar (paper + amber) — a dimmed-screen coach tour would feel like exactly the flashy consumer-app thing this product deliberately avoids. Second, it's **non-blocking**: the real button stays tappable underneath, so the hint can never trap the flow (it also means autoflow/CI never stalls on it).

Both are **one-shot** and honest about timing: the DONE hint only appears once *something is captured*, i.e. exactly when DONE becomes tappable — so we never point at a disabled button.

## What changed

- `BoardView` — `@AppStorage(CoachMarks.startWalkKey)`; callout above START WALK when `profile != nil && sessionWalks.isEmpty && !shown`. Tapping START or GOT IT marks it shown.
- `WalkView` — `@AppStorage(CoachMarks.doneKey)`; callout above the control cluster when `!(transcript && items both empty) && !shown`, caret aimed at DONE (`pointer: .trailing`). Tapping DONE or GOT IT marks it shown.
- `CoachCallout` + `CoachMarks` (keys) — new, in `BoardView.swift` (shared, no new file → no project regen needed to build).
- `GalleryApp` — `resetcoach=1` re-arms both; autoflow marks them shown (clean scripted screenshots).

## Verification

- `BUILD SUCCEEDED` (iPhone 17 sim), on a `main`-based branch (independent of #236 — different files).
- START callout rendered on a fresh operator board on-sim (amber callout, GOT IT, caret pointing at START WALK). DONE reuses the same `CoachCallout` component.

## Follow-up

- Optional guided practice walk (last piece of the onboarding set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)