### PR TITLE
Field fixes: walk-reopen + whisper warm-up — and the fresh-read contract repaid (Plan 20)

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -590,10 +590,29 @@ public protocol MurmurEngineProtocol : AnyObject {
     func listPhotos(sessionId: String) throws  -> [PhotoRef]
     
     /**
+     * The board walk log (D2/D3): every reopenable walk, newest first —
+     * never a transcript (Plan 04 lesson), never a Recording or tombstoned
+     * row. Read-only: safe at app-open alongside the sweeps (R4).
+     */
+    func listSessions() throws  -> [WalkSummary]
+    
+    /**
      * The user's vocabulary terms, insertion order. Read-only — no lock held
      * across FFI beyond the clone.
      */
     func listVocabulary() throws  -> [String]
+    
+    /**
+     * Plan 20 D1/D4 — the walk-reopen read seam AND the Plan 16 clause-(b)
+     * sanctioned post-edit fresh read. Returns a `NotesPayload`
+     * field-by-field identical to what `finish()` returned for the same
+     * session (WE-A), reconstructed from the store through the SAME funnel
+     * (`notes_payload_from_store`). Engine-keyed: works after the live
+     * `WalkSession` is gone (relaunch, board reopen). A missing/tombstoned
+     * session -> `Err` (a reopen that loses a delete/sweep race surfaces to
+     * Swift as a catchable error, never a silent payload).
+     */
+    func loadNotes(sessionId: String) throws  -> NotesPayload
     
     /**
      * Tombstone. A second remove of the same id errors (the store's
@@ -695,6 +714,15 @@ public protocol MurmurEngineProtocol : AnyObject {
      * after any mutation (keeper D-#7), never rebuild state from this echo.
      */
     func updateItem(sessionId: String, itemId: String, text: String?, kind: String?, right: String?) throws  -> BoardItem
+    
+    /**
+     * Plan 20 D7: app-open background STT warm-up. The shell fires this
+     * fire-and-forget from the TAIL of its app-open sweeps (AFTER the
+     * synchronous sweeps — the #185 invariant); a failure is silent-degrade
+     * (log + swallow on the Swift side): the next `begin` cold-loads on
+     * demand exactly as before. Must never block or crash the app.
+     */
+    func warmStt() throws 
     
 }
 
@@ -884,12 +912,42 @@ open func listPhotos(sessionId: String)throws  -> [PhotoRef] {
 }
     
     /**
+     * The board walk log (D2/D3): every reopenable walk, newest first —
+     * never a transcript (Plan 04 lesson), never a Recording or tombstoned
+     * row. Read-only: safe at app-open alongside the sweeps (R4).
+     */
+open func listSessions()throws  -> [WalkSummary] {
+    return try  FfiConverterSequenceTypeWalkSummary.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_list_sessions(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
      * The user's vocabulary terms, insertion order. Read-only — no lock held
      * across FFI beyond the clone.
      */
 open func listVocabulary()throws  -> [String] {
     return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
     uniffi_ffi_fn_method_murmurengine_list_vocabulary(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Plan 20 D1/D4 — the walk-reopen read seam AND the Plan 16 clause-(b)
+     * sanctioned post-edit fresh read. Returns a `NotesPayload`
+     * field-by-field identical to what `finish()` returned for the same
+     * session (WE-A), reconstructed from the store through the SAME funnel
+     * (`notes_payload_from_store`). Engine-keyed: works after the live
+     * `WalkSession` is gone (relaunch, board reopen). A missing/tombstoned
+     * session -> `Err` (a reopen that loses a delete/sweep race surfaces to
+     * Swift as a catchable error, never a silent payload).
+     */
+open func loadNotes(sessionId: String)throws  -> NotesPayload {
+    return try  FfiConverterTypeNotesPayload.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_load_notes(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),$0
     )
 })
 }
@@ -1059,6 +1117,19 @@ open func updateItem(sessionId: String, itemId: String, text: String?, kind: Str
         FfiConverterOptionString.lower(right),$0
     )
 })
+}
+    
+    /**
+     * Plan 20 D7: app-open background STT warm-up. The shell fires this
+     * fire-and-forget from the TAIL of its app-open sweeps (AFTER the
+     * synchronous sweeps — the #185 invariant); a failure is silent-degrade
+     * (log + swallow on the Swift side): the next `begin` cold-loads on
+     * demand exactly as before. Must never block or crash the app.
+     */
+open func warmStt()throws  {try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_warm_stt(self.uniffiClonePointer(),$0
+    )
+}
 }
     
 
