### PR TITLE
feat(ios): optional practice walk — scripted, unsaved dry run

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -220,6 +220,12 @@ final class AppModel {
     /// occasionally cold-load) engine bring-up runs behind the painted screen.
     var micStarting = false
 
+    /// A scripted, unsaved "practice run" armed from onboarding's optional
+    /// offer. While set, the next walk plays demo content regardless of the
+    /// persisted mode (a first-timer needn't know what to say) AND never lands
+    /// on the real board — cleared the moment the practice run leaves the flow.
+    private(set) var isPracticeWalk = false
+
     /// When live, drive the STT path from a bundled fixture WAV instead of the
     /// mic (`wavwalk=1`, D7) — a mic-free way to exercise real whisper.
     private let wavFixture: Bool
@@ -235,8 +241,9 @@ final class AppModel {
     var makeScriptedSource: (TradeFixture) -> TranscriptSource = { ScriptedSource(trade: $0) }
 
     init(engine: WalkEngine? = nil, forcedMode: WalkMode? = nil, wavFixture: Bool = false,
-         voiceProcessing: Bool = false) {
+         voiceProcessing: Bool = false, practiceArmed: Bool = false) {
         self.engine = engine ?? DemoWalkEngine()
+        self.isPracticeWalk = practiceArmed  // QA: practice=1 lands on a practice board
         if let forcedMode {
             self.walkMode = forcedMode
             self.modeLocked = true
@@ -270,6 +277,32 @@ final class AppModel {
         if walkMode == .demo { micDenied = false }
     }
 
+    /// Arm the optional practice walk (onboarding's "try a practice walk"): a
+    /// scripted dry run that is never saved. We deliberately do NOT touch
+    /// `walkMode` — the persisted default stays whatever the operator will
+    /// really use — and just land on the board so the START coach mark + the
+    /// PRACTICE marker frame it.
+    func armPracticeWalk() {
+        isPracticeWalk = true
+        micDenied = false
+        phase = .board
+        path = []
+    }
+
+    /// Exit an active practice run to the board WITHOUT logging it or flipping a
+    /// job. Returns true if a practice run was active (the caller should stop).
+    @discardableResult
+    private func exitPracticeIfActive() -> Bool {
+        guard isPracticeWalk else { return false }
+        isPracticeWalk = false
+        shareURL = nil
+        document = nil
+        notes = nil
+        phase = .board
+        path = []
+        return true
+    }
+
     // MARK: Trade switching (validation strategy: same bones, swappable template)
 
     func switchTrade(_ newTrade: TradeFixture) {
@@ -284,7 +317,7 @@ final class AppModel {
     /// Returns immediately when already authorized; first-ever tap shows the
     /// system prompt. Denied → `micDenied` surfaces on the board.
     func startWalk() {
-        if walkMode == .voice && !wavFixture {
+        if walkMode == .voice && !wavFixture && !isPracticeWalk {
             Task { [weak self] in
                 guard let self else { return }
                 if await AudioCaptureSource.requestPermissions() {
@@ -382,7 +415,9 @@ final class AppModel {
                 }
             }
 
-            if self.walkMode == .demo {
+            // Practice runs play the scripted demo content regardless of the
+            // persisted mode (a first-timer needn't know what to say).
+            if self.walkMode == .demo || self.isPracticeWalk {
                 self.startScriptedSource()
             } else {
                 self.startAudioSource()
@@ -516,6 +551,7 @@ final class AppModel {
         notes = nil
         documentBuildError = nil
         notesEditError = nil
+        isPracticeWalk = false
         phase = .board
         path = []
     }
@@ -611,6 +647,7 @@ final class AppModel {
     /// unlike `discardWalk()` (which cancels a still-live session). Just
     /// resets local UI state.
     func dismissNotes() {
+        isPracticeWalk = false
         notes = nil
         documentBuildError = nil
         notesEditError = nil
@@ -941,6 +978,9 @@ final class AppModel {
     }
 
     func completeSend() {
+        // A practice run shows the whole loop (incl. the share sheet) but is
+        // never recorded — no board log, no job flip.
+        if exitPracticeIfActive() { return }
         if let index = jobs.firstIndex(where: { !$0.done }) {
             let old = jobs[index]
             jobs[index] = JobFixture(
@@ -964,6 +1004,7 @@ final class AppModel {
     /// to SENT). The persisted core artifact is untouched — only the app-side
     /// review state resets.
     func discardDocument() {
+        if exitPracticeIfActive() { return }
         sessionWalks.append(WalkRecord(
             time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: false,
             sessionId: currentSessionId ?? "", queued: notes?.queued ?? false

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -188,6 +188,14 @@ final class AppModel {
     // Not fully `private`: read from AppModel+Photos.swift (a same-module
     // extension in a different file — Swift's `private` is file-scoped).
     private(set) var engine: WalkEngine
+    /// The real engine, parked while a practice run borrows a throwaway
+    /// `DemoWalkEngine` (F1, dam's #238 review): a practice walk must NOT touch
+    /// the real store. Swapping the engine gives structural isolation — on
+    /// real-core, `begin`/`append`/`finish`/`buildDocument` would otherwise all
+    /// persist a phantom session+items+document (demo-only CI can't see it,
+    /// since the demo engine never persists). Non-nil ⇔ a practice run is
+    /// borrowing the demo engine; restored on every practice-exit path.
+    private var suspendedEngine: WalkEngine?
     private var source: TranscriptSource?
     /// The live PCM source (Plan 08): used instead of `source` when
     /// `!scripted`. Produces PCM (not text) — STT is Rust-side whisper. Either
@@ -284,9 +292,26 @@ final class AppModel {
     /// PRACTICE marker frame it.
     func armPracticeWalk() {
         isPracticeWalk = true
+        // F1 (dam's #238 review): park the real engine and run the practice
+        // walk against a throwaway DemoWalkEngine so the full lifecycle stays
+        // off the real store. Idempotent — arm is only reached from onboarding,
+        // but guard against a double-arm leaking the real engine reference.
+        if suspendedEngine == nil {
+            suspendedEngine = engine
+            engine = DemoWalkEngine()
+        }
         micDenied = false
         phase = .board
         path = []
+    }
+
+    /// Restore the real engine after a practice run. No-op outside practice
+    /// (`suspendedEngine` is nil), so it's safe to call from every exit path.
+    private func restoreEngineAfterPractice() {
+        if let real = suspendedEngine {
+            engine = real
+            suspendedEngine = nil
+        }
     }
 
     /// Exit an active practice run to the board WITHOUT logging it or flipping a
@@ -295,6 +320,7 @@ final class AppModel {
     private func exitPracticeIfActive() -> Bool {
         guard isPracticeWalk else { return false }
         isPracticeWalk = false
+        restoreEngineAfterPractice()
         shareURL = nil
         document = nil
         notes = nil
@@ -552,6 +578,9 @@ final class AppModel {
         documentBuildError = nil
         notesEditError = nil
         isPracticeWalk = false
+        // Restore AFTER the local `engine` capture above cancelled the
+        // throwaway demo session (F1); safe no-op for a real discard.
+        restoreEngineAfterPractice()
         phase = .board
         path = []
     }
@@ -648,6 +677,7 @@ final class AppModel {
     /// resets local UI state.
     func dismissNotes() {
         isPracticeWalk = false
+        restoreEngineAfterPractice()
         notes = nil
         documentBuildError = nil
         notesEditError = nil

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -63,6 +63,15 @@ struct AppRoot: View {
                 tradeKey: "landscape"
             ))
         }
+        // practice=1: land straight on a practice board — stamps a profile (so
+        // onboarding is skipped) and arms the scripted, unsaved practice run.
+        let practiceArg = args.contains("practice=1")
+        if practiceArg {
+            BusinessProfile.save(BusinessProfile(
+                businessName: "Testflight Lawn Co", cityState: "Denver CO",
+                licenseNumber: "44-1234", tradeKey: "landscape"
+            ))
+        }
         // QA hooks for the Letterhead Studio (parallel to autoprofile): stamp a
         // sample branding so headless screenshots exercise a customized letterhead.
         if args.contains("resetbrand=1") { Branding.save(.default); DocumentLayout.save(.default) }
@@ -108,7 +117,8 @@ struct AppRoot: View {
                 engine: resolveEngine(demo: demo),
                 forcedMode: forcedMode,
                 wavFixture: wavwalk,
-                voiceProcessing: voiceProcessing
+                voiceProcessing: voiceProcessing,
+                practiceArmed: practiceArg
             )
         )
     }
@@ -117,9 +127,12 @@ struct AppRoot: View {
         if needsOnboarding {
             // First run: no business profile yet — the paperwork can't carry
             // the operator's name until this arc completes.
-            OnboardingFlow {
+            OnboardingFlow { startPractice in
                 model.reloadProfile()
                 withAnimation(.easeOut(duration: 0.3)) { needsOnboarding = false }
+                // Land on the board armed for a scripted, unsaved practice run;
+                // the START coach mark + demo content carry them through it.
+                if startPractice { model.armPracticeWalk() }
             }
             .transition(.opacity)
         } else {
@@ -282,7 +295,7 @@ struct GalleryRoot: View {
             .navigationDestination(for: Dest.self) { dest in
                 switch dest {
                 case .components: ComponentsPage()
-                case .onboarding: OnboardingFlow(onComplete: {})
+                case .onboarding: OnboardingFlow(onComplete: { _ in })
                 case .jobs: JobsBoardScreen(trade: Fixtures.landscape)
                 case .capture: CaptureScreen(trade: Fixtures.landscape)
                 case .document: DocumentReviewScreen(trade: Fixtures.landscape)

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -23,6 +23,20 @@ struct BoardView: View {
                         .tracking(2.0)
                         .foregroundStyle(Theme.C.orangeDeep)
                     Spacer()
+                    // Practice-run marker: the armed dry run is visible on the
+                    // board (the old mode chip carried this; the chip is gone —
+                    // per Isaac, input mode is voice-only for users — so the
+                    // marker survives as a non-interactive stamp).
+                    if model.isPracticeWalk {
+                        Text("PRACTICE")
+                            .font(Theme.F.mono(8, .semibold))
+                            .tracking(1.0)
+                            .foregroundStyle(Theme.C.yellowTag)
+                            .padding(.horizontal, 6)
+                            .padding(.top, 3)
+                            .padding(.bottom, 2)
+                            .background(Theme.C.yellowTint)
+                    }
                     // Input mode is voice-only for users; the DEMO toggle was a
                     // dev affordance (still reachable via the `demo=1` launch arg
                     // for QA/screenshots) — removed from the board per Isaac.
@@ -170,8 +184,10 @@ struct BoardView: View {
             // First-run coach mark: point a brand-new operator at the one thing
             // to do. Only on a fresh board (profile set, no walks yet); the
             // START button below stays fully tappable (non-blocking hint).
-            if !coachStartShown && model.profile != nil && model.sessionWalks.isEmpty {
-                CoachCallout(text: "Ready? Tap START WALK and just talk — walk the job like you're telling a helper.") {
+            if (!coachStartShown || model.isPracticeWalk) && model.profile != nil && model.sessionWalks.isEmpty {
+                CoachCallout(text: model.isPracticeWalk
+                    ? "This is a practice run — nothing gets saved. Tap START WALK and try talking through a job."
+                    : "Ready? Tap START WALK and just talk — walk the job like you're telling a helper.") {
                     coachStartShown = true
                 }
                 .padding(.horizontal, Theme.S.screenPad)

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -101,7 +101,12 @@ struct NotesView: View {
             if let url = exportURL { ShareSheet(url: url) { _ in exportURL = nil } }
         }
         .onAppear {
-            guard !UserDefaults.standard.bool(forKey: Self.vocabCardShownKey),
+            // F2 (dam's #238 review): never burn the one-shot vocab-seed on a
+            // practice run — the card would pop mid-"nothing gets saved" (and
+            // confirming writes REAL vocabulary), then the user's first real
+            // walk would never see it.
+            guard !model.isPracticeWalk,
+                  !UserDefaults.standard.bool(forKey: Self.vocabCardShownKey),
                   let pack = VocabPack.bundled(for: model.trade.key) else { return }
             UserDefaults.standard.set(true, forKey: Self.vocabCardShownKey) // show once, ever
             vocabPack = pack

--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -12,7 +12,9 @@ import UIKit
 struct OnboardingFlow: View {
     /// Called after FINISH on the mic step — the profile is already persisted
     /// (SAVE on step 2); the caller reloads it and shows the board.
-    var onComplete: () -> Void
+    /// Finishes onboarding. `startPractice` is true when the operator chose the
+    /// optional practice walk (a scripted, unsaved dry run) instead of diving in.
+    var onComplete: (_ startPractice: Bool) -> Void
 
     // welcome + 3 "how it works" beats (learn by seeing) → setup (business, mic).
     private enum Step: Int, CaseIterable { case welcome = 1, seeWalk, seeFix, seeDoc, business, mic }
@@ -427,11 +429,26 @@ struct OnboardingFlow: View {
                 }
                 .padding(.bottom, 10)
             case .granted:
-                blockButton("START WALKING") { onComplete() }
+                blockButton("START MY FIRST WALK") { onComplete(false) }
                     .padding(.bottom, 10)
             case .denied:
-                blockButton("CONTINUE") { onComplete() }
+                blockButton("CONTINUE") { onComplete(false) }
                     .padding(.bottom, 10)
+            }
+
+            // Optional dry run: scripted content so a first-timer doesn't need
+            // to know what to say, coach marks guide the taps, and it never
+            // lands on their real board. Offered once the mic decision is made.
+            if micState != .idle {
+                Button { onComplete(true) } label: {
+                    Text("New to this?  Try a practice walk first ›")
+                        .font(Theme.F.cond(14, .semibold))
+                        .foregroundStyle(Theme.C.orangeDeep)
+                        .frame(maxWidth: .infinity)
+                        .padding(.bottom, 14)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, Theme.S.screenPad)

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -27,8 +27,9 @@ struct WalkView: View {
                 left: model.trade.site,
                 right: model.micStarting
                     ? "MIC STARTING…"
+                    : model.isPracticeWalk ? "PRACTICE — SCRIPTED, NOT SAVED"
                     : (model.walkMode == .demo ? "DEMO WALK — SCRIPTED" : "REC — ON-DEVICE STT"),
-                warn: model.walkMode == .demo
+                warn: model.isPracticeWalk || model.walkMode == .demo
             )
 
             ScrollView {


### PR DESCRIPTION
## Thinking

The intro (#236) teaches *what* the app does; the coach marks (#237) guide the *taps*. The practice walk closes the confidence gap for the most hesitant user: **let them do the whole loop once with zero stakes** before a real customer's estimate is on the line. For someone who has never trusted a computer with their livelihood, "you can't break anything, try it" is the last unlock.

Two design constraints drove the mechanism:

1. **They shouldn't need to know what to say.** So a practice run plays *scripted* content (the demo engine, in their trade) — they just tap along and watch items land. That's why it's demo-driven, not "go talk into your phone and hope."
2. **It must never pollute their real records.** A practice run is *not saved* — it never lands in the TODAY board log and never flips a job to SENT. Critically, it also does **not** change their persisted walk mode: `armPracticeWalk()` deliberately leaves `walkMode` alone, so after the dry run their real walks are still voice (or whatever they set). Practice is a per-run override, not a mode switch.

It's **optional and unobtrusive**: a secondary text link under the primary button on the last onboarding screen — dive straight in, or try it first.

## What changed

- **OnboardingFlow** — `onComplete(_ startPractice: Bool)`; a "New to this? Try a practice walk first ›" link once the mic decision is made. Primary button behaves as before.
- **AppModel** — `isPracticeWalk` + `armPracticeWalk()`. `startWalk`/`beginWalk` honor it (scripted, skip mic permission) without touching `walkMode`. `completeSend`/`discardDocument` short-circuit through `exitPracticeIfActive()` (no log, no job flip); `dismissNotes`/`discardWalk` clear it. So every exit from a practice run is unrecorded.
- **Honest markers** — board mode chip reads **PRACTICE** (locked); the START coach mark says "nothing gets saved"; the walk MetaStrip reads "PRACTICE — SCRIPTED, NOT SAVED".
- **QA** — `practice=1` lands straight on a practice board.

## Verification

- `BUILD SUCCEEDED` (iPhone 17 sim).
- Practice board rendered on-sim: PRACTICE chip + the practice-specific coach copy (screenshot in the thread).
- "Not saved" is enforced by the two log sites (`completeSend`/`discardDocument`) short-circuiting — traced + guarded.

## Stacking

This is the **third of three** onboarding PRs and depends on both:
- #236 — onboarding intro (the `OnboardingFlow` this extends)
- #237 — coach marks (guide the practice taps)

Merge #236 and #237 first; this PR's diff then reduces to just the practice-walk changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)