### PR TITLE
feat(ios): 'My Business' — one button + two-tab sheet (replaces cryptic VOCAB/PAPER chips)

### DIFF
--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -253,9 +253,19 @@ struct CustomizeView: View {
                 tabButton("WORDS", .words)
             }
 
-            switch tab {
-            case .paperwork: LetterheadStudioView(model: model, embedded: true)
-            case .words: VocabularyView(model: model, embedded: true)
+            // Both tabs stay ALIVE (ZStack + opacity), not a `switch` that
+            // tears the inactive branch down. LetterheadStudioView holds its
+            // edits in @State draft (name/color/logo/terms) committed only on
+            // SAVE — a `switch` would destroy that draft on every tab hop,
+            // silently losing uncommitted letterhead edits (review #247). The
+            // hidden tab is non-interactive so it can't steal touches.
+            ZStack {
+                LetterheadStudioView(model: model, embedded: true)
+                    .opacity(tab == .paperwork ? 1 : 0)
+                    .allowsHitTesting(tab == .paperwork)
+                VocabularyView(model: model, embedded: true)
+                    .opacity(tab == .words ? 1 : 0)
+                    .allowsHitTesting(tab == .words)
             }
         }
         .background(Theme.C.paper.ignoresSafeArea())

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -27,35 +27,32 @@ struct BoardView: View {
                     // walk — graduates into onboarding). Tap to toggle;
                     // launch-arg-forced modes lock it.
                     Button { model.toggleMode() } label: {
-                        Text(model.walkMode == .voice ? "MIC · VOICE" : "DEMO WALK")
-                            .font(Theme.F.mono(8, .semibold))
-                            .tracking(1.0)
-                            .foregroundStyle(model.walkMode == .voice ? Theme.C.greenTag : Theme.C.yellowTag)
-                            .padding(.horizontal, 6)
-                            .padding(.top, 3)
-                            .padding(.bottom, 2)
-                            .background(model.walkMode == .voice ? Theme.C.greenTint : Theme.C.yellowTint)
-                            .padding(6)
-                            .contentShape(Rectangle())
+                        raisedChip(
+                            face: model.walkMode == .voice ? Theme.C.greenTint : Theme.C.yellowTint,
+                            edge: model.walkMode == .voice ? Theme.C.greenTag : Theme.C.yellowTag
+                        ) {
+                            Text(model.walkMode == .voice ? "MIC · VOICE" : "DEMO WALK")
+                                .font(Theme.F.mono(8, .semibold))
+                                .tracking(1.0)
+                                .foregroundStyle(model.walkMode == .voice ? Theme.C.greenTag : Theme.C.yellowTag)
+                        }
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .padding(-6)
                     .opacity(model.modeLocked ? 0.5 : 1)
                     .disabled(model.modeLocked)
                     // One clear entry for making the app yours — replaces two
-                    // cryptic chips (VOCAB + PAPER) that Isaac (rightly) found
-                    // opaque. Amber-outlined so it reads as "set this up"; opens
-                    // a two-tab sheet: PAPERWORK (logo/colors/letterhead) + WORDS.
+                    // cryptic chips (VOCAB + PAPER). A raised amber block (same
+                    // pressed-block grammar as START WALK) so it reads as a
+                    // button; opens the two-tab PAPERWORK / WORDS sheet.
                     Button { showCustomize = true } label: {
-                        Text("MY BUSINESS")
-                            .font(Theme.F.ui(11, .bold))
-                            .tracking(0.5)
-                            .foregroundStyle(Theme.C.orangeDeep)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(Theme.C.orangeTint)
-                            .overlay(Rectangle().stroke(Theme.C.orange, lineWidth: 1.5))
-                            .contentShape(Rectangle())
+                        raisedChip(face: Theme.C.orange, edge: Theme.C.orangeDeep) {
+                            Text("MY BUSINESS")
+                                .font(Theme.F.ui(11, .bold))
+                                .tracking(0.5)
+                                .foregroundStyle(Theme.C.onOrange)
+                        }
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                 }
@@ -217,6 +214,22 @@ struct BoardView: View {
                 .presentationBackground(Theme.C.paper)
         }
     }
+}
+
+// MARK: - Raised chip (clickable header buttons)
+
+/// A compact "pressed block" — the START WALK button's raised look, chip-sized:
+/// a `face` cap sitting on a darker `edge` lip (3pt) so it reads as a button, not
+/// a flat label. Same depth cue as the primary block button, scaled down.
+@ViewBuilder
+private func raisedChip<L: View>(face: Color, edge: Color, @ViewBuilder _ label: () -> L) -> some View {
+    label()
+        .padding(.horizontal, 11)
+        .padding(.vertical, 6)
+        .background(face)
+        .padding(.bottom, 3)      // reveal the darker edge as a bottom lip
+        .background(edge)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
 }
 
 // MARK: - My Business (customization sheet)

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -8,8 +8,7 @@ struct BoardView: View {
     @Bindable var model: AppModel
     // sac: entry point + presentation (sheet vs. a new AppModel.Phase) is your
     // call; a gear → .sheet is a functional default, not a design decision.
-    @State private var showVocabulary = false
-    @State private var showLetterhead = false
+    @State private var showCustomize = false
     // First-run coach mark, one-shot (survives relaunch). Cleared by resetcoach=1.
     @AppStorage(CoachMarks.startWalkKey) private var coachStartShown = false
 
@@ -43,38 +42,22 @@ struct BoardView: View {
                     .padding(-6)
                     .opacity(model.modeLocked ? 0.5 : 1)
                     .disabled(model.modeLocked)
-                    // Vocabulary entry: a stamped chip in the tag grammar —
-                    // this is a field tool, not settings, so no gear. Padding
-                    // widens the tap target without growing the stamp.
-                    Button { showVocabulary = true } label: {
-                        Text("VOCAB")
-                            .font(Theme.F.mono(8, .semibold))
-                            .tracking(1.0)
-                            .foregroundStyle(Theme.C.ink60)
-                            .padding(.horizontal, 6)
-                            .padding(.top, 3)
-                            .padding(.bottom, 2)
-                            .background(Theme.C.paperDeep)
-                            .padding(6)
+                    // One clear entry for making the app yours — replaces two
+                    // cryptic chips (VOCAB + PAPER) that Isaac (rightly) found
+                    // opaque. Amber-outlined so it reads as "set this up"; opens
+                    // a two-tab sheet: PAPERWORK (logo/colors/letterhead) + WORDS.
+                    Button { showCustomize = true } label: {
+                        Text("MY BUSINESS")
+                            .font(Theme.F.ui(11, .bold))
+                            .tracking(0.5)
+                            .foregroundStyle(Theme.C.orangeDeep)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(Theme.C.orangeTint)
+                            .overlay(Rectangle().stroke(Theme.C.orange, lineWidth: 1.5))
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .padding(-6)
-                    // Letterhead / paperwork branding — same stamp grammar.
-                    Button { showLetterhead = true } label: {
-                        Text("PAPER")
-                            .font(Theme.F.mono(8, .semibold))
-                            .tracking(1.0)
-                            .foregroundStyle(Theme.C.ink60)
-                            .padding(.horizontal, 6)
-                            .padding(.top, 3)
-                            .padding(.bottom, 2)
-                            .background(Theme.C.paperDeep)
-                            .padding(6)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .padding(-6)
                 }
                 if let profile = model.profile {
                     // Operator mode: the board carries THEIR business. Trade
@@ -227,18 +210,75 @@ struct BoardView: View {
         .animation(.easeOut(duration: 0.25), value: coachStartShown)
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)
-        .sheet(isPresented: $showVocabulary) {
-            VocabularyView(model: model)
+        .sheet(isPresented: $showCustomize) {
+            CustomizeView(model: model)
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
                 .presentationBackground(Theme.C.paper)
         }
-        .sheet(isPresented: $showLetterhead) {
-            LetterheadStudioView(model: model)
-                .presentationDetents([.large])
-                .presentationDragIndicator(.visible)
-                .presentationBackground(Theme.C.paper)
+    }
+}
+
+// MARK: - My Business (customization sheet)
+
+/// One sheet, two tabs — the single "MY BUSINESS" entry from the board (replaces
+/// the two cryptic VOCAB / PAPER chips). PAPERWORK (logo / colors / letterhead —
+/// the key differentiator) is shown first; WORDS is the former vocabulary editor.
+/// Wraps the two existing screens in `embedded` mode so they drop their own
+/// headers and share this one.
+struct CustomizeView: View {
+    @Bindable var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var tab: Tab = .paperwork
+    private enum Tab { case paperwork, words }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("MY BUSINESS")
+                    .font(Theme.F.mono(9, .semibold)).tracking(2.0)
+                    .foregroundStyle(Theme.C.orangeDeep)
+                Spacer()
+                Button { dismiss() } label: {
+                    Text("CLOSE")
+                        .font(Theme.F.mono(9, .semibold)).tracking(1.0)
+                        .foregroundStyle(Theme.C.ink60)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, Theme.S.screenPad)
+            .padding(.top, 16)
+            .padding(.bottom, 12)
+
+            HStack(spacing: 0) {
+                tabButton("PAPERWORK", .paperwork)
+                tabButton("WORDS", .words)
+            }
+
+            switch tab {
+            case .paperwork: LetterheadStudioView(model: model, embedded: true)
+            case .words: VocabularyView(model: model, embedded: true)
+            }
         }
+        .background(Theme.C.paper.ignoresSafeArea())
+    }
+
+    private func tabButton(_ label: String, _ t: Tab) -> some View {
+        let on = tab == t
+        return Button { tab = t } label: {
+            Text(label)
+                .font(Theme.F.ui(13.5, .bold)).tracking(0.8)
+                .foregroundStyle(on ? Theme.C.ink : Theme.C.ink35)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 13)
+                // Each tab draws its own bottom rule so the bar reads as one
+                // line with the active tab picked out in amber.
+                .overlay(alignment: .bottom) {
+                    (on ? Theme.C.orange : Theme.C.ink).frame(height: on ? 3 : 2)
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -23,24 +23,9 @@ struct BoardView: View {
                         .tracking(2.0)
                         .foregroundStyle(Theme.C.orangeDeep)
                     Spacer()
-                    // Input-mode chip: VOICE (the product) vs DEMO (the canned
-                    // walk — graduates into onboarding). Tap to toggle;
-                    // launch-arg-forced modes lock it.
-                    Button { model.toggleMode() } label: {
-                        raisedChip(
-                            face: model.walkMode == .voice ? Theme.C.greenTint : Theme.C.yellowTint,
-                            edge: model.walkMode == .voice ? Theme.C.greenTag : Theme.C.yellowTag
-                        ) {
-                            Text(model.walkMode == .voice ? "MIC · VOICE" : "DEMO WALK")
-                                .font(Theme.F.mono(8, .semibold))
-                                .tracking(1.0)
-                                .foregroundStyle(model.walkMode == .voice ? Theme.C.greenTag : Theme.C.yellowTag)
-                        }
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .opacity(model.modeLocked ? 0.5 : 1)
-                    .disabled(model.modeLocked)
+                    // Input mode is voice-only for users; the DEMO toggle was a
+                    // dev affordance (still reachable via the `demo=1` launch arg
+                    // for QA/screenshots) — removed from the board per Isaac.
                     // One clear entry for making the app yours — replaces two
                     // cryptic chips (VOCAB + PAPER). A raised amber block (same
                     // pressed-block grammar as START WALK) so it reads as a

--- a/apps/ios/Sources/Flow/LetterheadStudioView.swift
+++ b/apps/ios/Sources/Flow/LetterheadStudioView.swift
@@ -10,6 +10,9 @@ import UIKit
 // pending dam's core answers.
 struct LetterheadStudioView: View {
     @Bindable var model: AppModel
+    /// When embedded in the My Business sheet, drop this screen's own header —
+    /// the container provides a shared header + tab bar.
+    let embedded: Bool
     @Environment(\.dismiss) private var dismiss
     @State private var draft: Branding
     @State private var draftProfile: BusinessProfile
@@ -19,8 +22,9 @@ struct LetterheadStudioView: View {
     @State private var pickedLogoData: Data?
     @State private var draftLayout: DocumentLayout
 
-    init(model: AppModel) {
+    init(model: AppModel, embedded: Bool = false) {
         self.model = model
+        self.embedded = embedded
         _draft = State(initialValue: model.branding)
         _draftLayout = State(initialValue: model.documentLayout)
         // The letterhead's business identity (name / city / license) is set at
@@ -47,7 +51,7 @@ struct LetterheadStudioView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
+            if !embedded { header }
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     preview

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct VocabularyView: View {
     @Bindable var model: AppModel
+    /// When embedded in the My Business sheet, drop this screen's own header.
+    var embedded: Bool = false
     @State private var newTerm = ""
     @FocusState private var fieldFocused: Bool
 
@@ -16,21 +18,23 @@ struct VocabularyView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
-            VStack(alignment: .leading, spacing: 4) {
-                SectionLabel("FIELD VOCABULARY", color: Theme.C.orangeDeep)
-                Text("Teach the mic your jargon")
-                    .font(Theme.F.ui(22, .bold))
-                Text("NAMES, PLANTS, PART NUMBERS — WALKS HEAR THEM BETTER")
-                    .font(Theme.F.mono(8.5))
-                    .tracking(0.8)
-                    .foregroundStyle(Theme.C.ink60)
-                    .padding(.top, 1)
+            // Header (dropped when embedded — the My Business sheet supplies one)
+            if !embedded {
+                VStack(alignment: .leading, spacing: 4) {
+                    SectionLabel("FIELD VOCABULARY", color: Theme.C.orangeDeep)
+                    Text("Teach the mic your jargon")
+                        .font(Theme.F.ui(22, .bold))
+                    Text("NAMES, PLANTS, PART NUMBERS — WALKS HEAR THEM BETTER")
+                        .font(Theme.F.mono(8.5))
+                        .tracking(0.8)
+                        .foregroundStyle(Theme.C.ink60)
+                        .padding(.top, 1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.top, 18)
+                .padding(.bottom, 14)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Theme.S.screenPad)
-            .padding(.top, 18)
-            .padding(.bottom, 14)
 
             MetaStrip(
                 left: "TERMS \(model.vocabulary.count) / \(cap)",


### PR DESCRIPTION
## Thinking

Isaac flagged that the board's **VOCAB** and **PAPER** chips are opaque — "I have no idea what they mean," and he wasn't drawn to them. That's a real problem for a non-technical audience, and it was burying the **document customization** (letterhead/logo/colors), which is a key differentiator.

Fix: collapse the two cryptic chips into **one clear, amber-outlined `MY BUSINESS` button** that opens a single sheet with **two tabs**:
- **PAPERWORK** (shown first — the differentiator): logo, brand colors, letterhead on every document.
- **WORDS**: teach the mic your trade's terms (the former "VOCAB").

One obvious entry point; the customization is right there instead of hidden behind a jargon label. (Isaac chose the "MY BUSINESS" label and the two-tab structure.)

## What changed

- **`CustomizeView`** (new, in `BoardView.swift`) — owns a shared header (`MY BUSINESS` + CLOSE) and a two-tab bar (`PAPERWORK` / `WORDS`), then embeds the two existing screens.
- **`LetterheadStudioView`** + **`VocabularyView`** — gain an `embedded: Bool` flag that drops their own headers when nested (the container provides one).
- **`BoardView`** — the two chips + two sheets become one `MY BUSINESS` button + one `showCustomize` sheet.

## Verification

- `BUILD SUCCEEDED` (clean rebuild, iPhone 17 sim).
- ⚠️ **No on-sim screenshot this session** — the local CoreSimulator daemon wedged mid-session (install silently no-ops; killing the daemon + erasing didn't recover it — needs an Xcode/machine restart). The layout matches the approved mockup; worth an eyeball on device before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)