@@ -3083,6 +3154,152 @@ public func FfiConverterTypeSeedReport_lower(_ value: SeedReport) -> RustBuffer 
 
 
 /**
+ * One board walk-log row (D2): a lightweight projection — NO transcript.
+ * `queued = status != Processed` (the same predicate `NotesPayload.queued`
+ * carries); `has_document` = a live `document` artifact exists (a
+ * built-and-kept walk).
+ */
+public struct WalkSummary {
+    public var id: String
+    /**
+     * `doc_kind_for_template(template)` — advisory, for row labeling.
+     */
+    public var docKind: String
+    public var status: WalkStatus
+    /**
+     * `session.summary`, `""` when the session never reached Processed.
+     */
+    public var summary: String
+    /**
+     * Epoch SECONDS (`Store::now()` is `as_secs` — the same clock every
+     * session timestamp uses).
+     */
+    public var startedAt: UInt64
+    /**
+     * Live items only.
+     */
+    public var itemCount: UInt32
+    public var hasDocument: Bool
+    public var queued: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, 
+        /**
+         * `doc_kind_for_template(template)` — advisory, for row labeling.
+         */docKind: String, status: WalkStatus, 
+        /**
+         * `session.summary`, `""` when the session never reached Processed.
+         */summary: String, 
+        /**
+         * Epoch SECONDS (`Store::now()` is `as_secs` — the same clock every
+         * session timestamp uses).
+         */startedAt: UInt64, 
+        /**
+         * Live items only.
+         */itemCount: UInt32, hasDocument: Bool, queued: Bool) {
+        self.id = id
+        self.docKind = docKind
+        self.status = status
+        self.summary = summary
+        self.startedAt = startedAt
+        self.itemCount = itemCount
+        self.hasDocument = hasDocument
+        self.queued = queued
+    }
+}
+
+
+
+extension WalkSummary: Equatable, Hashable {
+    public static func ==(lhs: WalkSummary, rhs: WalkSummary) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.docKind != rhs.docKind {
+            return false
+        }
+        if lhs.status != rhs.status {
+            return false
+        }
+        if lhs.summary != rhs.summary {
+            return false
+        }
+        if lhs.startedAt != rhs.startedAt {
+            return false
+        }
+        if lhs.itemCount != rhs.itemCount {
+            return false
+        }
+        if lhs.hasDocument != rhs.hasDocument {
+            return false
+        }
+        if lhs.queued != rhs.queued {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(docKind)
+        hasher.combine(status)
+        hasher.combine(summary)
+        hasher.combine(startedAt)
+        hasher.combine(itemCount)
+        hasher.combine(hasDocument)
+        hasher.combine(queued)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWalkSummary: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WalkSummary {
+        return
+            try WalkSummary(
+                id: FfiConverterString.read(from: &buf), 
+                docKind: FfiConverterString.read(from: &buf), 
+                status: FfiConverterTypeWalkStatus.read(from: &buf), 
+                summary: FfiConverterString.read(from: &buf), 
+                startedAt: FfiConverterUInt64.read(from: &buf), 
+                itemCount: FfiConverterUInt32.read(from: &buf), 
+                hasDocument: FfiConverterBool.read(from: &buf), 
+                queued: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WalkSummary, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.docKind, into: &buf)
+        FfiConverterTypeWalkStatus.write(value.status, into: &buf)
+        FfiConverterString.write(value.summary, into: &buf)
+        FfiConverterUInt64.write(value.startedAt, into: &buf)
+        FfiConverterUInt32.write(value.itemCount, into: &buf)
+        FfiConverterBool.write(value.hasDocument, into: &buf)
+        FfiConverterBool.write(value.queued, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWalkSummary_lift(_ buf: RustBuffer) throws -> WalkSummary {
+    return try FfiConverterTypeWalkSummary.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWalkSummary_lower(_ value: WalkSummary) -> RustBuffer {
+    return FfiConverterTypeWalkSummary.lower(value)
+}
+
+
+/**
  * Fallible-path errors that cross the FFI boundary as a thrown error rather
  * than a panic (Plan 07 CANON: no panics across FFI). `flat_error` means the
  * Swift side receives the variant plus its `Display` message — no api key is
@@ -3426,6 +3643,82 @@ extension WalkEvent: Equatable, Hashable {}
 
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * A finished walk's status at the FFI boundary (D3). Core's
+ * `AwaitingProcessing` maps to `Processing` (Swift's `.processing`);
+ * `Recording` never crosses — `list_walk_summaries` excludes it.
+ */
+
+public enum WalkStatus {
+    
+    case processing
+    case processed
+    case failed
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWalkStatus: FfiConverterRustBuffer {
+    typealias SwiftType = WalkStatus
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WalkStatus {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .processing
+        
+        case 2: return .processed
+        
+        case 3: return .failed
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WalkStatus, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .processing:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .processed:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .failed:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWalkStatus_lift(_ buf: RustBuffer) throws -> WalkStatus {
+    return try FfiConverterTypeWalkStatus.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWalkStatus_lower(_ value: WalkStatus) -> RustBuffer {
+    return FfiConverterTypeWalkStatus.lower(value)
+}
+
+
+
+extension WalkStatus: Equatable, Hashable {}
+
+
+
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
@@ -3747,6 +4040,31 @@ fileprivate struct FfiConverterSequenceTypeSchemaSection: FfiConverterRustBuffer
         return seq
     }
 }
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeWalkSummary: FfiConverterRustBuffer {
+    typealias SwiftType = [WalkSummary]
+
+    public static func write(_ value: [WalkSummary], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeWalkSummary.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [WalkSummary] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [WalkSummary]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeWalkSummary.read(from: &buf))
+        }
+        return seq
+    }
+}
 private let UNIFFI_RUST_FUTURE_POLL_READY: Int8 = 0
 private let UNIFFI_RUST_FUTURE_POLL_MAYBE_READY: Int8 = 1
 
@@ -3833,7 +4151,13 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ffi_checksum_method_murmurengine_list_photos() != 9711) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_list_sessions() != 19041) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_list_vocabulary() != 10809) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_load_notes() != 52536) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_remove_document_schema() != 20008) {
@@ -3861,6 +4185,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_update_item() != 53674) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_warm_stt() != 63939) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_walkeventlistener_on_event() != 10314) {

--- a/apps/ios/Sources/App/AppModel+Photos.swift
+++ b/apps/ios/Sources/App/AppModel+Photos.swift
@@ -113,6 +113,14 @@ extension AppModel {
         sweepPhotoBytes()
         sweepZombieSessions()
         retryFailedSessionsInBackground()
+        // Plan 20: BOTH tail calls sit strictly AFTER the synchronous sweeps
+        // (#185 invariant — nothing async may run before them).
+        warmSttInBackground()
+        // Read-only walk-log hydrate (D5/R4): `listSessions` mutates nothing
+        // and Recording rows are excluded, so it cannot surface or disturb a
+        // walk. Runs here (the quiescent app-open point), never on a
+        // scenePhase re-trigger — and it is once-per-process guarded anyway.
+        hydrateWalkLog()
     }
 
     /// The offline banner ("SAVED OFFLINE — DOCUMENTS UNLOCK WHEN YOU
@@ -154,6 +162,26 @@ extension AppModel {
             let recovered = (try? await engine.retryFailedSessions()) ?? 0
             if recovered > 0 {
                 photoLogger.notice("retried and recovered \(recovered, privacy: .public) failed session(s)")
+            }
+        }
+    }
+
+    /// Plan 20 D7: warm the whisper model at app open so the first START WALK
+    /// tap doesn't pay the model read + Metal init (#228). Mirrors
+    /// `retryFailedSessionsInBackground` exactly: a separate, NOT-awaited
+    /// `Task` fired from the TAIL of `runAppOpenSweeps()` — it must NEVER run
+    /// before the synchronous sweeps (#185 invariant: a suspension point ahead
+    /// of them could let a walk start and get swept/Failed) and never delay
+    /// them. Failure is SILENT-DEGRADE: log + swallow; the next `begin`
+    /// cold-loads on demand (today's exact behavior — warm-up must never
+    /// block or crash the app). Idempotent on the Rust side (path-keyed
+    /// holder), so a `.task` re-fire is a cheap no-op.
+    private func warmSttInBackground() {
+        Task {
+            do {
+                try await engine.warmStt()
+            } catch {
+                photoLogger.error("stt warm-up failed (cold-load fallback): \(error, privacy: .public)")
             }
         }
     }

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -47,15 +47,46 @@ final class AppModel {
     /// `saveDocumentLayout`. Separate from `branding` (style) on purpose.
     var documentLayout: DocumentLayout = .current
 
-    /// One board row per walk finished THIS SESSION (profile mode replaces
-    /// the fixture jobs list with this honest log). In-memory on purpose —
-    /// walk history is a core concern; this is the interim surface.
+    /// One board row per finished walk. Plan 20: no longer this-session-only —
+    /// `hydrateWalkLog()` fills it from `engine.listSessions()` at app open,
+    /// so history survives relaunch; `completeSend`/`discardDocument` still
+    /// append full-fidelity in-session records until the next hydrate.
     struct WalkRecord: Identifiable {
         let id = UUID()
         let time: String     // "9:41"
         let docNo: String
         let docKind: String  // "ESTIMATE" / "MOVE-OUT REPORT" / ...
         let sent: Bool       // false = discarded at review
+        /// The core session id this row reopens (Plan 20 D5). "" only for
+        /// legacy/demo rows with no session (reopen no-ops there).
+        let sessionId: String
+        /// Mirror of `NotesModel.queued` for the reopened-notes gating banner.
+        let queued: Bool
+
+        init(time: String, docNo: String, docKind: String, sent: Bool,
+             sessionId: String, queued: Bool) {
+            self.time = time
+            self.docNo = docNo
+            self.docKind = docKind
+            self.sent = sent
+            self.sessionId = sessionId
+            self.queued = queued
+        }
+
+        /// Board hydration mapping (Plan 20 F7, pinned): `sent` reads a
+        /// built-and-kept walk as "sent"; **`docNo` is synthesized empty** —
+        /// the document number is minted per-build and is not in the
+        /// lightweight projection, an ACCEPTED v1 fidelity loss (in-session
+        /// records keep the real number until the next hydrate overwrites
+        /// the log).
+        init(_ summary: WalkSummary) {
+            self.time = AppModel.clockTime(epochSeconds: summary.startedAt)
+            self.docNo = ""
+            self.docKind = DocKinds.label(for: summary.docKind)
+            self.sent = summary.hasDocument
+            self.sessionId = summary.id
+            self.queued = summary.queued
+        }
     }
     private(set) var sessionWalks: [WalkRecord] = []
 
@@ -126,6 +157,22 @@ final class AppModel {
     /// Set when an item edit/add/remove (Plan 16 CRUD) throws — surfaced on the
     /// notes screen; the edit sheet stays so the operator can retry.
     var notesEditError: String?
+    /// Set when a board-row reopen tap fails (Plan 20 F4: a NotFound/
+    /// tombstoned race must be a breadcrumb, never a silent dead tap).
+    /// // sac: the reopenError chrome is yours; the floor is the log + this
+    /// // sac: breadcrumb string surfaced near the walk log.
+    var reopenError: String?
+    /// How the current notes screen was reached — picks the queued-banner
+    /// copy (Plan 20 F5): a FRESH offline finish can honestly promise
+    /// "unlocks when you reconnect"; a REOPENED still-Failed walk cannot
+    /// (the retry sweep may already have run and exhausted).
+    enum NotesBannerReason { case liveFinish, reopened }
+    var notesBannerReason: NotesBannerReason = .liveFinish
+    /// Once-per-process guard for `hydrateWalkLog()` (Plan 20 F2, mirror of
+    /// `isRetryingFailedSessions`): SwiftUI can re-fire the launching `.task`,
+    /// and a re-hydrate must not re-run (in the demo it would race the
+    /// in-memory log).
+    var isHydratingWalkLog = false
     /// True while a build-document tap is in flight — the notes screen
     /// disables the button so a double-tap can't burn two document numbers
     /// (D7: numbers mint per generate).
@@ -420,6 +467,9 @@ final class AppModel {
         notesLoading = true
         phase = .notes
         path = [.notes]
+        // A fresh finish — the queued banner may honestly promise the
+        // reconnect retry (Plan 20 F5; the reopen path sets `.reopened`).
+        notesBannerReason = .liveFinish
         Task {
             // Flush before finish (issue #155 / CANON: flush over speed —
             // the last words of a walk are often the price). `stop()` lets a
@@ -430,6 +480,56 @@ final class AppModel {
             let notes = await engine.finish()
             self.notes = notes
             self.notesLoading = false
+        }
+    }
+
+    // MARK: Walk reopen (Plan 20 Half A) — read-only re-entry into NotesView.
+
+    /// Hydrate the board walk log from the engine (Plan 20 D5/F2) so history
+    /// survives relaunch. Called once from the app-open path — read-only
+    /// (`listSessions` mutates nothing), safe alongside the sweeps (R4).
+    /// TWO guards (F2):
+    ///  1. once-per-process (`isHydratingWalkLog`) against `.task` re-fires;
+    ///  2. overwrite only when the fetched list is NON-EMPTY or the engine is
+    ///     real-core — `DemoWalkEngine.listSessions` returns `[]`
+    ///     SUCCESSFULLY (a `??` fallback never fires), and that empty success
+    ///     must not wipe the demo's in-memory log. Real-core's `[]` is a
+    ///     legitimate "no sessions yet" and may clear a stale log.
+    func hydrateWalkLog() {
+        guard !isHydratingWalkLog else { return }
+        isHydratingWalkLog = true
+        let fetched = (try? engine.listSessions()) ?? []
+        let isRealCore = !(engine is DemoWalkEngine)
+        if !fetched.isEmpty || isRealCore {
+            sessionWalks = fetched.map(WalkRecord.init)
+        }
+    }
+
+    /// Reopen a finished walk from the board into the EXISTING NotesView
+    /// (Plan 20 D5): `loadNotes` re-reads the same payload `finish()`
+    /// returned, `currentSessionId` re-keys buildDocument/edits, and the nav
+    /// path is `[.notes]` — back returns to the board root, never to a live
+    /// walk. Read-only re-entry: no pump, no `.walking`, no resurrection.
+    /// F4: a NotFound/tombstoned race (the row was deleted/swept between
+    /// hydrate and tap) mirrors `buildDocument`'s catch — log + breadcrumb,
+    /// board stays put, never a silent dead tap.
+    func reopenWalk(sessionId: String) {
+        guard phase == .board, !sessionId.isEmpty else { return }
+        reopenError = nil
+        Task {
+            do {
+                let loaded = try await engine.loadNotes(sessionId: sessionId)
+                self.notes = loaded
+                self.notesLoading = false
+                self.notesBannerReason = .reopened
+                self.currentSessionId = sessionId
+                self.phase = .notes
+                self.path = [.notes]
+            } catch {
+                Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "walk")
+                    .error("reopenWalk(\(sessionId, privacy: .public)) failed: \(error, privacy: .public)")
+                self.reopenError = "Couldn’t reopen that walk — it may have been removed."
+            }
         }
     }
 
@@ -444,6 +544,7 @@ final class AppModel {
         notesEditError = nil
         reviewKind = nil
         currentSessionId = nil
+        notesBannerReason = .liveFinish
         phase = .board
         path = []
     }
@@ -501,13 +602,11 @@ final class AppModel {
         guard let sessionId = currentSessionId else { return }
         notesEditError = nil
         do {
-            let updated = try engine.updateItem(
+            _ = try engine.updateItem(
                 sessionId: sessionId, itemId: item.id.uuidString.lowercased(),
                 text: text, kind: nil, right: right
             )
-            guard var n = notes, let idx = n.items.firstIndex(where: { $0.id == item.id }) else { return }
-            n.items[idx] = updated
-            notes = n
+            refreshNotes(sessionId: sessionId)
         } catch {
             itemEditFailed("save", error)
         }
@@ -519,8 +618,8 @@ final class AppModel {
         guard let sessionId = currentSessionId else { return }
         notesEditError = nil
         do {
-            let added = try engine.addItem(sessionId: sessionId, kind: "note", text: text, right: right)
-            if var n = notes { n.items.append(added); notes = n }
+            _ = try engine.addItem(sessionId: sessionId, kind: "note", text: text, right: right)
+            refreshNotes(sessionId: sessionId)
         } catch {
             itemEditFailed("add", error)
         }
@@ -533,9 +632,26 @@ final class AppModel {
         notesEditError = nil
         do {
             try engine.removeItem(sessionId: sessionId, itemId: item.id.uuidString.lowercased())
-            if var n = notes { n.items.removeAll { $0.id == item.id }; notes = n }
+            refreshNotes(sessionId: sessionId)
         } catch {
             itemEditFailed("remove", error)
+        }
+    }
+
+    /// Plan 20 D4 (the Plan 16 clause-(b) contract, finally honored): after a
+    /// successful mutation the notes screen RE-READS from the engine via
+    /// `loadNotes` — the only sanctioned post-edit path — instead of patching
+    /// `notes.items` in place (the echo-as-truth anti-pattern). A failed
+    /// re-read keeps the current screen state and logs; the next edit or
+    /// reopen re-reads again.
+    private func refreshNotes(sessionId: String) {
+        Task {
+            do {
+                self.notes = try await engine.loadNotes(sessionId: sessionId)
+            } catch {
+                Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "items")
+                    .error("post-edit loadNotes failed: \(error, privacy: .public)")
+            }
         }
     }
 
@@ -677,6 +793,17 @@ final class AppModel {
         return formatter.string(from: Date())
     }
 
+    /// Board-log time from a core `started_at` (epoch seconds) — the hydrate
+    /// path's counterpart of `clockNow()` (Plan 20 F7 mapping). `nonisolated`:
+    /// pure value formatting, callable from `WalkRecord.init` (a nonisolated
+    /// struct initializer).
+    fileprivate nonisolated static func clockTime(epochSeconds: UInt64) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "h:mm"
+        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(epochSeconds)))
+    }
+
     // MARK: Review interactions
 
     func beginEdit(_ row: DocRowFixture) {
@@ -750,7 +877,8 @@ final class AppModel {
             )
         }
         sessionWalks.append(WalkRecord(
-            time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: true
+            time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: true,
+            sessionId: currentSessionId ?? "", queued: notes?.queued ?? false
         ))
         shareURL = nil
         document = nil
@@ -765,7 +893,8 @@ final class AppModel {
     /// review state resets.
     func discardDocument() {
         sessionWalks.append(WalkRecord(
-            time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: false
+            time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: false,
+            sessionId: currentSessionId ?? "", queued: notes?.queued ?? false
         ))
         shareURL = nil
         document = nil

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -214,6 +214,10 @@ final class AppModel {
     /// Set when the user tries a voice walk with mic permission denied —
     /// BoardView surfaces it with an "open Settings" affordance.
     var micDenied = false
+    /// Plan 20 D9: true from the START WALK paint until `begin` + wiring
+    /// complete — WalkView shows "MIC STARTING…" while the (usually warm,
+    /// occasionally cold-load) engine bring-up runs behind the painted screen.
+    var micStarting = false
 
     /// When live, drive the STT path from a bundled fixture WAV instead of the
     /// mic (`wavwalk=1`, D7) — a mic-free way to exercise real whisper.
@@ -294,62 +298,87 @@ final class AppModel {
         }
     }
 
+    /// Plan 20 D9: paint the walk screen FIRST, then run the (warm ⇒ cheap)
+    /// `begin` + wiring on the next main-actor turn. The paint-first block
+    /// contains ONLY `phase`/`path`/`micStarting` — NOTHING session-dependent
+    /// moves into it (the D9 numbered invariant, F3): STT/audio must never
+    /// wire onto a session `begin` didn't successfully open (Plan 07
+    /// dead-walk — a dead session would pump and silently drop every append).
     private func beginWalk() {
         pumpTask?.cancel()
         eventTask?.cancel()
 
-        // begin() is throwing (review P1): the real engine's session start is
-        // fallible across FFI. If it fails, the user must NOT enter the
-        // walking flow — a dead session would run STT and silently drop every
-        // append (capture loss). Stay on the board; walk state untouched.
-        // sac: this deserves a visible error surface ("couldn't start the
-        // walk — try again"); no error chrome exists in the app yet, so the
-        // floor here is the log breadcrumb + not entering .walking. Yours to
-        // design.
-        let events: AsyncStream<WalkEvent>
-        do {
-            events = try engine.begin(trade: trade)
-        } catch {
-            Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "walk")
-                .error("startWalk: engine.begin failed, staying on board: \(error, privacy: .public)")
-            return
-        }
-
-        transcript = ""
-        previewTail = ""
-        items = []
-        isPaused = false
-        walkStart = Date()
-        // Snapshot the session id NOW, while the engine's live session still
-        // has one — see the doc comment on `currentSessionId` (Plan 11 D7).
-        currentSessionId = engine.currentSessionId
-        photos = []
-
-        eventTask = Task { [weak self] in
-            guard let self else { return }
-            for await event in events {
-                switch event {
-                case .boardUpdated(let items):
-                    withAnimation(.easeOut(duration: 0.25)) { self.items = items }
-                    // Track the newest by id, NOT array position (see
-                    // `lastCapturedID` doc comment).
-                    self.lastCapturedID = items.last?.id
-                case .transcriptCommitted(let text):
-                    // The audio path's transcript originates in Rust (whisper).
-                    self.transcript += text
-                    self.previewTail = ""
-                case .transcriptPreview(let text):
-                    self.previewTail = text
-                }
-            }
-        }
-
+        // Paint-first block (D9): screen appears immediately; WalkView shows
+        // "MIC STARTING…" until step 4 below clears it.
+        micStarting = true
         phase = .walking
         path = [.walking]
-        if walkMode == .demo {
-            startScriptedSource()
-        } else {
-            startAudioSource()
+
+        Task { [weak self] in
+            guard let self else { return }
+            // Yield so SwiftUI renders the painted walk screen before the
+            // begin work runs on this same main actor.
+            await Task.yield()
+
+            // (1) begin() is throwing (review P1): fallible across FFI. On a
+            // throw, do NOT run steps 2–4 — revert to the board with the log
+            // breadcrumb (the existing stay-on-board posture). F6 accepted
+            // cosmetic: the screen briefly painted .walking and flashes back;
+            // re-serializing the paint behind begin would forfeit the whole
+            // D9 perceived-latency win. sac: visible error chrome is yours.
+            let events: AsyncStream<WalkEvent>
+            do {
+                events = try self.engine.begin(trade: self.trade)
+            } catch {
+                Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "walk")
+                    .error("startWalk: engine.begin failed, back to board: \(error, privacy: .public)")
+                self.micStarting = false
+                self.phase = .board
+                self.path = []
+                return
+            }
+
+            // (2) Snapshot the session id STRICTLY AFTER begin returns Ok,
+            // while the engine's live session still has one (Plan 11 D7).
+            // Must not precede (1); must not sit in the paint-first block.
+            self.currentSessionId = self.engine.currentSessionId
+
+            // (3) Reset walk state + wire the event/audio tasks — all
+            // session-dependent, so all strictly after the begin gate.
+            self.transcript = ""
+            self.previewTail = ""
+            self.items = []
+            self.isPaused = false
+            self.walkStart = Date()
+            self.photos = []
+
+            self.eventTask = Task { [weak self] in
+                guard let self else { return }
+                for await event in events {
+                    switch event {
+                    case .boardUpdated(let items):
+                        withAnimation(.easeOut(duration: 0.25)) { self.items = items }
+                        // Track the newest by id, NOT array position (see
+                        // `lastCapturedID` doc comment).
+                        self.lastCapturedID = items.last?.id
+                    case .transcriptCommitted(let text):
+                        // The audio path's transcript originates in Rust (whisper).
+                        self.transcript += text
+                        self.previewTail = ""
+                    case .transcriptPreview(let text):
+                        self.previewTail = text
+                    }
+                }
+            }
+
+            if self.walkMode == .demo {
+                self.startScriptedSource()
+            } else {
+                self.startAudioSource()
+            }
+
+            // (4) live.
+            self.micStarting = false
         }
     }
 

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -211,13 +211,37 @@ final class DemoWalkEngine: WalkEngine {
         // Simulate the notes-compute beat (the real engine targets < 8 s).
         try? await Task.sleep(for: .seconds(0.8))
         let itemWord = board.count == 1 ? "item" : "items"
-        return NotesModel(
+        let notes = NotesModel(
             summary: "Walked \(trade.site.capitalized(with: nil)) — \(board.count) \(itemWord) captured.",
             items: board,
             docKind: DocKinds.primaryKind(for: trade.key),
             queued: false,
             notes: Self.sampleNotes
         )
+        lastNotes = notes
+        return notes
+    }
+
+    // MARK: Walk-reopen read seam (Plan 20) — no-op history in the demo.
+
+    /// The last finished walk's notes, kept so the reopen/fresh-read paths
+    /// compile and behave in the demo (Plan 20 demo posture).
+    private var lastNotes: NotesModel?
+
+    /// The demo keeps its walk log in-memory (`AppModel.sessionWalks`) —
+    /// `listSessions` stays a `[]` no-op stub. `hydrateWalkLog`'s F2 guard is
+    /// what keeps this empty-success from clobbering the demo log.
+    func listSessions() -> [WalkSummary] { [] }
+
+    /// The last demo notes with the CURRENT board (so a post-edit fresh read
+    /// reflects the edit rather than reverting it), or empty notes if no walk
+    /// has finished. A harmless no-op path — never throws, never resurrects.
+    func loadNotes(sessionId: String) -> NotesModel {
+        guard var notes = lastNotes else {
+            return NotesModel(summary: "", items: [], docKind: "report", queued: false)
+        }
+        notes.items = board
+        return notes
     }
 
     // Plan 14 Task 6: scripted sample buckets (WE-A shape) so the demo build

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -228,6 +228,9 @@ final class DemoWalkEngine: WalkEngine {
     /// compile and behave in the demo (Plan 20 demo posture).
     private var lastNotes: NotesModel?
 
+    /// No model to warm in the scripted demo (Plan 20 D7) — a no-op.
+    func warmStt() {}
+
     /// The demo keeps its walk log in-memory (`AppModel.sessionWalks`) —
     /// `listSessions` stays a `[]` no-op stub. `hydrateWalkLog`'s F2 guard is
     /// what keeps this empty-success from clobbering the demo log.

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -312,6 +312,18 @@ final class MurmurEngine: WalkEngine {
         try engine.removeItem(sessionId: sessionId, itemId: itemId)
     }
 
+    // Plan 20 D7: forward to the Rust warm holder (idempotent; Ok on a
+    // text-only engine). The FFI call is a SYNC export that performs the whole
+    // model read + Metal init — run it on `Task.detached` (the attachPhoto
+    // pattern) so the main actor never pays it. The caller
+    // (`warmSttInBackground`) swallows a throw — silent-degrade to cold-load.
+    func warmStt() async throws {
+        let engine = self.engine
+        try await Task.detached(priority: .utility) {
+            try engine.warmStt()
+        }.value
+    }
+
     // MARK: - Walk-reopen read seam (Plan 20 Half A): pure reads, engine-keyed.
 
     func listSessions() throws -> [WalkSummary] {

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -48,6 +48,8 @@ typealias FFIDocLine = MurmurCoreFFI.DocLine
 typealias FFINotesPayload = MurmurCoreFFI.NotesPayload
 typealias FFINotesEntry = MurmurCoreFFI.NotesEntry
 typealias FFIBoardItem = MurmurCoreFFI.BoardItem
+typealias FFIWalkSummary = MurmurCoreFFI.WalkSummary
+typealias FFIWalkStatus = MurmurCoreFFI.WalkStatus
 private typealias FFIWalkEvent = MurmurCoreFFI.WalkEvent
 private typealias FFIWalkEventListener = MurmurCoreFFI.WalkEventListener
 
@@ -308,6 +310,23 @@ final class MurmurEngine: WalkEngine {
 
     func removeItem(sessionId: String, itemId: String) throws {
         try engine.removeItem(sessionId: sessionId, itemId: itemId)
+    }
+
+    // MARK: - Walk-reopen read seam (Plan 20 Half A): pure reads, engine-keyed.
+
+    func listSessions() throws -> [WalkSummary] {
+        try engine.listSessions().map(Self.walkSummary)
+    }
+
+    // Off-main like `attachPhoto`: the FFI read takes the same store lock the
+    // pump contends for. Reopen happens from the board (no live walk), so the
+    // wait is short — but never hold the main actor for it.
+    func loadNotes(sessionId: String) async throws -> NotesModel {
+        let engine = self.engine
+        let payload = try await Task.detached {
+            try engine.loadNotes(sessionId: sessionId)
+        }.value
+        return Self.notes(payload)
     }
 
     func sweepZombieSessions() throws -> UInt64 {

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -168,5 +168,28 @@ extension MurmurEngine {
     static func emptyNotes() -> NotesModel {
         NotesModel(summary: "", items: [], docKind: "report", queued: false)
     }
+
+    // MARK: - Walk-log mapping (Plan 20 D2/D5)
+
+    static func walkSummary(_ summary: FFIWalkSummary) -> WalkSummary {
+        WalkSummary(
+            id: summary.id,
+            docKind: summary.docKind,
+            status: walkStatus(summary.status),
+            summary: summary.summary,
+            startedAt: summary.startedAt,
+            itemCount: summary.itemCount,
+            hasDocument: summary.hasDocument,
+            queued: summary.queued
+        )
+    }
+
+    static func walkStatus(_ status: FFIWalkStatus) -> WalkStatus {
+        switch status {
+        case .processing: return .processing
+        case .processed: return .processed
+        case .failed: return .failed
+        }
+    }
 }
 #endif

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -111,6 +111,32 @@ struct NotesModel {
     var notes: [NotesEntryFixture] = []
 }
 
+/// Plan 20 D2/D3: a finished walk's status in the board log. Mirrors the
+/// uniffi `WalkStatus` enum (core `AwaitingProcessing` maps to `.processing`;
+/// `Recording` never crosses the seam — the core query excludes it).
+enum WalkStatus {
+    case processing
+    case processed
+    case failed
+}
+
+/// Plan 20 D2: one board walk-log row — the app-facing mirror of the uniffi
+/// `WalkSummary` record. A LIGHTWEIGHT projection: never a transcript.
+/// `queued` is the same gating predicate `NotesModel.queued` carries
+/// (`status != processed`); `hasDocument` = a kept document exists for the
+/// session (a built walk).
+struct WalkSummary: Identifiable, Equatable {
+    var id: String
+    var docKind: String
+    var status: WalkStatus
+    var summary: String
+    /// Epoch SECONDS (core `Store::now()` — the session clock).
+    var startedAt: UInt64
+    var itemCount: UInt32
+    var hasDocument: Bool
+    var queued: Bool
+}
+
 /// App-facing mirror of the uniffi `SeedReport` record (Plan 15): the exact
 /// outcome of one `seedVocabulary` pass. Declared app-side so the DEMO build
 /// compiles without MurmurCoreFFI (`#if canImport` seam); `MurmurEngine` maps
@@ -266,14 +292,17 @@ protocol WalkEngine: AnyObject {
     // // sac:     same `!notes.queued` predicate the build buttons already
     // // sac:     follow — don't offer an edit control that will only throw.
     // // sac:
-    // // sac: (b) After an edit, re-read from the engine — the fresh read is
-    // // sac:     the ONLY sanctioned post-edit path. Never reconstruct screen
-    // // sac:     state from the returned item, and never patch local state in
-    // // sac:     place: the returned record is an echo for optimistic
-    // // sac:     feedback, not a source of truth (it deliberately omits
-    // // sac:     sibling items and any list-membership cascade like
-    // // sac:     list_open_todos). This is keeper D-#7, the one-source-of-
-    // // sac:     truth rule that motivates the whole design.
+    // // sac: (b) After an edit, re-read from the engine via
+    // // sac:     `loadNotes(sessionId:)` — that call is the ONLY sanctioned
+    // // sac:     post-edit path (Plan 20 D4 closed the gap the #232 review
+    // // sac:     flagged: the contract demanded a fresh read before any read
+    // // sac:     method existed). Never reconstruct screen state from the
+    // // sac:     returned item, and never patch local state in place: the
+    // // sac:     returned record is an echo for optimistic feedback, not a
+    // // sac:     source of truth (it deliberately omits sibling items and any
+    // // sac:     list-membership cascade like list_open_todos). This is
+    // // sac:     keeper D-#7, the one-source-of-truth rule that motivates the
+    // // sac:     whole design. AppModel's edit paths now re-read this way.
     // // sac:
     // // sac: (c) Core `right` is quantity, NOT price — narrower than the demo
     // // sac:     fixtures' free-chrome usage. Fixtures.swift puts prices
@@ -298,4 +327,23 @@ protocol WalkEngine: AnyObject {
         sessionId: String, kind: String, text: String, right: String
     ) throws -> CapturedFixture
     func removeItem(sessionId: String, itemId: String) throws
+
+    // Walk-reopen read seam (Plan 20 Half A). Both are pure READS — no pump,
+    // no session resurrection, no mutation.
+
+    /// The board walk log (D2/D3): every reopenable walk, newest first — a
+    /// transcript-free projection. Recording (live/zombie) and deleted walks
+    /// never appear. Throwing: the real FFI call is fallible (store lock).
+    /// `DemoWalkEngine` returns `[]` (its walk log is the in-memory
+    /// `sessionWalks`; an empty result must NOT clobber it — see
+    /// `AppModel.hydrateWalkLog`'s F2 guard).
+    func listSessions() throws -> [WalkSummary]
+
+    /// Re-read a session's notes from the store (D1) — the SAME payload
+    /// `finish()` returned for it, field by field (the Rust side reconstructs
+    /// through one shared funnel). Used by the board's reopen tap AND as the
+    /// clause-(b) post-edit fresh read above. Throwing: a missing/tombstoned
+    /// session (a reopen that lost a delete/sweep race) surfaces as an error
+    /// the caller turns into a breadcrumb — never a silent dead tap (F4).
+    func loadNotes(sessionId: String) async throws -> NotesModel
 }

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -339,6 +339,16 @@ protocol WalkEngine: AnyObject {
     /// `AppModel.hydrateWalkLog`'s F2 guard).
     func listSessions() throws -> [WalkSummary]
 
+    /// Plan 20 D7: warm the on-device STT model (the expensive model read +
+    /// Metal init) so the first START WALK tap doesn't pay it. Fired
+    /// fire-and-forget from the TAIL of the app-open sweeps — AFTER the
+    /// synchronous sweeps, never before them (#185 invariant). Idempotent; a
+    /// failure is silent-degrade (log + swallow — the next begin cold-loads
+    /// exactly as before). `async` so the real engine can hop the blocking
+    /// model load off the main actor (the attachPhoto pattern).
+    /// `DemoWalkEngine` no-ops (no model to warm).
+    func warmStt() async throws
+
     /// Re-read a session's notes from the store (D1) — the SAME payload
     /// `finish()` returned for it, field by field (the Rust side reconstructs
     /// through one shared funnel). Used by the board's reopen tap AND as the

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -165,8 +165,25 @@ struct BoardView: View {
                         .padding(.horizontal, Theme.S.screenPad)
                         .padding(.top, 16)
                 } else {
+                    // Plan 20 D5: rows are tappable — reopen the walk's notes.
+                    // // sac: the reopen affordance visuals (chevron? row
+                    // // sac: press state?) + the reopened banner are yours.
                     ForEach(model.sessionWalks) { walk in
-                        WalkLogRow(walk: walk)
+                        Button {
+                            model.reopenWalk(sessionId: walk.sessionId)
+                        } label: {
+                            WalkLogRow(walk: walk)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    if let reopenError = model.reopenError {
+                        // F4 floor: the breadcrumb surfaces; chrome is sac's.
+                        Text(reopenError.uppercased())
+                            .font(Theme.F.mono(8.5))
+                            .tracking(0.4)
+                            .foregroundStyle(Theme.C.orangeDeep)
+                            .padding(.horizontal, Theme.S.screenPad)
+                            .padding(.top, 8)
                     }
                 }
             } else {

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -185,7 +185,15 @@ struct NotesView: View {
                         .foregroundStyle(Theme.C.ink)
                         .lineSpacing(3)
                     if notes.queued {
-                        Text("SAVED OFFLINE — DOCUMENTS UNLOCK WHEN YOU RECONNECT")
+                        // Plan 20 F5: a REOPENED still-queued walk must not
+                        // reuse the reconnect promise — the app-open retry
+                        // sweep may already have run and exhausted. Distinct
+                        // string per banner reason.
+                        // // sac: the reopened-Failed copy below is a
+                        // // sac: placeholder — the wording is yours.
+                        Text(model.notesBannerReason == .reopened
+                             ? "COULDN’T FINISH THIS WALK — RETRYING AUTOMATICALLY"
+                             : "SAVED OFFLINE — DOCUMENTS UNLOCK WHEN YOU RECONNECT")
                             .font(Theme.F.mono(8.5, .semibold)).tracking(0.4)
                             .foregroundStyle(Theme.C.yellowTag)
                             .padding(.top, 2)

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -18,9 +18,16 @@ struct WalkView: View {
                 RecBanner(timer: model.isPaused ? "PAUSED" : model.elapsedLabel)
             }
 
+            // Plan 20 D9: "MIC STARTING…" masks the engine bring-up behind
+            // the already-painted screen (warm path clears it near-instantly;
+            // the first-ever cold load is what it exists for).
+            // // sac: the starting-state styling is yours — this is the
+            // // sac: functional-plain string swap.
             MetaStrip(
                 left: model.trade.site,
-                right: model.walkMode == .demo ? "DEMO WALK — SCRIPTED" : "REC — ON-DEVICE STT",
+                right: model.micStarting
+                    ? "MIC STARTING…"
+                    : (model.walkMode == .demo ? "DEMO WALK — SCRIPTED" : "REC — ON-DEVICE STT"),
                 warn: model.walkMode == .demo
             )
 

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -193,6 +193,16 @@ pub struct MurmurEngine {
     /// no_speech_prob post-check (see `EngineConfig::stt_no_speech_prob_threshold`).
     #[cfg_attr(not(feature = "whisper"), allow(dead_code))]
     pub(crate) stt_no_speech_prob_threshold: f32,
+    /// Plan 20 D6/D8: the warmed STT model — ffi's own path bookkeeping
+    /// stored NEXT TO the opaque `stt::WarmModel` handle (F1: ffi never
+    /// names a whisper backend type and never reaches inside the handle;
+    /// `grep whisper` over this crate must stay empty). Pool-of-one
+    /// (one walk at a time); reused by `build_stt_stream` only when the
+    /// stored path equals `stt_model_path` (D8 staleness guard). Holding
+    /// the ~140 MB context resident is INTENDED (D10) — dropped only on
+    /// engine teardown.
+    #[cfg(feature = "whisper")]
+    pub(crate) stt_warm: Mutex<Option<(String, stt::WarmModel)>>,
     _runtime: Option<Arc<tokio::runtime::Runtime>>,
 }
 
@@ -224,6 +234,8 @@ impl MurmurEngine {
             stt_use_gpu: config.stt_use_gpu,
             stt_vad_rms_threshold: config.stt_vad_rms_threshold,
             stt_no_speech_prob_threshold: config.stt_no_speech_prob_threshold,
+            #[cfg(feature = "whisper")]
+            stt_warm: Mutex::new(None),
             _runtime: Some(runtime),
         }))
     }
@@ -237,22 +249,37 @@ impl MurmurEngine {
     /// path (or the feature off) yields `Ok(None)` — a text-only walk.
     #[cfg(feature = "whisper")]
     pub(crate) fn build_stt_stream(&self, bias: &[String]) -> Result<Option<Arc<stt::SttStream>>, EngineError> {
-        match &self.stt_model_path {
-            Some(path) => {
-                let cfg = stt::SttConfig {
-                    use_gpu: self.stt_use_gpu,
-                    vad_rms_threshold: self.stt_vad_rms_threshold,
-                    no_speech_prob_threshold: self.stt_no_speech_prob_threshold,
-                    ..stt::SttConfig::default()
-                };
-                let stream = stt::SttStream::with_model(std::path::Path::new(path), cfg, bias)
-                // Never print a key here (it isn't in scope, but keep the
-                // message store/model-only — Plan 07 R6 redaction posture).
+        let Some(path) = &self.stt_model_path else {
+            return Ok(None);
+        };
+        let cfg = stt::SttConfig {
+            use_gpu: self.stt_use_gpu,
+            vad_rms_threshold: self.stt_vad_rms_threshold,
+            no_speech_prob_threshold: self.stt_no_speech_prob_threshold,
+            ..stt::SttConfig::default()
+        };
+        // `with_warm` doesn't re-validate (it never loads), so validate here —
+        // the same guard `with_model` used to run for every walk.
+        cfg.validate()
+            .map_err(|e| EngineError::BeginWalk(format!("stt config invalid: {e}")))?;
+        // Plan 20 D6/D8: reuse the warmed model when the stored path matches;
+        // otherwise load ONCE and keep the handle (warm-on-first-use / stale
+        // path replaced). Never print a key here (it isn't in scope, but keep
+        // messages store/model-only — Plan 07 R6 redaction posture).
+        let mut warm = self
+            .stt_warm
+            .lock()
+            .map_err(|_| EngineError::BeginWalk("stt warm holder poisoned".into()))?;
+        let stale = !matches!(warm.as_ref(), Some((stored, _)) if stored == path);
+        if stale {
+            let loaded = stt::load_warm_model(std::path::Path::new(path), self.stt_use_gpu)
                 .map_err(|e| EngineError::BeginWalk(format!("stt model load failed: {e}")))?;
-                Ok(Some(Arc::new(stream)))
-            }
-            None => Ok(None),
+            *warm = Some((path.clone(), loaded));
         }
+        let (_, model) = warm
+            .as_ref()
+            .ok_or_else(|| EngineError::BeginWalk("stt warm holder empty after load".into()))?;
+        Ok(Some(Arc::new(stt::SttStream::with_warm(model, cfg, bias))))
     }
 
     /// Feature-off build: no whisper backend is compiled in, so the walk always
@@ -260,6 +287,45 @@ impl MurmurEngine {
     #[cfg(not(feature = "whisper"))]
     pub(crate) fn build_stt_stream(&self, _bias: &[String]) -> Result<Option<Arc<stt::SttStream>>, EngineError> {
         Ok(None)
+    }
+
+    /// Plan 20 D7: load the model into the warm holder if absent or stale
+    /// (idempotent — a second call with a warm, path-matching holder is a
+    /// no-op). `None` model path → `Ok(())` (text-only).
+    #[cfg(feature = "whisper")]
+    fn warm_stt_impl(&self) -> Result<(), EngineError> {
+        let Some(path) = &self.stt_model_path else {
+            return Ok(());
+        };
+        let mut warm = self
+            .stt_warm
+            .lock()
+            .map_err(|_| EngineError::Session("stt warm holder poisoned".into()))?;
+        if matches!(warm.as_ref(), Some((stored, _)) if stored == path) {
+            return Ok(()); // already warm for this path — idempotent no-op
+        }
+        let loaded = stt::load_warm_model(std::path::Path::new(path), self.stt_use_gpu)
+            .map_err(|e| EngineError::Session(format!("stt warm-up failed: {e}")))?;
+        *warm = Some((path.clone(), loaded));
+        Ok(())
+    }
+
+    /// Feature-off build: nothing to warm — always `Ok(())`, holder absent.
+    #[cfg(not(feature = "whisper"))]
+    fn warm_stt_impl(&self) -> Result<(), EngineError> {
+        Ok(())
+    }
+}
+
+#[uniffi::export]
+impl MurmurEngine {
+    /// Plan 20 D7: app-open background STT warm-up. The shell fires this
+    /// fire-and-forget from the TAIL of its app-open sweeps (AFTER the
+    /// synchronous sweeps — the #185 invariant); a failure is silent-degrade
+    /// (log + swallow on the Swift side): the next `begin` cold-loads on
+    /// demand exactly as before. Must never block or crash the app.
+    pub fn warm_stt(&self) -> Result<(), EngineError> {
+        self.warm_stt_impl()
     }
 }
 
@@ -293,6 +359,8 @@ impl MurmurEngine {
             stt_use_gpu: true,
             stt_vad_rms_threshold: 0.0,
             stt_no_speech_prob_threshold: 0.6,
+            #[cfg(feature = "whisper")]
+            stt_warm: Mutex::new(None),
             _runtime: None,
         })
     }
@@ -400,6 +468,88 @@ mod tests {
             stt_no_speech_prob_threshold: 0.6,
         };
         assert!(matches!(MurmurEngine::new(cfg), Err(EngineError::Store(_))));
+    }
+
+    // --- Plan 20 Stage 3: warm_stt (D6/D7/D8) ------------------------------
+
+    /// A `None` model path (text-only engine) warms to Ok — a no-op in both
+    /// feature modes. This is the hermetic CI-side contract; the real-model
+    /// warm/reuse/staleness paths are the gated tests below + the Stage 6
+    /// device smoke.
+    #[test]
+    fn warm_stt_none_model_is_ok() {
+        let cfg = EngineConfig {
+            db_path: ":memory:".into(),
+            device_id: "dev".into(),
+            api_key: "sk-test".into(),
+            base_url: None,
+            model_live: "claude-haiku-4-5".into(),
+            model_processing: "claude-sonnet-4-5".into(),
+            model_reflection: "claude-haiku-4-5".into(),
+            stt_model_path: None,
+            stt_flush_on_finish: true,
+            stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
+        };
+        let engine = MurmurEngine::new(cfg).unwrap();
+        engine.warm_stt().expect("no model path -> warm is a no-op Ok");
+        engine.warm_stt().expect("and idempotent");
+    }
+
+    /// Env + feature gated (never in CI — same posture as
+    /// `real_model_begin_walk_builds_an_stt_session`): warm_stt loads the
+    /// holder once, a second call is a path-match no-op (the Arc'd context
+    /// pointer is UNCHANGED — proof there was no reload), build_stt_stream
+    /// takes the warm path, and a stale stored path is discarded + reloaded
+    /// (D8).
+    #[cfg(feature = "whisper")]
+    #[test]
+    #[ignore = "needs the whisper feature + MURMUR_WHISPER_MODEL; never in CI"]
+    fn warm_stt_is_idempotent_and_reused_and_path_keyed() {
+        let Ok(model) = std::env::var("MURMUR_WHISPER_MODEL") else { return };
+        let db = std::env::temp_dir().join("murmur-warm-smoke.db");
+        let cfg = EngineConfig {
+            db_path: db.to_string_lossy().into_owned(),
+            device_id: "smoke".into(),
+            api_key: "sk-test".into(),
+            base_url: None,
+            model_live: "claude-haiku-4-5".into(),
+            model_processing: "claude-sonnet-4-5".into(),
+            model_reflection: "claude-haiku-4-5".into(),
+            stt_model_path: Some(model.clone()),
+            stt_flush_on_finish: true,
+            stt_use_gpu: true,
+            stt_vad_rms_threshold: 0.0,
+            stt_no_speech_prob_threshold: 0.6,
+        };
+        let engine = MurmurEngine::new(cfg).unwrap();
+        engine.warm_stt().expect("first warm loads the model");
+        let first_path = {
+            let warm = engine.stt_warm.lock().unwrap();
+            let (p, _) = warm.as_ref().expect("holder populated");
+            p.clone()
+        };
+        assert_eq!(first_path, model);
+        // Idempotent: second call is a path-match no-op.
+        engine.warm_stt().expect("second warm is a no-op");
+        // Reuse: building a stream with a warm holder must not error and must
+        // keep the holder (with_warm clones; the handle survives).
+        let stream = engine.build_stt_stream(&[]).expect("warm build").expect("stream");
+        drop(stream);
+        assert!(engine.stt_warm.lock().unwrap().is_some(), "handle survives the build (D6)");
+        // D8 staleness: a mismatched stored path is discarded and reloaded.
+        {
+            let mut warm = engine.stt_warm.lock().unwrap();
+            let (_, handle) = warm.take().expect("holder present");
+            *warm = Some(("/stale/other-model.bin".into(), handle));
+        }
+        engine.build_stt_stream(&[]).expect("stale path -> reload").expect("stream");
+        let repaired = {
+            let warm = engine.stt_warm.lock().unwrap();
+            warm.as_ref().map(|(p, _)| p.clone())
+        };
+        assert_eq!(repaired.as_deref(), Some(model.as_str()), "holder re-keyed to the live path");
     }
 
     #[test]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -16,6 +16,7 @@ pub mod photos;
 pub mod schemas;
 pub mod session;
 pub mod session_retry;
+pub mod sessions_read;
 pub mod vocabulary;
 
 pub use convert::document_payload;
@@ -26,3 +27,4 @@ pub use notes::{NotesBucket, NotesEntry, NotesPayload};
 pub use photos::PhotoRef;
 pub use schemas::{DocumentSchema, SchemaField, SchemaSection};
 pub use session::WalkSession;
+pub use sessions_read::{WalkStatus, WalkSummary};

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Condvar, Mutex as StdMutex};
 
 use harness::{LlmProvider, Memory, MemoryStore};
 use murmur_core::{
-    doc_kind_for_template, parse_notes_artifact, CapturedItem, LiveExtractOutcome, LiveExtractor,
+    doc_kind_for_template, parse_notes_artifact, LiveExtractOutcome, LiveExtractor,
     SessionProcessor, Store,
 };
 use tokio::sync::Mutex as TokioMutex;
@@ -412,49 +412,43 @@ impl WalkSession {
         listener.on_event(WalkEvent::BoardUpdated { items: board_items });
     }
 
-    /// The current board (items + batched per-item photo counts), shared by
-    /// `emit_board_snapshot` and the notes builders below.
-    fn board_items_and_photo_counts(&self) -> (Vec<CapturedItem>, HashMap<String, u32>) {
-        let store = self.store.lock().unwrap();
-        let items = store.list_items_for_session(&self.session_id).unwrap_or_default();
-        let counts =
-            store.count_live_photos_by_item_for_session(&self.session_id).unwrap_or_default();
-        (items, counts)
-    }
-
-    /// Plan 14 D5-14/D6-14: reads the session's latest `kind=="notes"`
-    /// artifact (if any) and tolerant-parses it back to core-side
-    /// `NotesEntry` (`bucket` as a wire string — mapped to the FFI enum by
-    /// `notes_payload`, dropping unknown buckets, R6). ANY failure — no
-    /// artifact (pre-14 session, empty/offline finish that never reached
-    /// `process()`), a poisoned lock, a store error — degrades to `[]`,
-    /// never a panic across FFI.
-    fn session_notes(&self) -> Vec<murmur_core::NotesEntry> {
-        let Ok(store) = self.store.lock() else {
-            return Vec::new();
-        };
-        let Ok(artifacts) = store.list_artifacts_for_session(&self.session_id) else {
-            return Vec::new();
-        };
-        // Newest-first: a reprocess writes a fresh notes artifact after
-        // clear_authoritative_outputs sweeps the prior one, but taking the
-        // last match is defensive against any future multi-write scenario.
-        let Some(artifact) = artifacts.iter().rev().find(|a| a.kind == "notes") else {
-            return Vec::new();
-        };
-        parse_notes_artifact(&artifact.body)
-    }
-
     /// Builds a `NotesPayload` from whatever is on the current board (Plan
     /// 13 D3) plus the stored notes artifact (Plan 14 D6-14). Shared by: the
     /// offline-degrade path (`queued: true`, D9), the empty-transcript short
     /// circuit, and the double-finish/degraded exit (all `queued: false` —
     /// nothing is pending in those cases).
+    ///
+    /// Plan 20 D1/R1: DELEGATES to `notes_payload_from_store` — the ONE
+    /// reconstruction funnel `load_notes` also uses — then overrides
+    /// `summary`/`queued` with the caller's inline knowledge (which agrees
+    /// with the store-derived values for any committed state; the override
+    /// preserves `finish()`'s exact historical behavior on the degrade arms).
     fn partial_notes(&self, summary: &str, queued: bool) -> NotesPayload {
-        let doc_kind = doc_kind_for_template(self.template.as_deref());
-        let (items, photo_counts) = self.board_items_and_photo_counts();
-        let notes = self.session_notes();
-        notes_payload(&self.session_id, doc_kind, summary, &items, &photo_counts, &notes, queued)
+        let reconstructed = self
+            .store
+            .lock()
+            .ok()
+            .and_then(|store| notes_payload_from_store(&store, &self.session_id).ok());
+        match reconstructed {
+            Some(mut payload) => {
+                payload.summary = summary.to_string();
+                payload.queued = queued;
+                payload
+            }
+            // Degraded arm (a finish() after cancel(): the session row is
+            // tombstoned so `get_session` NotFounds; or a poisoned lock):
+            // empty board/notes with the template-derived kind — never a
+            // panic across FFI.
+            None => notes_payload(
+                &self.session_id,
+                doc_kind_for_template(self.template.as_deref()),
+                summary,
+                &[],
+                &HashMap::new(),
+                &[],
+                queued,
+            ),
+        }
     }
 
     /// Degrade path for a `finish()` call that can't transition the session
@@ -472,6 +466,68 @@ impl WalkSession {
         }
         .unwrap_or_default();
         self.partial_notes(&summary, false)
+    }
+}
+
+/// The session's latest stored `kind=="notes"` artifact, tolerant-parsed back
+/// to core-side `NotesEntry` (Plan 14 D5-14/D6-14; `bucket` stays a wire
+/// string here — `notes_payload` maps it to the FFI enum, dropping unknown
+/// buckets, R6). ANY failure — no artifact (pre-14 session, empty/offline
+/// finish that never reached `process()`), a store error — degrades to `[]`.
+fn stored_session_notes(store: &Store, session_id: &str) -> Vec<murmur_core::NotesEntry> {
+    let Ok(artifacts) = store.list_artifacts_for_session(session_id) else {
+        return Vec::new();
+    };
+    // Newest-first: a reprocess writes a fresh notes artifact after
+    // clear_authoritative_outputs sweeps the prior one, but taking the
+    // last match is defensive against any future multi-write scenario.
+    let Some(artifact) = artifacts.iter().rev().find(|a| a.kind == "notes") else {
+        return Vec::new();
+    };
+    parse_notes_artifact(&artifact.body)
+}
+
+/// Plan 20 D1/R1 — the ONE reconstruction funnel: rebuilds a `NotesPayload`
+/// for a session from committed rows only (no live `WalkSession` needed).
+/// `WalkSession::partial_notes` (live finish/degrade) and
+/// `MurmurEngine::load_notes` (board reopen) BOTH call this, so the two
+/// paths cannot drift (the WE-A equality contract). `summary` is
+/// `session.summary.unwrap_or_default()`; `queued = status != Processed` —
+/// the one field `finish()` knows inline and this reads back from the
+/// terminal status. A missing/tombstoned session is `Err` (`get_session`
+/// filters `deleted_at IS NULL` and returns `NotFound`).
+pub(crate) fn notes_payload_from_store(
+    store: &Store,
+    session_id: &str,
+) -> Result<NotesPayload, murmur_core::CoreError> {
+    let session = store.get_session(session_id)?;
+    let doc_kind = doc_kind_for_template(session.template.as_deref());
+    let items = store.list_items_for_session(session_id).unwrap_or_default();
+    let photo_counts =
+        store.count_live_photos_by_item_for_session(session_id).unwrap_or_default();
+    let notes = stored_session_notes(store, session_id);
+    let summary = session.summary.unwrap_or_default();
+    let queued = session.status != murmur_core::SessionStatus::Processed;
+    Ok(notes_payload(session_id, doc_kind, &summary, &items, &photo_counts, &notes, queued))
+}
+
+#[uniffi::export]
+impl MurmurEngine {
+    /// Plan 20 D1/D4 — the walk-reopen read seam AND the Plan 16 clause-(b)
+    /// sanctioned post-edit fresh read. Returns a `NotesPayload`
+    /// field-by-field identical to what `finish()` returned for the same
+    /// session (WE-A), reconstructed from the store through the SAME funnel
+    /// (`notes_payload_from_store`). Engine-keyed: works after the live
+    /// `WalkSession` is gone (relaunch, board reopen). A missing/tombstoned
+    /// session -> `Err` (a reopen that loses a delete/sweep race surfaces to
+    /// Swift as a catchable error, never a silent payload).
+    pub fn load_notes(&self, session_id: String) -> Result<NotesPayload, EngineError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|_| EngineError::Session("store lock poisoned".into()))?;
+        notes_payload_from_store(&store, &session_id)
+            .map_err(|e| EngineError::Session(e.to_string()))
     }
 }
 
@@ -1657,6 +1713,109 @@ mod tests {
         let payload = session.finish().await;
         assert_eq!(payload.notes, Vec::new());
         assert!(payload.queued, "process() failed outright -> queued: true (D9)");
+    }
+
+    // --- Plan 20 Stage 2: load_notes / the ONE reconstruction funnel -------
+
+    /// WE-A (the D1 equality contract): for a session `finish()` has returned
+    /// for, `load_notes` returns a FIELD-BY-FIELD identical payload — both
+    /// read the same committed rows through the same funnel.
+    #[tokio::test]
+    async fn load_notes_equals_finish_for_processed_session() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(vec![
+                    tool_use("add_item", serde_json::json!({"kind": "todo", "text": "mulch front beds"})),
+                    end_turn("done"),
+                    tool_use(
+                        "write_notes",
+                        serde_json::json!({
+                            "summary": "Estimate for the front yard.",
+                            "notes": [
+                                {"bucket": "scope_of_work", "label": "Mulch", "detail": "Darker than last year."}
+                            ]
+                        }),
+                    ),
+                ])),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        );
+        let session = engine.clone().begin_walk(None, "landscape".into()).unwrap();
+        let sid = session.session_id();
+        // A manual item with photos: survives the swap, exercises photo_count.
+        {
+            let store = engine.store.lock().unwrap();
+            let manual = store.add_item(&sid, "note", "gate code 4411").unwrap();
+            store.add_photo(&sid, Some(&manual.id), "a.jpg", None).unwrap();
+            store.add_photo(&sid, Some(&manual.id), "b.jpg", None).unwrap();
+            store
+                .append_transcript(&sid, "mulch the front beds; keep it under $1200")
+                .unwrap();
+        }
+
+        let finished = session.finish().await;
+        assert!(!finished.queued);
+        assert!(!finished.items.is_empty());
+        assert_eq!(finished.notes.len(), 1);
+
+        let loaded = engine.load_notes(sid).unwrap();
+        assert_eq!(loaded, finished, "load_notes == finish(), field by field (WE-A)");
+    }
+
+    /// WE-B: reopening a Failed (offline-degraded) session — items intact,
+    /// notes empty, queued=true, summary "".
+    #[tokio::test]
+    async fn load_notes_failed_session_is_queued_with_items() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            // Empty processing script -> process() errs -> offline degrade.
+            no_op_providers(),
+        );
+        let session = engine.clone().begin_walk(None, "landscape".into()).unwrap();
+        let sid = session.session_id();
+        {
+            let store = engine.store.lock().unwrap();
+            for t in ["check the gutters", "call Dev", "order lumber"] {
+                store.add_item(&sid, "todo", t).unwrap();
+            }
+            store.append_transcript(&sid, "walked the site talking").unwrap();
+        }
+
+        let finished = session.finish().await;
+        assert!(finished.queued, "offline degrade -> queued");
+        assert_eq!(finished.items.len(), 3);
+        assert_eq!(finished.notes, Vec::new());
+        assert_eq!(finished.summary, "");
+
+        let loaded = engine.load_notes(sid).unwrap();
+        assert_eq!(loaded, finished, "load_notes == finish() for the Failed session (WE-B)");
+        assert!(loaded.queued);
+    }
+
+    #[tokio::test]
+    async fn load_notes_unknown_session_errs() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let engine = MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            no_op_providers(),
+        );
+        assert!(engine.load_notes("no-such-session".into()).is_err());
+
+        // A tombstoned session errs the same way (D3: reopen loses the race).
+        let session = engine.clone().begin_walk(None, "landscape".into()).unwrap();
+        let sid = session.session_id();
+        session.clone().cancel().await;
+        assert!(engine.load_notes(sid).is_err(), "tombstoned -> Err, never a silent payload");
     }
 
     /// D6-14: a double-`finish()` call returns the stored notes artifact from

