### PR TITLE
fix(ios): pocket recording — keep the walk alive when the screen sleeps (v1.1.0 final piece)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Observation
+import UIKit
 import os
 
 // One observable model drives the whole flow:
@@ -304,6 +305,14 @@ final class AppModel {
     /// moves into it (the D9 numbered invariant, F3): STT/audio must never
     /// wire onto a session `begin` didn't successfully open (Plan 07
     /// dead-walk — a dead session would pump and silently drop every append).
+    /// Keep the display awake for the duration of a walk. Without this the phone
+    /// auto-locks in a pocket mid-walk, iOS suspends/kills the app, and the
+    /// in-progress walk is discarded (the whole "pocket it and keep walking"
+    /// flow). Toggled off at every walk exit so the board sleeps normally.
+    private func keepScreenAwake(_ on: Bool) {
+        UIApplication.shared.isIdleTimerDisabled = on
+    }
+
     private func beginWalk() {
         pumpTask?.cancel()
         eventTask?.cancel()
@@ -313,6 +322,7 @@ final class AppModel {
         micStarting = true
         phase = .walking
         path = [.walking]
+        keepScreenAwake(true)   // don't let the phone sleep + kill the walk
 
         Task { [weak self] in
             guard let self else { return }
@@ -333,6 +343,7 @@ final class AppModel {
                 Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "walk")
                     .error("startWalk: engine.begin failed, back to board: \(error, privacy: .public)")
                 self.micStarting = false
+                self.keepScreenAwake(false)
                 self.phase = .board
                 self.path = []
                 return
@@ -452,6 +463,7 @@ final class AppModel {
     }
 
     func discardWalk() {
+        keepScreenAwake(false)
         source?.abort()
         audioSource?.stop()
         pumpTask?.cancel()
@@ -489,6 +501,7 @@ final class AppModel {
     var notesLoading = false
 
     func finishWalk() {
+        keepScreenAwake(false)   // recording's done — let the phone sleep normally
         source?.stop()
         audioSource?.stop()
         // Navigate once, immediately, into the notes phase in a loading state.

--- a/apps/ios/Sources/App/Info.plist
+++ b/apps/ios/Sources/App/Info.plist
@@ -45,11 +45,17 @@
 		<string>SourceSerif4-SemiBold.ttf</string>
 		<string>SourceSerif4-Bold.ttf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -44,6 +44,12 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         NSMicrophoneUsageDescription: "Jefe records your walk-and-talk so it can turn it into paperwork."
+        # Keep recording when the screen locks / the phone is pocketed. Without
+        # this, iOS suspends the app on lock and the mic goes silent mid-walk —
+        # which breaks the core "press record, pocket the phone, keep walking"
+        # flow. Paired with the `.record` AVAudioSession in AudioCaptureSource.
+        UIBackgroundModes:
+          - audio
         NSCameraUsageDescription: "Photos you take during a walk pin to the item you're describing and land in the finished document."
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## Thinking

Isaac found a fatal flaw for the core use case (**press record → pocket the phone → walk 30 min**): when the phone slept, iOS suspended/killed the app and the **whole in-progress walk was discarded** — nothing captured.

Two commits, escalating to what actually works on-device:

1. **`audio` background mode** (project.yml + Info.plist) — declares that recording should continue when the screen locks. Necessary, but on Isaac's device it wasn't enough on its own to hold the app alive.
2. **Keep the screen awake during a walk** (`isIdleTimerDisabled` in `AppModel`, on at walk start / off at every exit) — the reliable fix (Isaac's own suggestion). If the phone never sleeps mid-walk, there's no suspend/kill cycle to lose the walk to. **Isaac confirmed on-device: the walk now survives and captures the whole time.** ✅

**Tradeoff:** the screen stays on for the walk → more battery, and it's lit in the pocket. The nicer screen-off version (zero drain, survives an actual kill) needs session-persistence + auto-resume — core-side, a follow-up. This is the reliable stopgap that unblocks the pocket walk now.

## This is the FINAL piece for the v1.1.0 external build

Everything else is already on `main` (rename→Jefe, onboarding, coach marks, My Business, accurate privacy, dark-mode, your Plan 19/20 core). Once this merges:

```
git tag v1.1.0 && git push origin v1.1.0
```

→ external candidate lands in ASC → Isaac submits for Beta App Review.

## Verification
- `BUILD SUCCEEDED` real-core.
- Keep-awake confirmed working on Isaac's iPhone (walk no longer discarded on sleep).
- (Not in v1.1.0, intentionally: #238 practice walk, #240 Plan 18 — both conflicting, next build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)