### PR TITLE
copy(onboarding): accurate mic privacy sub-header (YOUR AUDIO STAYS ON YOUR PHONE)

### DIFF
--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -386,7 +386,7 @@ struct OnboardingFlow: View {
             Text(micState == .granted ? "You’re ready to walk." : "Let Jefe hear your walk.")
                 .font(Theme.F.ui(23, .bold))
                 .padding(.top, 6)
-            Text("EVERYTHING TRANSCRIBES ON YOUR PHONE")
+            Text("YOUR AUDIO STAYS ON YOUR PHONE")
                 .font(Theme.F.mono(8.5))
                 .tracking(0.8)
                 .foregroundStyle(Theme.C.ink60)


### PR DESCRIPTION
## Thinking

Isaac wants the in-app privacy copy and the website legal pages to be **consistent and accurate**. Verified data flow: STT is on-device (`crates/stt` whisper), but the transcript **text** is sent to the LLM (`crates/harness` → Anthropic/PPQ) to generate the paperwork. So "audio never leaves the phone" is true; text does leave.

The mic screen's sub-header **"EVERYTHING TRANSCRIBES ON YOUR PHONE"** is technically true (all transcription is on-device) but "everything" can imply *nothing* leaves. This changes it to **"YOUR AUDIO STAYS ON YOUR PHONE"** — unambiguous, audio-specific, and matching both the `AUDIO NEVER LEAVES YOUR PHONE` row and the website Privacy Policy (getjefe.netlify.app/privacy).

## Why this is a standalone PR

This exact fix was made on #236's branch — but **after #236 had already merged**, so it stranded on the branch and never reached `main` (which still shows the old copy). Re-applying it directly here so it's on `main` before the `v1.1.0` external build is tagged.

One line, no logic. 🤖 Generated with [Claude Code](https://claude.com/claude-code)