--- a/crates/ffi/src/sessions_read.rs
+++ b/crates/ffi/src/sessions_read.rs
@@ -30,7 +30,8 @@ pub struct WalkSummary {
     pub status: WalkStatus,
     /// `session.summary`, `""` when the session never reached Processed.
     pub summary: String,
-    /// Epoch-ms, the same clock `walkStart` uses.
+    /// Epoch SECONDS (`Store::now()` is `as_secs` — the same clock every
+    /// session timestamp uses).
     pub started_at: u64,
     /// Live items only.
     pub item_count: u32,

--- a/crates/ffi/src/sessions_read.rs
+++ b/crates/ffi/src/sessions_read.rs
@@ -1,0 +1,194 @@
+//! Plan 20 Half A (D2/D3): the board walk-log projection across FFI.
+//! `MurmurEngine::list_sessions()` — a lightweight, transcript-free listing
+//! of finished walks (Recording + tombstoned rows excluded in core's
+//! `Store::list_walk_summaries`), reverse-chronological. The reopen READ
+//! (`load_notes`) lives in `session.rs` next to the shared reconstruction
+//! funnel. This file is deliberately disjoint from Plan 19's document/schema
+//! surfaces (Conflict Note).
+
+use crate::engine::{EngineError, MurmurEngine};
+
+/// A finished walk's status at the FFI boundary (D3). Core's
+/// `AwaitingProcessing` maps to `Processing` (Swift's `.processing`);
+/// `Recording` never crosses — `list_walk_summaries` excludes it.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalkStatus {
+    Processing,
+    Processed,
+    Failed,
+}
+
+/// One board walk-log row (D2): a lightweight projection — NO transcript.
+/// `queued = status != Processed` (the same predicate `NotesPayload.queued`
+/// carries); `has_document` = a live `document` artifact exists (a
+/// built-and-kept walk).
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct WalkSummary {
+    pub id: String,
+    /// `doc_kind_for_template(template)` — advisory, for row labeling.
+    pub doc_kind: String,
+    pub status: WalkStatus,
+    /// `session.summary`, `""` when the session never reached Processed.
+    pub summary: String,
+    /// Epoch-ms, the same clock `walkStart` uses.
+    pub started_at: u64,
+    /// Live items only.
+    pub item_count: u32,
+    pub has_document: bool,
+    pub queued: bool,
+}
+
+fn walk_status(status: murmur_core::SessionStatus) -> WalkStatus {
+    match status {
+        murmur_core::SessionStatus::Processed => WalkStatus::Processed,
+        murmur_core::SessionStatus::Failed => WalkStatus::Failed,
+        // Recording is filtered out by the core query (D3); defensive map to
+        // Processing rather than a panic across FFI if that ever regressed.
+        murmur_core::SessionStatus::AwaitingProcessing | murmur_core::SessionStatus::Recording => {
+            WalkStatus::Processing
+        }
+    }
+}
+
+pub(crate) fn walk_summary(core: &murmur_core::WalkSummary) -> WalkSummary {
+    WalkSummary {
+        id: core.id.clone(),
+        doc_kind: murmur_core::doc_kind_for_template(core.template.as_deref()).to_string(),
+        status: walk_status(core.status),
+        summary: core.summary.clone().unwrap_or_default(),
+        started_at: core.started_at,
+        item_count: core.item_count.min(u32::MAX as u64) as u32,
+        has_document: core.has_document,
+        queued: core.status != murmur_core::SessionStatus::Processed,
+    }
+}
+
+#[uniffi::export]
+impl MurmurEngine {
+    /// The board walk log (D2/D3): every reopenable walk, newest first —
+    /// never a transcript (Plan 04 lesson), never a Recording or tombstoned
+    /// row. Read-only: safe at app-open alongside the sweeps (R4).
+    pub fn list_sessions(&self) -> Result<Vec<WalkSummary>, EngineError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|_| EngineError::Session("store lock poisoned".into()))?;
+        let walks = store
+            .list_walk_summaries()
+            .map_err(|e| EngineError::Session(e.to_string()))?;
+        Ok(walks.iter().map(walk_summary).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use harness::{HarnessError, Memory, MemoryStore, MockProvider};
+    use murmur_core::Store;
+
+    use crate::engine::Providers;
+
+    use super::*;
+
+    struct NullMemoryStore;
+    impl MemoryStore for NullMemoryStore {
+        fn load(&self) -> Result<Memory, HarnessError> {
+            Ok(Memory::default())
+        }
+        fn save(&self, _m: &Memory) -> Result<(), HarnessError> {
+            Ok(())
+        }
+    }
+
+    fn engine_over(store: Store) -> Arc<MurmurEngine> {
+        MurmurEngine::with_providers(
+            store,
+            Memory::default(),
+            Arc::new(NullMemoryStore),
+            Providers {
+                live: Arc::new(MockProvider::new(vec![])),
+                processing: Arc::new(MockProvider::new(vec![])),
+                reflection: Arc::new(MockProvider::new(vec![])),
+            },
+        )
+    }
+
+    /// WE-C at the FFI boundary: projection fields, status/queued mapping,
+    /// and the Recording/tombstoned filters.
+    #[tokio::test]
+    async fn list_sessions_projects_and_gates() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        // P: Processed, 2 live items, 1 live document artifact.
+        let p = store.start_session_with_template(None, "landscape").unwrap();
+        store.add_item(&p.id, "todo", "one").unwrap();
+        store.add_item(&p.id, "note", "two").unwrap();
+        store.end_session(&p.id).unwrap();
+        store.mark_session_processed(&p.id, "Estimate walk.").unwrap();
+        store.add_artifact(&p.id, "document", "estimate", "{}").unwrap();
+        // F: Failed, 3 items, no document.
+        let f = store.start_session_with_template(None, "inspection").unwrap();
+        for t in ["a", "b", "c"] {
+            store.add_item(&f.id, "todo", t).unwrap();
+        }
+        store.end_session(&f.id).unwrap();
+        store.mark_session_failed(&f.id).unwrap();
+        // A: AwaitingProcessing -> maps to Processing, queued.
+        let a = store.start_session_with_template(None, "property").unwrap();
+        store.end_session(&a.id).unwrap();
+        // R: Recording — excluded.
+        store.start_session_with_template(None, "landscape").unwrap();
+        // D: tombstoned — excluded.
+        let d = store.start_session_with_template(None, "landscape").unwrap();
+        store.end_session(&d.id).unwrap();
+        store.delete_session(&d.id).unwrap();
+
+        let engine = engine_over(store);
+        let walks = engine.list_sessions().unwrap();
+        let ids: Vec<&str> = walks.iter().map(|w| w.id.as_str()).collect();
+        assert!(!ids.iter().any(|id| *id == d.id), "tombstoned excluded");
+        assert_eq!(walks.len(), 3, "P, F, A listed; R and D excluded");
+
+        let wp = walks.iter().find(|w| w.id == p.id).unwrap();
+        assert_eq!(wp.status, WalkStatus::Processed);
+        assert!(!wp.queued);
+        assert_eq!(wp.summary, "Estimate walk.");
+        assert_eq!(wp.item_count, 2);
+        assert!(wp.has_document);
+        assert_eq!(wp.doc_kind, "estimate", "landscape template -> estimate kind");
+
+        let wf = walks.iter().find(|w| w.id == f.id).unwrap();
+        assert_eq!(wf.status, WalkStatus::Failed);
+        assert!(wf.queued, "Failed -> queued (gating predicate)");
+        assert_eq!(wf.summary, "", "never-Processed summary reads back empty");
+        assert_eq!(wf.item_count, 3);
+        assert!(!wf.has_document);
+
+        let wa = walks.iter().find(|w| w.id == a.id).unwrap();
+        assert_eq!(wa.status, WalkStatus::Processing, "AwaitingProcessing -> Processing");
+        assert!(wa.queued);
+    }
+
+    /// D2 (Plan 04 lesson), compile-enforced at the FFI boundary too: the
+    /// record has no transcript field — exhaustive destructuring fails to
+    /// compile if one is ever added.
+    #[tokio::test]
+    async fn list_sessions_carries_no_transcript() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let s = store.start_session(None).unwrap();
+        store.append_transcript(&s.id, &"x".repeat(50_000)).unwrap();
+        store.end_session(&s.id).unwrap();
+        let engine = engine_over(store);
+        let walks = engine.list_sessions().unwrap();
+        let WalkSummary {
+            id: _,
+            doc_kind: _,
+            status: _,
+            summary: _,
+            started_at: _,
+            item_count: _,
+            has_document: _,
+            queued: _,
+        } = walks[0].clone();
+    }
+}

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -392,6 +392,24 @@ pub struct SessionSummary {
     pub transcript_chars: u64,
 }
 
