### PR TITLE
fix(ios): gate edit affordances on !notes.queued (post-merge review of #232)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -397,6 +397,7 @@ final class AppModel {
         photos = []
         notes = nil
         documentBuildError = nil
+        notesEditError = nil
         phase = .board
         path = []
     }
@@ -440,6 +441,7 @@ final class AppModel {
     func dismissNotes() {
         notes = nil
         documentBuildError = nil
+        notesEditError = nil
         reviewKind = nil
         currentSessionId = nil
         phase = .board
@@ -463,6 +465,7 @@ final class AppModel {
     func buildDocument(kind: String) {
         guard let sessionId = currentSessionId, !isBuildingDocument else { return }
         documentBuildError = nil
+        notesEditError = nil
         isBuildingDocument = true
         buildingKind = kind
         Task {
@@ -548,6 +551,7 @@ final class AppModel {
     /// build overwrites it. Pops just the review frame (board → notes).
     func backToNotes() {
         documentBuildError = nil
+        notesEditError = nil
         reviewKind = nil
         phase = .notes
         path = [.notes]

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -57,20 +57,26 @@ struct NotesView: View {
                         bucketSections
                         if notes.items.isEmpty && notes.notes.isEmpty {
                             emptyState
-                            addLineButton
+                            if !notes.queued { addLineButton }
                         } else {
                             if !notes.items.isEmpty {
                                 ForEach(grouped, id: \.0) { kind, items in
                                     SectionHead(left: sectionTitle(kind), right: "\(items.count)", heavyRule: false)
                                         .padding(.top, 4)
                                     ForEach(items) { item in
+                                        // Edit gates on !queued (Plan 16 contract clause a):
+                                        // a queued/Failed session's items are swept by the
+                                        // retry reprocess — the engine refuses edits by
+                                        // design, so the affordance must not render.
                                         CapturedRow(item: item)
                                             .contentShape(Rectangle())
-                                            .onTapGesture { itemEdit = .edit(item) }
+                                            .onTapGesture {
+                                                if !notes.queued { itemEdit = .edit(item) }
+                                            }
                                     }
                                 }
                             }
-                            addLineButton
+                            if !notes.queued { addLineButton }
                             transcriptRow
                         }
                         if let message = model.notesEditError {


### PR DESCRIPTION
## Thinking

Retroactive review of #232 (merged without CI/review during the Actions hold — full report being posted there). Verdict: the tap-to-fix UI is sound — clean merge, errors surfaced not swallowed, no crash surfaces, the honest-echo invariant neutralizes the fresh-read deviation — except **one violated contract clause on the real-core path**: edit affordances rendered on queued/Failed sessions, where the engine refuses edits by design (offline walk → tap a line → SAVE → EngineError.Item → 'try again' that can never succeed). Demo builds structurally can't hit it (demo never sets queued), which is why even green CI wouldn't have caught it.

Fix: the affordances now gate on `!notes.queued` — the same rule the build buttons already follow — plus `notesEditError` resets at the four screen exits so walk N's error bar can't leak onto walk N+1 (review F3).

Follow-ups filed with sac, not blocking: sheet-dismisses-on-error comment mismatch (F4), no remove-undo (F5), and F2 — the seam has NO notes re-read method, so 'fresh-read after mutation' isn't currently implementable; either the seam grows a board re-read or the contract documents honest-echo as the load-bearing invariant. That call rides into Plan 18.

Verified: demo build green with the fix; main's three gates were run locally post-#232 (all pass).