### PR TITLE
chore(ios): rename app to Jefe (home-screen + permission dialog)

### DIFF
--- a/apps/ios/Sources/App/Info.plist
+++ b/apps/ios/Sources/App/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Sitewalk</string>
+	<string>Jefe</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>Jefe</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -27,7 +27,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Photos you take during a walk pin to the item you're describing and land in the finished document.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Sitewalk records your walk-and-talk so it can turn it into paperwork.</string>
+	<string>Jefe records your walk-and-talk so it can turn it into paperwork.</string>
 	<key>PPQ_API_KEY</key>
 	<string>$(PPQ_API_KEY)</string>
 	<key>UIAppFonts</key>

--- a/apps/ios/project-release.yml
+++ b/apps/ios/project-release.yml
@@ -41,7 +41,11 @@ targets:
     info:
       path: Sources/App/Info.plist
       properties:
-        CFBundleDisplayName: Sitewalk
+        # Jefe rename (#239 review fix): this spec deep-merges OVER project.yml,
+        # so the name must be set here too or the TestFlight build ships 'Sitewalk'
+        # while the mic dialog says 'Jefe'.
+        CFBundleDisplayName: Jefe
+        CFBundleName: Jefe
         # Belt-and-suspenders (see TARGETED_DEVICE_FAMILY comment below): app
         # uses only exempt (HTTPS/TLS) encryption — no custom crypto. Explicit
         # here too so a future project.yml edit can't silently drop it and

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -32,7 +32,8 @@ targets:
         # Provider base URL (e.g. https://api.ppq.ai). Same injection flow as
         # the key; empty => provider default (api.anthropic.com).
         ANTHROPIC_BASE_URL: "$(ANTHROPIC_BASE_URL)"
-        CFBundleDisplayName: Sitewalk
+        CFBundleDisplayName: Jefe
+        CFBundleName: Jefe
         # Fixed paper-and-ink theme: lock light appearance so system dark mode
         # never falls un-styled Text back to the white system label color on the
         # always-light paper (issue #220 — invisible board title / vocab / rows).
@@ -42,7 +43,7 @@ targets:
         # answer in ASC before testers can install it.
         ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
-        NSMicrophoneUsageDescription: "Sitewalk records your walk-and-talk so it can turn it into paperwork."
+        NSMicrophoneUsageDescription: "Jefe records your walk-and-talk so it can turn it into paperwork."
         NSCameraUsageDescription: "Photos you take during a walk pin to the item you're describing and land in the finished document."
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## Thinking

The product is Jefe (CANON #202), but the shipped build still calls itself **Sitewalk** where it matters most to a new tester: the name under the home-screen icon, the TestFlight listing, and the microphone-permission prompt. As we open external/public TestFlight, that mismatch is confusing ("I installed Sitewalk, not Jefe"). This renames the user-facing app name; nothing structural.

Deliberately minimal + conflict-free: only `project.yml` (the build's source of truth) and the committed generated `Info.plist`. The bundle id, the Xcode target/scheme name (`SitewalkGallery`), and file names are **unchanged** — internal, never shown to users, and renaming them would be churn for no user benefit.

## What changed

- `project.yml`: `CFBundleDisplayName` Sitewalk → **Jefe**, add `CFBundleName: Jefe`, mic usage string Sitewalk → Jefe.
- `Info.plist` (committed generated output): the same three, so the artifact is consistent whether or not CI regenerates via xcodegen.

Takes effect in the **next build** (the release lane regenerates from `project.yml`).

## Out of scope (on purpose)

- The **onboarding wordmark** → JEFE already ships in the onboarding-intro PR, so I left this file's rewrite to that PR to avoid a conflict.
- A few scattered in-app strings (board "MIC IS OFF — SITEWALK…" notice, gallery wordmark, notes plain-text export "Prepared with Sitewalk") are a trivial follow-up — none is the home-screen name.
- The **App Store Connect listing name** (what TestFlight/the public join page shows) is a separate change in ASC, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)