+/// Board walk-log projection (Plan 20 D2): a purpose-built sibling of
+/// `SessionSummary` for the reopen-a-walk board list. Adds `template`,
+/// `item_count` (live items only) and `has_document` (a live `document`
+/// artifact exists) — and carries NO transcript field: the projection is
+/// compile-enforced transcript-free (Plan 04 lesson).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WalkSummary {
+    pub id: String,
+    pub job_id: Option<String>,
+    pub template: Option<String>,
+    pub status: SessionStatus,
+    pub summary: Option<String>,
+    pub started_at: u64,
+    pub ended_at: Option<u64>,
+    pub item_count: u64,
+    pub has_document: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/murmur-core/src/lib.rs
+++ b/crates/murmur-core/src/lib.rs
@@ -10,7 +10,7 @@ pub use coordinator::ReflectionCoordinator;
 pub use domain::{
     builtin_schemas, Artifact, CapturedItem, Contact, DocumentSchema, Job, JobStatus, ItemSource,
     LlmUsageRow, NewJob, Photo, SchemaField, SchemaSection, Session, SessionStatus,
-    SessionSummary, BUILTIN_SCHEMA_DEVICE_ID, BUILTIN_SCHEMA_ID_CONDITION,
+    SessionSummary, WalkSummary, BUILTIN_SCHEMA_DEVICE_ID, BUILTIN_SCHEMA_ID_CONDITION,
     BUILTIN_SCHEMA_ID_ESTIMATE, BUILTIN_SCHEMA_ID_INSPECTION, BUILTIN_SCHEMA_ID_INVOICE,
     BUILTIN_SCHEMA_ID_MOVE_OUT, BUILTIN_SCHEMA_ID_REPORT, BUILTIN_SCHEMA_ID_WORK_ORDER,
     VALID_FIELD_KINDS, VALID_FILL_KINDS, VALID_ITEM_KINDS, VALID_SECTION_KINDS,

--- a/crates/murmur-core/src/store/sessions.rs
+++ b/crates/murmur-core/src/store/sessions.rs
@@ -1,6 +1,6 @@
 use rusqlite::Row;
 
-use crate::domain::{Session, SessionStatus, SessionSummary};
+use crate::domain::{Session, SessionStatus, SessionSummary, WalkSummary};
 use crate::error::CoreError;
 use crate::ids::new_id;
 use crate::store::Store;
@@ -359,6 +359,49 @@ impl Store {
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
             out.push(summary_from_row(row)?);
+        }
+        Ok(out)
+    }
+
+    /// The board walk log (Plan 20 D2/D3): a lightweight, transcript-free
+    /// projection for the reopen-a-walk list. ONE SQL statement — a correlated
+    /// COUNT for live items and an EXISTS for a live `document` artifact.
+    /// Filters (D3, pinned): tombstoned rows are excluded (`deleted_at IS
+    /// NULL`) and `Recording` rows are excluded entirely — a Recording row is
+    /// either the live walk (reopening it is nonsense) or an un-swept crash
+    /// zombie the app-open sweep will flip to Failed. Reverse-chronological.
+    /// A SEPARATE method (not extra columns on `SessionSummary`) so the hot
+    /// processing-poll path never pays for the counts.
+    pub fn list_walk_summaries(&self) -> Result<Vec<WalkSummary>, CoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT s.id, s.job_id, s.template, s.status, s.summary, s.started_at, s.ended_at,
+                    (SELECT COUNT(*) FROM items i
+                      WHERE i.session_id = s.id AND i.deleted_at IS NULL) AS item_count,
+                    EXISTS(SELECT 1 FROM artifacts a
+                            WHERE a.session_id = s.id AND a.kind = 'document'
+                              AND a.deleted_at IS NULL) AS has_document
+             FROM sessions s
+             WHERE s.deleted_at IS NULL AND s.status != 'recording'
+             ORDER BY s.started_at DESC, s.id DESC",
+        )?;
+        let mut rows = stmt.query([])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            let status_raw: String = row.get("status").map_err(CoreError::Sqlite)?;
+            out.push(WalkSummary {
+                id: row.get("id").map_err(CoreError::Sqlite)?,
+                job_id: row.get("job_id").map_err(CoreError::Sqlite)?,
+                template: row.get("template").map_err(CoreError::Sqlite)?,
+                status: SessionStatus::parse(&status_raw)?,
+                summary: row.get("summary").map_err(CoreError::Sqlite)?,
+                started_at: row.get::<_, i64>("started_at").map_err(CoreError::Sqlite)? as u64,
+                ended_at: row
+                    .get::<_, Option<i64>>("ended_at")
+                    .map_err(CoreError::Sqlite)?
+                    .map(|v| v as u64),
+                item_count: row.get::<_, i64>("item_count").map_err(CoreError::Sqlite)? as u64,
+                has_document: row.get::<_, bool>("has_document").map_err(CoreError::Sqlite)?,
+            });
         }
         Ok(out)
     }
