### PR TITLE
feat(ios): editable notes buckets — Plan 18 UI (blocked on dam's core seam)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -542,6 +542,61 @@ final class AppModel {
             .error("item \(what, privacy: .public) failed: \(error, privacy: .public)")
     }
 
+    // MARK: Notes-entry edits (Plan 18) — the coordination BUCKETS (the notes
+    // screen's first three sections) are editable too, through the CORE artifact
+    // (parse → mutate → serialize → update_artifact_body), so a fix reaches the
+    // exported notes, not just this screen. Mirrors the item CRUD above; the
+    // returned entry is an optimistic echo (engine is the source of truth).
+
+    /// Fix a coordination note's label / detail / bucket.
+    func editNotesEntry(_ entry: NotesEntryFixture, label: String, detail: String, bucket: NotesBucket) {
+        guard let sessionId = currentSessionId else { return }
+        notesEditError = nil
+        do {
+            let updated = try engine.updateNotesEntry(
+                sessionId: sessionId, entryId: entry.id,
+                label: label, detail: detail, bucket: bucket.wire
+            )
+            guard var n = notes, let idx = n.notes.firstIndex(where: { $0.id == entry.id }) else { return }
+            n.notes[idx] = updated
+            notes = n
+        } catch {
+            notesEntryEditFailed("save", error)
+        }
+    }
+
+    /// Add a coordination note to a bucket. Appends last (artifact order).
+    func addNotesEntry(bucket: NotesBucket, label: String, detail: String) {
+        guard let sessionId = currentSessionId else { return }
+        notesEditError = nil
+        do {
+            let added = try engine.addNotesEntry(
+                sessionId: sessionId, bucket: bucket.wire, label: label, detail: detail
+            )
+            if var n = notes { n.notes.append(added); notes = n }
+        } catch {
+            notesEntryEditFailed("add", error)
+        }
+    }
+
+    /// Remove a coordination note — drops it from the rewritten notes artifact.
+    func removeNotesEntry(_ entry: NotesEntryFixture) {
+        guard let sessionId = currentSessionId else { return }
+        notesEditError = nil
+        do {
+            try engine.removeNotesEntry(sessionId: sessionId, entryId: entry.id)
+            if var n = notes { n.notes.removeAll { $0.id == entry.id }; notes = n }
+        } catch {
+            notesEntryEditFailed("remove", error)
+        }
+    }
+
+    private func notesEntryEditFailed(_ what: String, _ error: Error) {
+        notesEditError = "Couldn’t \(what) that note — try again."
+        Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "notes")
+            .error("notes-entry \(what, privacy: .public) failed: \(error, privacy: .public)")
+    }
+
     /// Review → back to notes (the review screen's back arrow). Keeps the
     /// session and the built notes intact so the operator can build a different
     /// document or re-read; the last document stays in memory until the next

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -19,6 +19,12 @@ final class DemoWalkEngine: WalkEngine {
     /// per event (Task 10).
     private var board: [CapturedFixture] = []
 
+    /// Per-session coordination buckets (Plan 18) — the demo mirror of the
+    /// `kind=="notes"` artifact. Seeded from `sampleNotes` at `finish()`;
+    /// the notes-entry CRUD below mutates THIS (stable ids), so an edit
+    /// survives a re-read the same way the real artifact rewrite does.
+    private var notesEntries: [NotesEntryFixture] = []
+
     /// In-memory vocabulary so the editor is usable with no backend (Plan 10
     /// D8). Seeded with a couple of demo terms. Mirrors the Rust semantics
     /// loosely — normalize + case-insensitive dedup + a 100-term cap — enough
@@ -65,6 +71,7 @@ final class DemoWalkEngine: WalkEngine {
         firedItems = []
         board = []
         itemKinds = [:]
+        notesEntries = []
         sessionStatus[demoSessionId] = .recording
         var cont: AsyncStream<WalkEvent>.Continuation!
         let stream = AsyncStream<WalkEvent> { cont = $0 }
@@ -208,6 +215,8 @@ final class DemoWalkEngine: WalkEngine {
         // Plan 16: the demo session reaches its terminal state — edits are
         // allowed from here on (the D3-16 gate mirror).
         sessionStatus[demoSessionId] = .processed
+        // Plan 18: seed the editable coordination buckets for this walk.
+        notesEntries = Self.sampleNotes
         // Simulate the notes-compute beat (the real engine targets < 8 s).
         try? await Task.sleep(for: .seconds(0.8))
         let itemWord = board.count == 1 ? "item" : "items"
@@ -216,7 +225,7 @@ final class DemoWalkEngine: WalkEngine {
             items: board,
             docKind: DocKinds.primaryKind(for: trade.key),
             queued: false,
-            notes: Self.sampleNotes
+            notes: notesEntries
         )
     }
 
@@ -225,16 +234,19 @@ final class DemoWalkEngine: WalkEngine {
     // rendering is your follow-up — this data is inert until then.
     private static let sampleNotes: [NotesEntryFixture] = [
         NotesEntryFixture(
+            id: "demo-note-scope",
             bucket: .scopeOfWork,
             label: "Mulch — front beds",
             detail: "Darker mulch than last year; the old mulch faded."
         ),
         NotesEntryFixture(
+            id: "demo-note-budget",
             bucket: .constraints,
             label: "Budget",
             detail: "Keep the whole job under $1,200."
         ),
         NotesEntryFixture(
+            id: "demo-note-zone2",
             bucket: .conditionsAndIssues,
             label: "Zone-2 irrigation head broken",
             detail: "Replace — parts + labor."
@@ -319,6 +331,58 @@ final class DemoWalkEngine: WalkEngine {
         }
         itemKinds.removeValue(forKey: uuid)
         board.remove(at: index)
+    }
+
+    // MARK: Notes-entry CRUD (Plan 18) — in-memory demo parity, mirroring the
+    // Rust artifact-rewrite: partial-apply update, bucket validated against the
+    // three wire strings, empty label rejected, Processed-only, add appends,
+    // remove drops. The REAL semantics (WE-A..WE-E) live in
+    // crates/ffi/src/notes_crud.rs.
+
+    func updateNotesEntry(
+        sessionId: String, entryId: String, label: String?, detail: String?, bucket: String?
+    ) throws -> NotesEntryFixture {
+        try requireEditable(sessionId)
+        guard let index = notesEntries.firstIndex(where: { $0.id == entryId }) else {
+            throw DemoEditError.rejected("no such note: \(entryId)")
+        }
+        if let label, label.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw DemoEditError.rejected("note label is empty")
+        }
+        var entry = notesEntries[index]
+        if let label { entry.label = label }
+        if let detail { entry.detail = detail }
+        if let bucket {
+            guard let mapped = NotesBucket(wire: bucket) else {
+                throw DemoEditError.rejected("invalid bucket '\(bucket)'")
+            }
+            entry.bucket = mapped
+        }
+        notesEntries[index] = entry
+        return entry
+    }
+
+    func addNotesEntry(
+        sessionId: String, bucket: String, label: String, detail: String
+    ) throws -> NotesEntryFixture {
+        try requireEditable(sessionId)
+        guard let mapped = NotesBucket(wire: bucket) else {
+            throw DemoEditError.rejected("invalid bucket '\(bucket)'")
+        }
+        guard !label.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw DemoEditError.rejected("note label is empty")
+        }
+        let entry = NotesEntryFixture(id: UUID().uuidString, bucket: mapped, label: label, detail: detail)
+        notesEntries.append(entry)   // append — mirrors the artifact-order rule
+        return entry
+    }
+
+    func removeNotesEntry(sessionId: String, entryId: String) throws {
+        try requireEditable(sessionId)
+        guard notesEntries.contains(where: { $0.id == entryId }) else {
+            throw DemoEditError.rejected("no such note: \(entryId)")
+        }
+        notesEntries.removeAll { $0.id == entryId }
     }
 
     // Plan 13 D1: the on-demand build, engine-keyed. The demo has no real

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -87,6 +87,13 @@ private final class BoardListener: FFIWalkEventListener {
     }
 }
 
+/// Plan 18: the notes-entry CRUD FFI methods are not generated yet (dam's
+/// Task 2/5). `MurmurEngine` conforms with throwing stubs so the real-core
+/// archive keeps compiling; dam swaps the throws for the real forwards
+/// (`engine.updateNotesEntry(...)` etc.) when the bindings land. The demo
+/// engine carries the working in-memory parity that drives sac's edit UI.
+private enum NotesEntrySeamPending: Error { case pending }
+
 @MainActor
 final class MurmurEngine: WalkEngine {
     private let engine: FFIMurmurEngine
@@ -308,6 +315,27 @@ final class MurmurEngine: WalkEngine {
 
     func removeItem(sessionId: String, itemId: String) throws {
         try engine.removeItem(sessionId: sessionId, itemId: itemId)
+    }
+
+    // MARK: - Notes-entry CRUD (Plan 18): PENDING dam's FFI seam (Task 2/5).
+    // TODO(dam, Plan 18): forward to `engine.updateNotesEntry(...)` /
+    // `addNotesEntry(...)` / `removeNotesEntry(...)` (mapping via
+    // `Self.notesEntry`) once crates/ffi's notes-entry CRUD + `NotesEntry.id`
+    // land; drop the `pending` throws.
+    func updateNotesEntry(
+        sessionId: String, entryId: String, label: String?, detail: String?, bucket: String?
+    ) throws -> NotesEntryFixture {
+        throw NotesEntrySeamPending.pending
+    }
+
+    func addNotesEntry(
+        sessionId: String, bucket: String, label: String, detail: String
+    ) throws -> NotesEntryFixture {
+        throw NotesEntrySeamPending.pending
+    }
+
+    func removeNotesEntry(sessionId: String, entryId: String) throws {
+        throw NotesEntrySeamPending.pending
     }
 
     func sweepZombieSessions() throws -> UInt64 {

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -162,7 +162,11 @@ extension MurmurEngine {
         case .constraints: bucket = .constraints
         case .conditionsAndIssues: bucket = .conditionsAndIssues
         }
-        return NotesEntryFixture(bucket: bucket, label: entry.label, detail: entry.detail)
+        // TODO(dam, Plan 18): use `entry.id` once crates/ffi's `NotesEntry`
+        // carries it (Task 1/2). Synthesized for now so the ForEach key is
+        // unique; real-core bucket editing is a pending stub in MurmurEngine
+        // until the id + CRUD bindings land.
+        return NotesEntryFixture(id: UUID().uuidString, bucket: bucket, label: entry.label, detail: entry.detail)
     }
 
     static func emptyNotes() -> NotesModel {

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -71,6 +71,26 @@ enum NotesBucket {
     case scopeOfWork
     case constraints
     case conditionsAndIssues
+
+    /// Wire string crossing the FFI seam (mirrors `NotesBucket::from_wire`,
+    /// `crates/ffi/src/notes.rs`). A bucket re-file passes this to
+    /// `updateNotesEntry`; `add`/`remove` use it too (Plan 18).
+    var wire: String {
+        switch self {
+        case .scopeOfWork: return "scope_of_work"
+        case .constraints: return "constraints"
+        case .conditionsAndIssues: return "conditions_and_issues"
+        }
+    }
+
+    init?(wire: String) {
+        switch wire {
+        case "scope_of_work": self = .scopeOfWork
+        case "constraints": self = .constraints
+        case "conditions_and_issues": self = .conditionsAndIssues
+        default: return nil
+        }
+    }
 }
 
 /// Plan 14 D2-14: one comprehensive-notes coordination entry — the detail
@@ -80,9 +100,10 @@ enum NotesBucket {
 /// your follow-up (NotesView.swift's kind-grouped rendering already covers
 /// the terse board — bucket rendering is additive on top).
 struct NotesEntryFixture: Identifiable {
-    /// Stable unique identity — two identical LLM entries must not collide
-    /// as ForEach IDs (label+detail did).
-    let id = UUID()
+    /// Core artifact-entry id (Plan 18), stable post-`finish()` — both the
+    /// `ForEach` identity (two identical LLM entries must not collide, as
+    /// label+detail did) AND the edit key the notes-entry CRUD seam addresses.
+    var id: String
     var bucket: NotesBucket
     var label: String
     var detail: String
@@ -298,4 +319,34 @@ protocol WalkEngine: AnyObject {
         sessionId: String, kind: String, text: String, right: String
     ) throws -> CapturedFixture
     func removeItem(sessionId: String, itemId: String) throws
+
+    // Notes-entry CRUD (Plan 18) — the edit seam for the coordination BUCKETS
+    // (Scope / Constraints / Conditions), i.e. the notes screen's first three
+    // sections. Like item CRUD it is engine-keyed and Processed-gated in core
+    // (D3-18), but it operates by ARTIFACT REWRITE (parse_notes_artifact →
+    // mutate → serialize_buckets → update_artifact_body) because the buckets
+    // are a derived `kind=="notes"` artifact, not item rows. `bucket` crosses
+    // as a wire string (`NotesBucket.wire`).
+    //
+    // // sac: mirrors the Plan 16 item contract —
+    // // sac: (a) edit affordances render only when `!notes.queued` (the exact
+    // // sac:     gate the build buttons already follow; a queued session fails
+    // // sac:     the Processed-only core gate by design).
+    // // sac: (b) the returned NotesEntryFixture is an optimistic ECHO — patch
+    // // sac:     it in place; the engine is the source of truth (a full
+    // // sac:     `loadNotes` bucket re-read rides in with #223).
+    // // sac: (c) `bucket` is one of the three known wire strings — an unknown
+    // // sac:     one is rejected (R6), never coerced. `detail` may be "";
+    // // sac:     `label` may not (an empty entry is noise).
+    //
+    // A nil field on updateNotesEntry = leave unchanged. addNotesEntry appends
+    // (last in its bucket) and CREATES the notes artifact if the walk had none.
+    // removeNotesEntry drops the entry from the rewritten body.
+    func updateNotesEntry(
+        sessionId: String, entryId: String, label: String?, detail: String?, bucket: String?
+    ) throws -> NotesEntryFixture
+    func addNotesEntry(
+        sessionId: String, bucket: String, label: String, detail: String
+    ) throws -> NotesEntryFixture
+    func removeNotesEntry(sessionId: String, entryId: String) throws
 }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -17,6 +17,9 @@ struct NotesView: View {
     @State private var exportURL: URL?
     // Plan 16: tap a line to fix it, or add one. The walk is a first draft.
     @State private var itemEdit: NoteItemEdit?
+    // Plan 18: tap a coordination-bucket line to fix it, or add one — the same
+    // "input is just the first draft" rule, now for the first three sections.
+    @State private var noteEntryEdit: NotesEntryEdit?
 
     // Plan 15 D9-15: the vocab seed card shows ONCE, on the FIRST notes-screen
     // appearance — i.e. right after the user's first real walk, when they have
@@ -55,6 +58,12 @@ struct NotesView: View {
                         // ABOVE the terse tag-grouped board (additive — the board
                         // still carries the priced line items).
                         bucketSections
+                        // Plan 18: add a coordination note (the sheet picks the
+                        // bucket, so this covers an empty bucket too). Same
+                        // `!notes.queued` gate the edit taps + build buttons use.
+                        if !notes.queued && !(notes.items.isEmpty && notes.notes.isEmpty) {
+                            addNoteButton
+                        }
                         if notes.items.isEmpty && notes.notes.isEmpty {
                             emptyState
                             addLineButton
@@ -111,6 +120,31 @@ struct NotesView: View {
                 .presentationDragIndicator(.visible)
                 .presentationBackground(Theme.C.paper)
         }
+        .sheet(item: $noteEntryEdit) { target in
+            NotesEntryEditSheet(target: target, model: model)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+                .presentationBackground(Theme.C.paper)
+        }
+    }
+
+    // Plan 18: add a coordination note — same dashed affordance as ＋ ADD LINE,
+    // but it opens the bucket editor (which picks Scope/Constraints/Conditions).
+    private var addNoteButton: some View {
+        Button { noteEntryEdit = .add } label: {
+            Text("＋ ADD NOTE")
+                .font(Theme.F.mono(9, .semibold)).tracking(1.0)
+                .foregroundStyle(Theme.C.orangeDeep)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 11)
+                .overlay(RoundedRectangle(cornerRadius: 4)
+                    .stroke(style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                    .foregroundStyle(Theme.C.orangeDeep.opacity(0.6)))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 12)
     }
 
     // Add a manual line — dashed, in the tag grammar, distinct from a captured row.
@@ -382,6 +416,8 @@ struct NotesView: View {
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.vertical, 8)
         .overlay(alignment: .bottom) { Theme.C.hairlineSoft.frame(height: 1) }
+        .contentShape(Rectangle())
+        .onTapGesture { if !notes.queued { noteEntryEdit = .edit(entry) } }
     }
 
     // MARK: Grouping (trade-aware headers, attention-first)
@@ -561,6 +597,169 @@ private struct NoteItemEditSheet: View {
 
     private func commitRemove() {
         if case .edit(let item) = target { model.removeNoteItem(item) }
+        dismiss()
+    }
+}
+
+// MARK: - Notes-entry edit / add sheet (Plan 18)
+
+/// Fixing a coordination bucket line, or adding one.
+private enum NotesEntryEdit: Identifiable {
+    case edit(NotesEntryFixture)
+    case add
+    var id: String { if case .edit(let e) = self { return e.id } else { return "add-note" } }
+}
+
+/// Fix a bucket entry's label / detail, re-file its section, remove it, or add
+/// a new one. Commits through the core (AppModel → Plan 18 artifact rewrite),
+/// so the correction reaches the exported notes — not just this screen.
+private struct NotesEntryEditSheet: View {
+    let target: NotesEntryEdit
+    let model: AppModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var bucket: NotesBucket
+    @State private var label: String
+    @State private var detail: String
+
+    init(target: NotesEntryEdit, model: AppModel) {
+        self.target = target
+        self.model = model
+        switch target {
+        case .edit(let e):
+            _bucket = State(initialValue: e.bucket)
+            _label = State(initialValue: e.label)
+            _detail = State(initialValue: e.detail)
+        case .add:
+            _bucket = State(initialValue: .scopeOfWork)
+            _label = State(initialValue: "")
+            _detail = State(initialValue: "")
+        }
+    }
+
+    private var isEdit: Bool { if case .edit = target { return true } else { return false } }
+    private var canSave: Bool { !label.trimmingCharacters(in: .whitespaces).isEmpty }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            VStack(alignment: .leading, spacing: 16) {
+                bucketPicker
+                field("LABEL", text: $label, placeholder: "Budget")
+                field("DETAIL", text: $detail, placeholder: "Keep the whole job under $1,200 · optional")
+            }
+            .padding(.horizontal, Theme.S.screenPad).padding(.top, 20)
+            Spacer(minLength: 12)
+            actions
+        }
+        .background(Theme.C.paper.ignoresSafeArea())
+    }
+
+    private var header: some View {
+        HStack {
+            Button { dismiss() } label: {
+                Text("CANCEL")
+                    .font(Theme.F.mono(9, .semibold)).tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+            Text(isEdit ? "EDIT NOTE" : "ADD NOTE")
+                .font(Theme.F.mono(9, .semibold)).tracking(2.0)
+                .foregroundStyle(Theme.C.orangeDeep)
+        }
+        .padding(.horizontal, Theme.S.screenPad).padding(.top, 18).padding(.bottom, 14)
+        .overlay(alignment: .bottom) { Theme.C.ink.frame(height: 2) }
+    }
+
+    private var bucketPicker: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("SECTION")
+                .font(Theme.F.mono(8, .semibold)).tracking(1.4)
+                .foregroundStyle(Theme.C.ink35)
+            HStack(spacing: 7) {
+                ForEach([NotesBucket.scopeOfWork, .constraints, .conditionsAndIssues], id: \.self) { b in
+                    bucketChip(b)
+                }
+            }
+        }
+    }
+
+    private func bucketChip(_ b: NotesBucket) -> some View {
+        let on = bucket == b
+        return Button { bucket = b } label: {
+            Text(shortTitle(b))
+                .font(Theme.F.mono(8.5, .semibold)).tracking(0.4)
+                .foregroundStyle(on ? Theme.C.onOrange : Theme.C.ink60)
+                .frame(maxWidth: .infinity).padding(.vertical, 9)
+                .background(RoundedRectangle(cornerRadius: 6).fill(on ? Theme.C.orange : Theme.C.sheet))
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(on ? Theme.C.orange : Theme.C.hairline, lineWidth: 1.5))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func shortTitle(_ b: NotesBucket) -> String {
+        switch b {
+        case .scopeOfWork: return "SCOPE"
+        case .constraints: return "CONSTRAINTS"
+        case .conditionsAndIssues: return "CONDITIONS"
+        }
+    }
+
+    private var actions: some View {
+        HStack(spacing: 10) {
+            if isEdit {
+                Button { commitRemove() } label: {
+                    Text("REMOVE")
+                        .font(Theme.F.ui(14, .bold)).tracking(1.1)
+                        .foregroundStyle(Theme.C.redTag)
+                        .frame(width: 118).frame(height: 54)
+                        .overlay(RoundedRectangle(cornerRadius: Theme.S.radius)
+                            .stroke(Theme.C.redTag, lineWidth: 2))
+                }
+                .buttonStyle(.plain)
+            }
+            Button { commitSave() } label: {
+                Text(isEdit ? "SAVE" : "ADD")
+                    .font(Theme.F.ui(15, .bold)).tracking(1.4)
+                    .foregroundStyle(Theme.C.onOrange)
+                    .frame(maxWidth: .infinity).frame(height: 54)
+                    .background(RoundedRectangle(cornerRadius: Theme.S.radius).fill(Theme.C.orange))
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSave)
+            .opacity(canSave ? 1 : 0.4)
+        }
+        .padding(.horizontal, Theme.S.screenPad).padding(.top, 12).padding(.bottom, 14)
+        .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
+    }
+
+    private func field(_ label: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(label)
+                .font(Theme.F.mono(8, .semibold)).tracking(1.4)
+                .foregroundStyle(Theme.C.ink35)
+            TextField(placeholder, text: text, axis: .vertical)
+                .font(Theme.F.cond(15, .semibold))
+                .lineLimit(1...4)
+                .autocorrectionDisabled()
+                .padding(.bottom, 6)
+                .overlay(alignment: .bottom) { Theme.C.orangeDeep.frame(height: 2) }
+        }
+    }
+
+    private func commitSave() {
+        let l = label.trimmingCharacters(in: .whitespaces)
+        let d = detail.trimmingCharacters(in: .whitespaces)
+        guard !l.isEmpty else { return }
+        switch target {
+        case .edit(let e): model.editNotesEntry(e, label: l, detail: d, bucket: bucket)
+        case .add:         model.addNotesEntry(bucket: bucket, label: l, detail: d)
+        }
+        dismiss()
+    }
+
+    private func commitRemove() {
+        if case .edit(let e) = target { model.removeNotesEntry(e) }
         dismiss()
     }
 }

--- a/docs/superpowers/plans/2026-07-17-rust-core-18-notes-entry-crud.md
+++ b/docs/superpowers/plans/2026-07-17-rust-core-18-notes-entry-crud.md
@@ -1,0 +1,180 @@
+# Murmur Rust Core — Plan 18: editable notes buckets (the notes-entry CRUD seam)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`. Steps use checkbox (`- [ ]`) syntax. The Rust tasks (1–3) are **hermetic**: in-memory `Store`, `MockProvider`, `SpyStore` — **no model, no `whisper` feature, no network, no mic**. `cargo test --workspace` must NEVER require the `whisper` feature or a model file (the load-bearing CI invariant). Run `cargo`/`xcodegen` **inside** the Nix dev shell; run `xcodebuild` **outside** it (Nix linker env breaks Xcode `ld`). Never read `.env` or `project.local.yml`.
+>
+> **⚠ SHIPPABILITY — merging this plan auto-publishes the TestFlight internal lane on real-engine** (CANON 2026-07-10). main must build the **real-core archive** at every merge. Plan 18 is **additive** (an `id` field on the notes artifact's `NotesEntry` + a new FFI CRUD surface that rewrites the notes artifact body + a Swift protocol seam), so it is **ONE PR** — but the real-core compile is a **MANDATORY manual gate** (Task 5; CI cannot build real-core).
+>
+> **Design source:** this plan implements the "narrative bucket editing" seam that **Plan 16 explicitly deferred** — keeper decision D-#5 (`2026-07-14-rust-core-16-item-crud.md`): *"the Scope/Constraints/Conditions buckets are a derived `write_notes` artifact; editing them means versioning the `NotesPayload` artifact, a different seam."* This is that seam. It carries forward Plan 16's binding decisions where they transfer (Processed-gate; re-read-from-engine; R6/R7).
+>
+> **The sac edit UI is landing ALONGSIDE this plan** (a sibling `pr/sac/notes-bucket-edit-ui`, already built + demo-verified against `DemoWalkEngine` parity). Unlike Plan 16 (where the UI was a later follow-up), the UI exists now; this plan supplies the real-core data path so the UI works on-device. **Sequencing:** dam's seam PR merges **first** (or together) — the UI's real-core path throws a `pending` stub until the FFI methods resolve (Task 4), so a UI-first merge would ship an always-erroring "edit note" on real-engine. Land dam first.
+
+**Goal.** Make the **first three sections of the notes screen editable** — `SCOPE OF WORK`, `CONSTRAINTS`, `CONDITIONS & ISSUES` (the Plan-14 coordination buckets). Today only the priced items board is editable (Plan 16); the buckets render read-only (`NotesView.notesEntryRow` has no tap, and there is no CRUD seam for them anywhere). The operator's field report is a first draft — a mis-heard budget ("under $1,200" → "$2,100"), a wrong scope line, a condition that should be added or dropped — and a correction that doesn't reach the notes they **export/send** is worse than none (Plan 16's thesis, applied to buckets). Because the buckets live in a **`kind=="notes"` artifact body** (`{"buckets":[…]}` JSON), the edit lives there: read the artifact → `parse_notes_artifact` → mutate the `Vec` → `serialize_buckets` → `update_artifact_body`. Every later `session_notes()` read (the notes screen) and `exportNotes()` reflects it.
+
+**What lands (all in ONE PR):**
+1. **murmur-core — `NotesEntry` gains a stable `id`, round-tripped through the artifact.** `pipeline::notes::NotesEntry` (`{bucket,label,detail}`) gains `id: String`; `parse_notes_artifact`/`parse_notes_value` read an `"id"` when present and **mint a UUIDv7 when absent** (legacy pre-18 artifacts + fresh `write_notes` output that didn't emit one); `serialize_buckets` writes it. (Task 1.)
+2. **ffi — the CRUD surface: `update_notes_entry` / `add_notes_entry` / `remove_notes_entry`.** Engine-keyed (the walk is over at review), `Processed`-gated (the `build_document`/Plan-16 precedent), operating by **artifact rewrite** over the existing `list_artifacts_for_session` + `parse_notes_artifact` + `serialize_buckets` + `update_artifact_body` (add the notes artifact if none exists yet). `bucket` validated against the three known wire strings (`NotesBucket::from_wire`, R6 — reject unknown, never coerce). FFI `NotesEntry` gains `id`; `convert::notes_entries` threads it. New `EngineError::NotesEntry`. (Task 2.)
+3. **ffi — the round-trip invariant, pinned.** `update` then `session_notes()` reflects it (label/detail/bucket); `remove` drops the entry; `add` **appends**; a legacy artifact with id-less entries **backfills + persists** ids on first edit. (Task 3.)
+4. **apps/ios — the sac seam + demo parity.** `WalkEngine.updateNotesEntry/addNotesEntry/removeNotesEntry` on both engines; `DemoWalkEngine` in-memory parity; `NotesEntryFixture` gains `id`. The **edit UI is sac's sibling PR** (built now). (Task 4.)
+5. **Real-core compile + bindings drift (dam-manual) + merge.** (Task 5, MANDATORY gate.)
+
+**What Plan 18 is NOT (see Non-goals).** No SUMMARY editing (the narrative summary is a separate `NotesPayload.summary`, its own seam — deferred). No **document propagation** — buckets are notes-screen + notes-export content, they do **not** render into the built document today (D5-18); when the DocumentSchema seam (#207 §7.2) lets buckets flow into documents they'll propagate for free (they already live in the artifact the builder would read). No **correction-learning signal** (Plan 17's domain — a bucket text edit does not touch `record_correction`). No mid-walk editing (edit-at-review, post-`finish()`, is the whole surface).
+
+---
+
+## Binding decisions (carried from Plan 16 where they transfer)
+
+1. **Editable fields: `label` + `detail` + `bucket`.** A mis-filed bucket ("this is a constraint, not scope") is as trust-breaking as a mis-heard word. `bucket` validated against the three known variants; unknown rejected (R6). `detail` may be empty (a terse note is valid); `label` may not (an empty entry is noise).
+2. **Delete: tombstone the *entry within the artifact* by rewrite** — there is no per-entry tombstone row (buckets aren't rows); "remove" means the entry is dropped from the rewritten artifact body. The artifact row itself is untouched (its `updated_at` bumps). This is the artifact analogue of Plan 16's item tombstone.
+3. **Stable ids post-`finish()`.** Single-writer store; `Processed` is terminal; the notes artifact is written once at `process()` and thereafter changes **only** via these edits (which re-read after each). So an entry's `id` is stable across the review session — the same guarantee Plan 16's item ids have (keeper D-#6). → **D3-18: mutations are `Processed`-gated.**
+4. **App-side rule.** After a mutation the notes screen patches the returned echo in place for optimistic feedback but treats the **engine as the source of truth** — the returned `NotesEntry` is an echo, not a re-derivation of the whole artifact (keeper D-#7). A full re-read seam for buckets (`loadNotes`) rides in with the walk-reopen work (#223); until then the echo-patch mirrors Plan 16's item edit exactly.
+
+---
+
+## Hard dependencies (all DONE, on `main`)
+
+- **The notes artifact (Plan 14 — LANDED):** `pipeline::notes::NotesEntry { bucket: String, label, detail }`; `parse_notes_artifact(body) -> Vec<NotesEntry>` and `serialize_buckets(&[NotesEntry]) -> String` (`crates/murmur-core/src/pipeline/notes.rs`) — the tolerant `{"buckets":[…]}` round-trip (garbled → `[]`, R7). The buckets are persisted as a `kind=="notes"` **artifact** (not item rows, D5-14). `session_notes()` (`crates/ffi/src/session.rs:432`) reads the latest `kind=="notes"` artifact and parses it; unknown buckets dropped by `convert::notes_entries` (R6).
+- **Artifact store (Plans 03/13 — LANDED):** `Store::add_artifact(session_id, kind, title, body, …)`, `Store::update_artifact_body(id, body)` (`UPDATE artifacts SET body=?, updated_at=? WHERE id=? AND deleted_at IS NULL`), `Store::list_artifacts_for_session(session_id)`, `Store::get_artifact(id)` (`crates/murmur-core/src/store/artifacts.rs`). **`update_artifact_body` is the whole rewrite mechanism — no new store method needed** (contrast Plan 16, which added `Store::update_item`; the artifact-body update path already exists).
+- **Engine-keyed CRUD precedents (LANDED):** `crates/ffi/src/items.rs` (Plan 16 — the exact lock-then-mutate, `Processed`-gate-under-the-same-lock, `EngineError`-per-domain, `SpyStore`+literal-`Providers` test shape this plan copies), `crates/ffi/src/photos.rs`, `vocabulary.rs`. `build_document` (`document_build.rs`) is the `Processed`-gated post-`finish()` precedent.
+- **`NotesBucket::from_wire` (Plan 14 — LANDED):** `crates/ffi/src/notes.rs:29` — maps `"scope_of_work"|"constraints"|"conditions_and_issues"` → enum, else `None` (drop). The **validation boundary** for a re-file's target bucket (Task 2 reuses it).
+
+**Spec basis:** R6 (validate/reject unknown `bucket`; `id` minted, never fabricated content); R7 (inspectable & undoable — every edit is a visible artifact rewrite, remove is reversible by re-adding, no silent state); R9 (spend — `update`/`add`/`remove` add **zero** LLM calls). Design: Plan 16 keeper decisions; `meta/CANON.md`.
+
+---
+
+## Architecture — decisions, justified (reviewers read these first)
+
+### D1-18. The seam is an **artifact rewrite**, not a new table
+The buckets are a **derived `write_notes` artifact** (D5-14), not rows. So — unlike Plan 16's item CRUD (row `UPDATE`) — the seam reads the `kind=="notes"` artifact body, parses it to `Vec<NotesEntry>`, mutates the vec, re-serializes, and calls the **existing** `update_artifact_body`. Rationale: the artifact IS the storage; a parallel item-style table would duplicate the source of truth and desync from `session_notes()`. This is the "version the `NotesPayload` artifact" path Plan 16's D-#5 named. It reuses `parse_notes_artifact` ↔ `serialize_buckets` verbatim, so the parse tolerance (R7) and bucket-drop (R6) are inherited, not re-implemented.
+
+### D2-18. Stable per-entry `id`, persisted in the artifact body
+Editing needs to address a single entry across reads; entries have **no id** today (`{bucket,label,detail}`). Options: (a) address by array **index** — brittle (no cross-read identity, shifts on add/remove, no clean Swift `ForEach` key); (b) a stable **`id`**, persisted in the body. Choose (b), mirroring items: `NotesEntry` gains `id: String` (UUIDv7). Minted at the `write_notes`/serialize site going forward; for **legacy** artifacts (and any `write_notes` output without one), `parse_notes_artifact` **mints an id when `"id"` is absent**, and the **first edit persists the backfill** (the CRUD rewrites the whole body with ids — WE-E). Un-edited legacy sessions are behavior-preserving: `session_notes()` still returns the same buckets, now each carrying a stable id the app uses as a `ForEach` key. The FFI `NotesEntry` and app `NotesEntryFixture` gain the matching `id`.
+
+### D3-18. Mutations are **`Processed`-gated** (the `build_document`/Plan-16 rule)
+`update_notes_entry`/`add_notes_entry`/`remove_notes_entry` (FFI) require `session.status == Processed`; any other status → `EngineError::NotesEntry` (validation, thrown, never a panic). Same reasoning as Plan 16 D3-16: `Recording`/`AwaitingProcessing` have a pending pass that rewrites the notes artifact (a reprocess writes a fresh `kind=="notes"` artifact after sweeping the prior — `session_notes`'s own comment) and would clobber an edit; `Failed` is retryable (re-runs `process()`); `Processed` is terminal, the artifact is fixed, ids stable. "Editable" ≡ "buildable" — one coherent rule. The gate is a status read **under the same store lock** as the rewrite (no await between check and write), so no TOCTOU.
+
+### D4-18. `add` appends; `remove` drops; `bucket` re-file is validated
+- **Add:** mints a fresh entry (`id` = new UUIDv7), appends to the parsed `Vec` (last), re-serializes. The app renders buckets in the fixed `scopeOfWork → constraints → conditionsAndIssues` order regardless of vec position, so "append" is order-within-bucket; a fresh entry is the last of its bucket.
+- **Remove:** drops the entry with the given `id` from the vec, re-serializes. A missing/already-removed `id` → `EngineError::NotesEntry` (mirror the item `NotFound` shape).
+- **Re-file (`bucket`):** validated via `NotesBucket::from_wire`; unknown → `EngineError::NotesEntry` (R6, never coerce to a default). `None` = leave unchanged.
+- **No `write_notes` re-run, no LLM (R9):** every op is a pure parse→mutate→serialize→`update_artifact_body`.
+
+### D5-18. No document propagation in v1 (the simplification vs Plan 16)
+Plan 16 had to thread `right` → `qty` into `render_structure_document` because items ARE the document. Buckets are **not** — the built document (`DocumentSheet`) renders items + totals + terms + signature, never the coordination buckets. So a bucket edit must reach exactly two readers, **both of which read the artifact**: the notes screen (`session_notes()`) and notes export (`exportNotes()`, app-side, over the same payload). Rewriting the artifact body satisfies both — **no document-builder change**. (When #207's `DocumentSchema` lets buckets flow into a document, they propagate for free: the builder would read the same artifact this seam rewrites.) Reviewer: confirm no document test depends on notes-bucket content (they don't — the builder never reads the `kind=="notes"` artifact).
+
+### D6-18. Sync bookkeeping: the **artifact row's** `updated_at`, not the session's
+`update_artifact_body` bumps the artifact row's `updated_at` (it already does). The session `updated_at` is **not** bumped — consistent with Plan 16 D6-16 (mutations are row-level sync events). The artifact row + `device_id` is the sync unit; a session bump would create false conflicts.
+
+---
+
+## Worked examples (reviewers: hand-recompute against the real code)
+
+Conventions: the `kind=="notes"` artifact body is `{"buckets":[{ "id"?, "bucket", "label", "detail" }, …]}`. `parse_notes_artifact` → `Vec<NotesEntry>` in body order (mint `id` where absent). App renders grouped by fixed bucket order; within a bucket, body order.
+
+**Shared fixture F1 (landscape, Processed).** Notes artifact, three entries (ids N1<N2<N3 by insertion):
+
+| id | bucket | label | detail |
+|----|--------|-------|--------|
+| N1 | `scope_of_work` | `Mulch — front beds` | `Darker mulch than last year.` |
+| N2 | `constraints` | `Budget` | `Under $1,200.` |
+| N3 | `conditions_and_issues` | `Zone-2 head broken` | `Replace — parts + labor.` |
+
+**WE-A — `update_notes_entry` fixes a mis-heard detail.** `update_notes_entry(sid, N2, label=None, detail=Some("Under $2,100."), bucket=None)`.
+- Validate: `Processed` ✓; `detail` any string ✓; `label`/`bucket` unchanged.
+- Read `kind=="notes"` artifact → parse → find N2 → set `detail="Under $2,100."` → `serialize_buckets` → `update_artifact_body(artifact_id, body)`. Artifact `updated_at` bumped; session's not (D6).
+- `session_notes()` now returns N2 with the corrected detail; `CONSTRAINTS` on screen (and in `exportNotes`) reflects it. **No LLM, no document change (D5).** ✓
+
+**WE-B — re-file a bucket.** `update_notes_entry(sid, N1, label=None, detail=None, bucket=Some("constraints"))`.
+- `NotesBucket::from_wire("constraints")` = `Some(Constraints)` ✓. N1 moves `scope_of_work → constraints`. Re-serialize. On screen N1 leaves `SCOPE OF WORK`, joins `CONSTRAINTS` (fixed-order render). An unknown target (`from_wire("logistics") == None`) → `EngineError::NotesEntry` (R6). ✓
+
+**WE-C — `remove_notes_entry` drops an entry.** `remove_notes_entry(sid, N3)`. Parse → drop N3 → serialize (now 2 entries) → `update_artifact_body`. `session_notes()` = [N1, N2]; `CONDITIONS & ISSUES` section disappears (empty buckets are omitted by the app's `bucketed`). A second `remove_notes_entry(sid, N3)` → `EngineError::NotesEntry` (id absent). ✓
+
+**WE-D — `add_notes_entry` appends.** `add_notes_entry(sid, bucket="scope_of_work", label="Edge the beds", detail="")`. Mint N4; append. `session_notes()` = [N1, N2, N4] (N3 removed in WE-C); N4 is the **last** `scope_of_work` entry on screen; `detail=""` renders label-only. If **no** `kind=="notes"` artifact exists yet (a walk that captured items but no coordination notes), `add_notes_entry` **creates** one via `add_artifact(kind="notes", body=serialize_buckets(&[N4]))`. ✓
+
+**WE-E — legacy artifact backfills ids on first edit.** A pre-18 artifact body `{"buckets":[{"bucket":"scope_of_work","label":"Mulch","detail":"…"}]}` (no `"id"`). `session_notes()` parses it, `parse_notes_artifact` **mints** an id for the entry (display-stable within the process). The first `update_notes_entry`/`add`/`remove` re-serializes **with** ids and `update_artifact_body` persists them — subsequent reads carry the same ids. Un-edited legacy sessions are unchanged on disk (the mint is display-only until an edit writes it). Reviewer: confirm the mint is deterministic-enough for one process lifetime (a fresh UUIDv7 per parse is fine — the app only needs stability between a read and the edit it triggers, and the edit persists it). ✓
+
+---
+
+## Staging (main stays shippable)
+
+**ONE PR** (`pr/dam/plan-18-notes-entry-crud` → main). All-additive: an `id` field on the notes artifact's `NotesEntry` (backward-compatible parse), a new FFI CRUD module rewriting the artifact body, a new `EngineError` variant, a Swift protocol seam + demo parity. No migration (the artifact body is schemaless JSON — an added field is tolerated by the existing tolerant parser). Gated by `cargo test --workspace` + `clippy --workspace --all-targets -- -D warnings` + iOS **demo** build + **the mandatory dam-manual real-core compile + bindings-drift check (Task 5)**.
+
+---
+
+## Tasks
+
+### Task 1 — `NotesEntry.id` + artifact round-trip (murmur-core; D2-18)
+- [ ] **RED** (`pipeline/notes.rs` tests): (a) `parse_notes_artifact` on a body **with** `"id"` preserves it; (b) on a body **without** `"id"` mints a non-empty id per entry; (c) `serialize_buckets(parse(body))` round-trips ids (parse → serialize → parse yields identical ids); (d) the existing tolerant-parse tests (garbled → `[]`, non-array → `[]`) stay green.
+- [ ] **GREEN:** add `pub id: String` to `pipeline::notes::NotesEntry` (place first). In `parse_notes_value`, read `entry["id"].as_str()`; if absent/empty, `murmur_core::new_id()` (the UUIDv7 mint used everywhere). In `serialize_buckets`, emit `"id"`. Keep the bucket-string tolerance unchanged.
+- [ ] **Gate:** `nix develop -c cargo test -p murmur-core` + `clippy -p murmur-core --all-targets -- -D warnings`. All pre-existing notes/pipeline tests green.
+
+### Task 2 — FFI CRUD: `update_notes_entry` / `add_notes_entry` / `remove_notes_entry` (ffi; D1-18/D3-18/D4-18)
+- [ ] **RED** (new module `crates/ffi/src/notes_crud.rs`, reusing the `SpyStore` + literal-`Providers` harness from `items.rs`; `mod notes_crud;` in `lib.rs`):
+  - **Status gate (D3):** each op on `Recording`/`AwaitingProcessing` → `EngineError::NotesEntry`; on `Processed` → `Ok`. (Build the `Processed` fixture as `items.rs`/`document_build.rs` do.)
+  - **Validation (D4/R6):** empty/whitespace `label` (update-with-`Some` or add) → `NotesEntry`; an unknown `bucket` wire string → `NotesEntry`; a missing `id` (update/remove) → `NotesEntry`.
+  - **Round-trip:** after `update_notes_entry(N2, detail="…")`, `session_notes()` reflects it; `remove` drops; `add` appends and, when **no** notes artifact exists, **creates** one.
+  - **Backfill (WE-E):** an id-less legacy artifact → first edit persists ids (re-read shows stable ids).
+- [ ] **GREEN:** add `id: String` to `crates/ffi/src/notes.rs::NotesEntry`; thread it in `convert::notes_entries` (`NotesEntry { id: e.id.clone(), bucket, label, detail }`). Add `EngineError::NotesEntry(String)` (`flat_error`, store/validation strings only — no api key). In `notes_crud.rs`:
+  ```rust
+  #[uniffi::export]
+  impl MurmurEngine {
+      pub fn update_notes_entry(&self, session_id: String, entry_id: String,
+          label: Option<String>, detail: Option<String>, bucket: Option<String>)
+          -> Result<NotesEntry, EngineError>
+      pub fn add_notes_entry(&self, session_id: String,
+          bucket: String, label: String, detail: String) -> Result<NotesEntry, EngineError>
+      pub fn remove_notes_entry(&self, session_id: String, entry_id: String)
+          -> Result<(), EngineError>
+  }
+  ```
+  Each: lock the store once; `get_session` → reject `status != Processed` (D3, same-lock, no await); validate (`label` trim-non-empty when required; `bucket` via `NotesBucket::from_wire`); load the latest `kind=="notes"` artifact (`list_artifacts_for_session`, `.rev().find(|a| a.kind == "notes")` — the `session_notes` pattern); `parse_notes_artifact(&artifact.body)`; mutate the `Vec` (find-by-id / drop-by-id / append); `serialize_buckets`; `update_artifact_body(&artifact.id, &body)`. **`add` with no existing artifact:** `add_artifact(session_id, "notes", "", serialize_buckets(&[new]))`. Return the fresh FFI `NotesEntry` (with `id`). Panic-free: poisoned lock → `EngineError::NotesEntry("store lock poisoned")`.
+- [ ] **Gate:** `nix develop -c cargo test -p ffi` + `clippy -p ffi --all-targets -- -D warnings`.
+
+### Task 3 — round-trip pinned end-to-end (ffi; WE-A…WE-E)
+- [ ] **RED** (`notes_crud.rs` tests, asserting through `session_notes()`): WE-A (detail edit reflected), WE-B (bucket re-file), WE-C (remove drops + second-remove errors), WE-D (add appends + create-when-absent), WE-E (legacy backfill persists). Pin the **negative**: no notes op changes `reflection_signals().corrections_since_reflection` (Plan 18 wires no correction signal — that's Plan 17's domain; guards a stray coupling).
+- [ ] **Gate:** `nix develop -c cargo test -p ffi` + `nix develop -c cargo test --workspace` (whole workspace green; no `whisper`, no model).
+
+### Task 4 — Swift seam + demo parity (apps/ios; edit UI is sac's sibling PR, ALREADY BUILT)
+- [ ] **Protocol** (`WalkEngine.swift`): add `updateNotesEntry(sessionId:entryId:label:detail:bucket:) throws -> NotesEntryFixture`, `addNotesEntry(sessionId:bucket:label:detail:) throws -> NotesEntryFixture`, `removeNotesEntry(sessionId:entryId:) throws`. `NotesEntryFixture` gains `id: String` (was `let id = UUID()`). `NotesBucket` gains `wire`/`init?(wire:)`. **The `// sac:` contract mirrors Plan 16's:** edit affordances gate on `!notes.queued`; the returned entry is an optimistic echo (patch in place; engine is source of truth); `bucket` crosses the seam as a wire string.
+- [ ] **`MurmurEngine`** (real, `#if canImport(MurmurCoreFFI)`): **PENDING dam's FFI (Task 2)** — the three methods `throw` a `notesEntrySeamPending` error with a `// TODO(dam, Plan 18): forward to engine.updateNotesEntry(...)` marker; `MurmurEngineFormatting.notesEntry` maps the new `entry.id` once the FFI record carries it (synthesized UUID with a TODO until then). This keeps the real-core archive compiling; dam swaps the throws for the real calls in Task 2/5.
+- [ ] **`DemoWalkEngine`** parity: a per-session `notesEntries: [NotesEntryFixture]` (seeded from the sample buckets at `finish()`, stable ids); `update` partial-applies + validates `bucket` against the three wire strings + rejects empty `label` + `.processed`-gated (reuse `requireEditable`); `add` appends; `remove` drops. Enough to drive the edit UI with no backend. **(DONE in the sibling UI PR's demo changes.)**
+- [ ] **Gate:** iOS **demo** build (xcodebuild OUTSIDE nix): `xcodebuild -project SitewalkGallery.xcodeproj -scheme SitewalkGallery -destination 'platform=iOS Simulator,name=iPhone 17' build`.
+
+### Task 5 — real-core compile + bindings drift (dam-manual) + merge **[MANDATORY GATE]**
+- [ ] dam runs `cd apps/ios && ./build-ffi.sh && ./generate.sh && xcodebuild … build` — confirm the real-core archive compiles against the new `update_notes_entry`/`add_notes_entry`/`remove_notes_entry` + `EngineError::NotesEntry` + `NotesEntry.id` bindings, and **swaps the `MurmurEngine` `pending` stubs for the real forwards** + wires `entry.id` in `MurmurEngineFormatting`.
+- [ ] Bindings-drift check: regenerate Swift bindings; confirm the three methods resolve, `EngineError.notesEntry` is present, `NotesEntry.id` exists, no unrelated record drifted.
+- [ ] **Merge** — TestFlight internal lane publishes the notes-bucket edit seam on real-engine. (sac's edit-UI PR follows/rebases on this.)
+
+---
+
+## Gates (every task)
+- `nix develop -c cargo test --workspace` — exit 0 (run under the Nix shell; never grep counts).
+- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings`.
+- **All pre-existing notes / artifact / document / reflection tests stay green** (the `id` field is backward-compatible parse; no builder change).
+- iOS **demo** build (CI-gated) — **outside** the Nix shell.
+- **MANDATORY:** real-core compile + bindings-drift (dam-manual, Task 5) — before merge.
+
+## Acceptance criteria
+1. `pipeline::notes::NotesEntry` carries a stable `id`, round-tripped through `parse_notes_artifact`/`serialize_buckets`, minted for legacy id-less entries (Task 1, WE-E).
+2. `MurmurEngine::update_notes_entry`/`add_notes_entry`/`remove_notes_entry` are engine-keyed and **`Processed`-gated**; other statuses → `EngineError::NotesEntry` (Task 2, D3).
+3. Edits rewrite the `kind=="notes"` artifact body via `update_artifact_body` (or create it on first add), so `session_notes()` and `exportNotes()` reflect every edit — **no document-builder change** (Task 2/3, D5).
+4. `bucket` re-file is validated via `NotesBucket::from_wire` (unknown rejected, R6); empty `label` rejected; `detail` free-form (Task 2, D4).
+5. `remove` drops the entry (second remove → error); `add` appends and creates the artifact when absent (Task 3, WE-C/WE-D).
+6. **No correction-learning side effect** — no notes op touches `record_correction` (Task 3; that's Plan 17). 
+7. The Swift seam exists on both engines with the `// sac:` echo/`!notes.queued` contract; the demo engine drives the edit UI with no backend; the real-core archive builds after dam swaps the stubs (Task 4/5).
+
+## Non-goals (explicit)
+- **The SUMMARY** (narrative `NotesPayload.summary`) — a different field/seam; deferred.
+- **Document propagation** — buckets don't render into the built document today (D5); they will for free under #207's `DocumentSchema`. No `render_structure_document` change here.
+- **Correction-learning** — Plan 17 owns `record_correction` + the vocab suggest-card; a bucket edit wires none of it.
+- **Mid-walk editing** — `Recording`/`AwaitingProcessing`/`Failed` mutations forbidden (D3); edit-at-review (`Processed`) is the whole surface.
+- **A per-entry tombstone row / a buckets table** — the buckets stay a derived artifact (D1, keeper D-#5); promoting them to rows is a larger sync-schema change, not warranted at review scale.
+
+## Risks & rollback
+- **Risk — id instability across a reprocess.** A `Failed`→retry reprocess rewrites the whole `kind=="notes"` artifact (fresh `write_notes`), minting new ids and discarding prior edits. Bounded/deliberate: editing is `Processed`-gated (D3), and a `Processed` session is not reprocessed; a salvage-a-Failed-session surface is a future design round. Rollback: none needed.
+- **Risk — the artifact `add`-when-absent races an offline finish.** `add_notes_entry` on a session whose `finish()` degraded (`queued`, no `Processed`) is blocked by the D3 gate (the app also gates the affordance on `!notes.queued`), so the create path only runs on a `Processed` session that legitimately had zero coordination notes. 
+- **Risk — a body without `"buckets"` or malformed JSON.** `parse_notes_artifact` already degrades to `[]` (R7); a mutate-on-`[]` for `add` yields a one-entry body (fine); `update`/`remove` on `[]` → id-not-found → `EngineError::NotesEntry` (correct — nothing to edit).
+- **Rollback of the whole plan:** delete `crates/ffi/src/notes_crud.rs` + `EngineError::NotesEntry` + the `NotesEntry.id` field (ffi + core) + the Swift protocol methods/demo parity. The artifact bodies with an extra `"id"` remain valid under the pre-18 tolerant parser (the field is ignored), so no data migration is needed. All additive → clean revert.
+
+## Open questions
+1. **Full `loadNotes` re-read seam (dam).** This plan patches the echo in place (Plan 16 parity). The walk-reopen work (#223: `listSessions`/`loadNotes` over FFI) is the natural home for a full bucket re-read; until it lands, the echo-patch is the sanctioned path. — **recommend: echo-patch now; fold a `loadNotes` bucket re-read into #223.**
+2. **Editing an empty-`detail` entry vs deleting it (sac UI).** A label-only entry is valid (D1). Should the UI nudge "add detail or remove"? — **recommend: allow label-only; no nudge; sac's call.**


### PR DESCRIPTION
> ⚠️ **DRAFT — do not merge before dam's Plan 18 core seam.** On real-engine the bucket-edit calls are throwing `pending` stubs until the FFI CRUD lands; the **demo engine works fully**. Land dam's seam (this PR's plan doc) first or together, then flip the stubs.

## Thinking

**The bug.** The notes screen's first three sections — **Scope of Work / Constraints / Conditions & Issues** (the Plan-14 coordination buckets) — render read-only. Plan 16's tap-to-edit only wired the priced *items* board (`notes.items` / `CapturedFixture`); the buckets are a different type (`notes.notes` / `NotesEntryFixture`) with **no tap and no CRUD path anywhere** — not in `AppModel`, not in the `WalkEngine` seam, not in core.

**Why it's not a UI-only fix.** The buckets are a derived `kind=="notes"` **artifact** (`{"buckets":[…]}` JSON), not item rows — core `NotesEntry` has no id and no store CRUD (only `parse_notes_artifact` / `serialize_buckets`). So an app-only edit would have nowhere to commit and would be dropped on the next `session_notes()` read — violating the "commit through core / one source of truth" rule Plan 16's own seam comments enforce. This is exactly the *"narrative bucket editing … versioning the NotesPayload artifact, a different seam"* that Plan 16 deferred (keeper **D-#5**).

**The split (mirrors Plan 16: seam + UI).** dam owns the core/FFI notes-entry CRUD — plan in this PR at `docs/superpowers/plans/2026-07-17-rust-core-18-notes-entry-crud.md`. This PR is the **app-side seam + demo parity + the edit UI**.

**Design decisions (carried from Plan 16 where they transfer):**
- **Artifact rewrite, not a new table.** The seam reuses `parse_notes_artifact` → mutate → `serialize_buckets` → the **existing** `update_artifact_body` — **no migration** (simpler than Plan 16's `right_text` column).
- **Stable `id` on `NotesEntry`** so edits are id-keyed like items (mint-at-write, backfill legacy on first edit).
- **Processed-gated** (the `build_document` / Plan-16 rule); bucket re-file validated via `NotesBucket::from_wire` (R6).
- **No document propagation** — buckets are notes-screen + export content, not built-document content, so a bucket edit needs only the artifact rewrite (**no `render_structure_document` change**). They flow into documents for free under #207's DocumentSchema.
- **Real-core is a `pending` throwing stub** so the archive keeps compiling now; dam swaps it for `engine.updateNotesEntry(...)` in his Task 2/5. The **demo engine** carries full in-memory parity that drives the UI.

## What's in this PR (app-side · sac)
- **`NotesView`** — `notesEntryRow` is tap-to-edit; a `＋ ADD NOTE` affordance; a new `NotesEntryEditSheet` (label / detail / section-picker / remove), mirroring `NoteItemEditSheet`. Edit affordances gate on `!notes.queued` (same as the build buttons).
- **`AppModel`** — `editNotesEntry` / `addNotesEntry` / `removeNotesEntry` (mirror the item CRUD; shared `notesEditError` surface).
- **`WalkEngine`** — the three protocol methods + the `// sac:` contract; `NotesEntryFixture` gains a stable `id`; `NotesBucket` gains `wire` / `init?(wire:)`.
- **`DemoWalkEngine`** — per-session `notesEntries`, Processed-gated in-memory CRUD.
- **`MurmurEngine` / `MurmurEngineFormatting`** — `pending` throwing stubs + `id` synth, both with `TODO(dam)` markers.

## What dam owns (the plan, in this PR)
`docs/superpowers/plans/2026-07-17-rust-core-18-notes-entry-crud.md`:
- **Task 1** — `NotesEntry.id` + artifact round-trip (mint/backfill).
- **Task 2** — FFI CRUD `update/add/remove_notes_entry` by artifact rewrite, Processed-gated, `EngineError::NotesEntry`, bucket validation.
- **Task 3** — WE-A…WE-E round-trip pins (through `session_notes()`), incl. the create-when-absent + legacy-backfill cases; negative pin that no notes op touches `record_correction`.
- **Task 5** — real-core compile + **swap the `pending` stubs for real forwards** + merge.

## Verification
- `xcodebuild` → **BUILD SUCCEEDED** on the demo engine (iPhone 17 sim).
- Rendered on-sim: the three bucket sections are tap-to-edit and `＋ ADD NOTE` shows; no regression to the rest of the notes screen.

## Merge gate
Land dam's core seam (Task 2/5) **before/with** this on the TestFlight-publishing main. Until then: demo works; real-core bucket edits throw gracefully (surfaced via the existing `notesEditError` bar).

*Note: meta/STATE + ROADMAP intentionally not touched — this branch is off an older `main`; the STATE/ROADMAP note lands at rebase onto the current sac line to avoid a stale-file conflict.*