@@ -994,6 +1037,111 @@ mod tests {
             s.clear_authoritative_outputs("nope"),
             Err(CoreError::NotFound { entity: "session", .. })
         ));
+    }
+
+    // --- Plan 20 Stage 1: list_walk_summaries (D2/D3) ----------------------
+
+    /// WE-C: seed P (Processed, 2 items, 1 document), F (Failed, 3 items),
+    /// R (Recording — live walk), D (Processed but tombstoned). Only [P, F]
+    /// are listed, in reverse-chronological order, with correct fields.
+    #[test]
+    fn list_walk_summaries_excludes_recording_and_deleted() {
+        let s = store();
+        // D: started_at = 100, Processed, then tombstoned.
+        let s = s.with_clock(Arc::new(|| 100));
+        let d = s.start_session_with_template(None, "landscape").unwrap();
+        s.end_session(&d.id).unwrap();
+        s.mark_session_processed(&d.id, "deleted walk").unwrap();
+        s.delete_session(&d.id).unwrap();
+        // F: started_at = 200, Failed, 3 items.
+        let s = s.with_clock(Arc::new(|| 200));
+        let f = s.start_session_with_template(None, "inspection").unwrap();
+        for t in ["a", "b", "c"] {
+            s.add_item(&f.id, "todo", t).unwrap();
+        }
+        s.end_session(&f.id).unwrap();
+        s.mark_session_failed(&f.id).unwrap();
+        // P: started_at = 300, Processed, 2 items, 1 live document artifact.
+        let s = s.with_clock(Arc::new(|| 300));
+        let p = s.start_session_with_template(None, "estimate").unwrap();
+        s.add_item(&p.id, "todo", "one").unwrap();
+        s.add_item(&p.id, "note", "two").unwrap();
+        s.end_session(&p.id).unwrap();
+        s.mark_session_processed(&p.id, "Estimate for the front yard.").unwrap();
+        s.add_artifact(&p.id, "document", "estimate", "{}").unwrap();
+        // R: started_at = 400, still Recording — the NEWEST row, never listed.
+        let s = s.with_clock(Arc::new(|| 400));
+        s.start_session_with_template(None, "landscape").unwrap();
+
+        let walks = s.list_walk_summaries().unwrap();
+        assert_eq!(
+            walks.iter().map(|w| w.id.as_str()).collect::<Vec<_>>(),
+            vec![p.id.as_str(), f.id.as_str()],
+            "R (Recording) and D (tombstoned) are excluded; order is reverse-chron"
+        );
+        assert_eq!(walks[0].status, SessionStatus::Processed);
+        assert_eq!(walks[0].template.as_deref(), Some("estimate"));
+        assert_eq!(walks[0].summary.as_deref(), Some("Estimate for the front yard."));
+        assert_eq!(walks[0].started_at, 300);
+        assert_eq!(walks[0].item_count, 2);
+        assert!(walks[0].has_document);
+        assert_eq!(walks[1].status, SessionStatus::Failed);
+        assert_eq!(walks[1].template.as_deref(), Some("inspection"));
+        assert_eq!(walks[1].item_count, 3);
+        assert!(!walks[1].has_document);
+    }
+
+    #[test]
+    fn list_walk_summaries_counts_live_items_only() {
+        let s = store();
+        let session = s.start_session(None).unwrap();
+        s.add_item(&session.id, "todo", "keep").unwrap();
+        let dead = s.add_item(&session.id, "todo", "tombstoned").unwrap();
+        s.delete_item(&dead.id).unwrap();
+        s.end_session(&session.id).unwrap();
+        let walks = s.list_walk_summaries().unwrap();
+        assert_eq!(walks.len(), 1);
+        assert_eq!(walks[0].item_count, 1, "only the live item counts");
+    }
+
+    #[test]
+    fn list_walk_summaries_flags_has_document() {
+        let s = store();
+        let session = s.start_session(None).unwrap();
+        s.end_session(&session.id).unwrap();
+        assert!(!s.list_walk_summaries().unwrap()[0].has_document);
+        // A non-document artifact does not flip the flag.
+        s.add_artifact(&session.id, "notes", "walk", "{}").unwrap();
+        assert!(!s.list_walk_summaries().unwrap()[0].has_document);
+        let doc = s.add_artifact(&session.id, "document", "estimate", "{}").unwrap();
+        assert!(s.list_walk_summaries().unwrap()[0].has_document);
+        s.delete_artifact(&doc.id).unwrap();
+        assert!(
+            !s.list_walk_summaries().unwrap()[0].has_document,
+            "a tombstoned document artifact no longer counts"
+        );
+    }
+
+    /// Plan 04 lesson, compile-enforced: `WalkSummary` has no transcript field
+    /// — exhaustive destructuring fails to compile if one is ever added.
+    #[test]
+    fn walk_summary_projection_has_no_transcript_field() {
+        let s = store();
+        let session = s.start_session(None).unwrap();
+        s.append_transcript(&session.id, &"x".repeat(50_000)).unwrap();
+        s.end_session(&session.id).unwrap();
+        let walks = s.list_walk_summaries().unwrap();
+        let crate::domain::WalkSummary {
+            id: _,
+            job_id: _,
+            template: _,
+            status: _,
+            summary: _,
+            started_at: _,
+            ended_at: _,
+            item_count: _,
+            has_document: _,
+        } = walks[0].clone();
     }
 
     #[test]

--- a/crates/stt/src/lib.rs
+++ b/crates/stt/src/lib.rs
@@ -15,6 +15,8 @@ pub use bias::build_bias_prompt;
 pub use decoder::{Decoder, RawSegment, ScriptedDecoder, WordTiming};
 #[cfg(feature = "whisper")]
 pub use whisper::WhisperDecoder;
+#[cfg(feature = "whisper")]
+pub use whisper::{load_warm_model, WarmModel};
 
 /// A finalized, never-to-be-revised transcript segment (append-only contract).
 /// Timestamps are ABSOLUTE audio milliseconds from stream start. The shell
@@ -159,6 +161,22 @@ impl SttStream {
         cfg.validate()?; // reject overlap ≥ chunk before opening the model
         let decoder = whisper::WhisperDecoder::open(model, &cfg.language, cfg.use_gpu, cfg.word_timestamps)?;
         Ok(Self::with_decoder(Box::new(decoder), cfg, vocab))
+    }
+
+    /// Plan 20 D6: build a stream over an already-warmed model — NO model
+    /// load. Internally `Arc::clone`s the `WarmModel`'s context into a
+    /// `WhisperDecoder`; the handle stays reusable for the next walk.
+    /// (`use_gpu` was fixed when the context was loaded; `cfg.use_gpu` is
+    /// ignored here.) `cfg` window math is guarded the same way
+    /// `with_decoder` guards it (saturating horizon).
+    #[cfg(feature = "whisper")]
+    pub fn with_warm(model: &WarmModel, cfg: SttConfig, vocab: &[String]) -> Self {
+        let decoder = whisper::WhisperDecoder::from_context(
+            model.ctx.clone(),
+            &cfg.language,
+            cfg.word_timestamps,
+        );
+        Self::with_decoder(Box::new(decoder), cfg, vocab)
     }
 
     /// Buffer PCM. Cheap: a short lock, no decode. Call OFF the real-time audio

--- a/crates/stt/src/whisper.rs
+++ b/crates/stt/src/whisper.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use whisper_rs::{
     FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters,
@@ -9,11 +10,47 @@ use whisper_rs::WhisperSegment;
 use crate::decoder::{Decoder, RawSegment, WordTiming};
 use crate::SttError;
 
-/// whisper.cpp backend (Metal). Owns a loaded model context; each `decode`
-/// creates a fresh state (whisper-rs pattern). The crate NEVER downloads the
-/// model — `open` reads a file the shell has already provisioned.
+/// Plan 20 D6 (F1): the warmed whisper model as an OPAQUE, stt-owned handle.
+/// Wraps the loaded `Arc<WhisperContext>` and deliberately exposes nothing —
+/// callers (the ffi crate) can only hold it and hand it back to
+/// `SttStream::with_warm`; no `whisper_rs` type ever crosses the stt
+/// boundary. Load once via `load_warm_model` (the expensive model read +
+/// Metal init), then every `with_warm` is an `Arc::clone` — no reload.
+pub struct WarmModel {
+    pub(crate) ctx: Arc<WhisperContext>,
+}
+
+/// Compile-assert `WarmModel: Send + Sync` (Plan 20 Stage 3 / R2): the warm
+/// handle is held in the engine and consumed from walk/pump contexts.
+/// Verified true in vendored whisper-rs 0.16.0 (`WhisperInnerContext` is
+/// `unsafe impl Send`/`Sync`; the model is read-only after load, decode
+/// states are per-call).
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<WarmModel>();
+};
+
+/// Load the whisper model once, off the tap path (Plan 20 D6/D7): the same
+/// `WhisperContext::new_with_params` open `SttStream::with_model` performs,
+/// captured into the reusable opaque handle.
+pub fn load_warm_model(model: &Path, use_gpu: bool) -> Result<WarmModel, SttError> {
+    let mut params = WhisperContextParameters::default();
+    params.use_gpu(use_gpu);
+    let ctx = WhisperContext::new_with_params(
+        model.to_str().ok_or_else(|| SttError::ModelLoad("non-utf8 model path".into()))?,
+        params,
+    )
+    .map_err(|e| SttError::ModelLoad(e.to_string()))?;
+    Ok(WarmModel { ctx: Arc::new(ctx) })
+}
+
+/// whisper.cpp backend (Metal). Holds a loaded model context (shared via
+/// `Arc` so a warmed context is reusable across sessions, Plan 20 D6); each
+/// `decode` creates a fresh state (whisper-rs pattern). The crate NEVER
+/// downloads the model — `open` reads a file the shell has already
+/// provisioned.
 pub struct WhisperDecoder {
-    ctx: WhisperContext,
+    ctx: Arc<WhisperContext>,
     language: String,
     /// When on, `decode` sets whisper `token_timestamps` and reconstructs
     /// per-word timing onto `RawSegment.words` (Plan 09 D5). Flows from
@@ -22,6 +59,16 @@ pub struct WhisperDecoder {
 }
 
 impl WhisperDecoder {
+    /// Wrap an already-loaded context (Plan 20 D6): the warm path. NO model
+    /// load happens here — the context is `Arc::clone`d from a `WarmModel`.
+    pub(crate) fn from_context(
+        ctx: Arc<WhisperContext>,
+        language: &str,
+        word_timestamps: bool,
+    ) -> Self {
+        Self { ctx, language: language.to_string(), word_timestamps }
+    }
+
     /// `use_gpu` is LOAD-BEARING (Plan 08 D7, falsified assumption): with the
     /// `metal` cargo feature the default is GPU-on, which HARD-CRASHES on the
     /// iOS simulator (SIGTRAP in ggml_metal_buffer_set_tensor via MTLSimDevice)
@@ -41,7 +88,7 @@ impl WhisperDecoder {
             params,
         )
         .map_err(|e| SttError::ModelLoad(e.to_string()))?;
-        Ok(Self { ctx, language: language.to_string(), word_timestamps })
+        Ok(Self::from_context(Arc::new(ctx), language, word_timestamps))
     }
 }
 


### PR DESCRIPTION
## Thinking

Implements Plan 20 Rev 2 (#243) — the two build-44 field fixes, plus the repaid contract debt.

**Walk-reopen (#223)**: `list_walk_summaries` (lightweight projection, compile-enforced transcript-free, Recording+tombstones excluded) + `load_notes(sessionId)` built on the ONE `notes_payload_from_store` funnel that `finish()` itself now delegates to — payload equality is asserted as a deep-equal test, not hoped. Tapping a walk row reopens its notes; reopened Failed sessions show items with edits gated and an honest banner (no more "unlocks when you reconnect" for retry-exhausted sessions). And the Plan 16 clause-(b) deviation is retired: edit paths now fresh-read through `loadNotes`; the contract text names it as the sanctioned path.

**Whisper warm-up (#228)**: `stt::WarmModel` — opaque, stt-owned (the ffi crate never names whisper_rs; grep-gated empty), Send+Sync compile-asserted against the vendored source. Model loads once in the background at app-open (fired at the sweeps tail, #185-honored), reused across walks via Arc, path-keyed staleness, silent cold-load degrade. `beginWalk` paints the screen first under the D9 numbered invariant (nothing session-dependent before `begin` succeeds — the Plan 07 dead-walk rationale), with a MIC STARTING state covering the cold case.

Notable build events: Plan 19 merged mid-build — rebased + bindings regenerated per the plan's own conflict protocol, final gates re-run on the rebased head. Divergence worth eyes: `started_at` is epoch-seconds (the plan said ms; the store says seconds — mapped and documented as seconds).

## Gates

cargo test --workspace 0 (murmur-core 209, ffi 76) · clippy 0 (incl. whisper-feature) · ffi whisper_rs grep gate EMPTY · demo build SUCCEEDED · bindings drift 0. FFI surface changed → real-core gate before merge; device smoke rides the next TestFlight build.
