### PR TITLE
fix(ios): downsize photos before storing — stop the OOM crash on capture

### DIFF
--- a/apps/ios/Sources/Flow/PhotoCapture.swift
+++ b/apps/ios/Sources/Flow/PhotoCapture.swift
@@ -1,10 +1,57 @@
 import SwiftUI
 import PhotosUI
 import UIKit
+import ImageIO
+import UniformTypeIdentifiers
 
 // One-tap field capture. Device = the camera directly (zero chrome, zero
 // confirm — gloves and speed rule out anything else); simulator / no-camera
 // = PhotosPicker fallback so the flow stays exercisable everywhere.
+
+/// Downsize a captured photo before it's stored. A field photo needs to be
+/// legible on a document, not 48-megapixel — and a full-res capture (12–48 MP)
+/// decoded + re-encoded WHILE a live whisper walk already holds the model +
+/// Metal context in memory is a classic out-of-memory (jetsam) kill. This is
+/// the fix for the field crash "app crashed when uploading a photo": cap the
+/// longest edge and keep peak memory bounded.
+enum PhotoDownsize {
+    /// Longest-edge cap in pixels. 2048 is sharp for a letter-size document
+    /// while ~10–30× smaller in bytes + memory than a raw capture.
+    static let maxPixel = 2048.0
+    static let quality = 0.8
+
+    /// Memory-efficient path (picker / any encoded Data): ImageIO downsamples
+    /// straight from the source without fully decoding the full-res image.
+    static func jpeg(fromData data: Data) -> Data {
+        guard let src = CGImageSourceCreateWithData(
+            data as CFData, [kCGImageSourceShouldCache: false] as CFDictionary) else { return data }
+        let opts = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,   // honor EXIF orientation
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+            kCGImageSourceShouldCacheImmediately: true,
+        ] as CFDictionary
+        guard let cg = CGImageSourceCreateThumbnailAtIndex(src, 0, opts),
+              let out = UIImage(cgImage: cg).jpegData(compressionQuality: quality) else { return data }
+        return out
+    }
+
+    /// Camera path: the picker already handed us a decoded UIImage. Cap the
+    /// dimension BEFORE the JPEG encode (where a second full-res allocation
+    /// would otherwise blow up), preserving orientation.
+    static func jpeg(fromImage image: UIImage) -> Data? {
+        let longest = max(image.size.width, image.size.height)
+        guard longest > maxPixel else { return image.jpegData(compressionQuality: quality) }
+        let scale = maxPixel / longest
+        let size = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+        let fmt = UIGraphicsImageRendererFormat.default()
+        fmt.scale = 1
+        let scaled = UIGraphicsImageRenderer(size: size, format: fmt).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: size))
+        }
+        return scaled.jpegData(compressionQuality: quality)
+    }
+}
 
 struct CameraCapture: UIViewControllerRepresentable {
     var onImage: (Data) -> Void
@@ -34,7 +81,7 @@ struct CameraCapture: UIViewControllerRepresentable {
             didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
         ) {
             if let image = info[.originalImage] as? UIImage,
-               let data = image.jpegData(compressionQuality: 0.85) {
+               let data = PhotoDownsize.jpeg(fromImage: image) {
                 parent.onImage(data)
             }
             parent.dismiss()

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -150,7 +150,11 @@ struct WalkView: View {
             guard let newValue else { return }
             Task {
                 if let data = try? await newValue.loadTransferable(type: Data.self) {
-                    model.addPhoto(data)
+                    // Downsample off the main actor before storing (same OOM
+                    // guard as the camera path — a full-res library image is
+                    // just as heavy).
+                    let jpeg = await Task.detached { PhotoDownsize.jpeg(fromData: data) }.value
+                    model.addPhoto(jpeg)
                 }
                 pickerItem = nil
             }


### PR DESCRIPTION
## Thinking

Field crash report (external tester): **app crashed when adding a photo during a walk.**

Root cause: both photo paths stored the image at **full resolution** with no downsizing —
- camera: `info[.originalImage]` (12–48 MP) → `jpegData(0.85)`
- picker: `loadTransferable(type: Data.self)` (full library image)

Decoding + re-encoding a full-res image **while a live whisper walk already holds the model + Metal context in memory** is a textbook **out-of-memory (jetsam) kill** — which the tester experiences as a crash "when uploading a photo." (There's no force-unwrap or obvious logic bug in the capture path — this is memory.)

## What changed

`PhotoDownsize` (new, in `PhotoCapture.swift`) caps the longest edge at **2048px** before storing — plenty sharp for a letter-size document, ~10–30× smaller in bytes and memory:
- **Camera** path: downsizes the `UIImage` before the JPEG encode (where the second full-res allocation would blow up).
- **Picker** path: `ImageIO` downsamples straight from the source `Data` — no full decode — and runs off the main actor.

Peak memory stays bounded, so capture no longer OOM-kills mid-walk. Bonus: much smaller photos on disk / in the document.

## Verification

- `BUILD SUCCEEDED` (real-core, iPhone 17 sim).
- ⚠️ **Must confirm on device** — the sim can't reproduce the memory pressure. Take several photos during a real walk and confirm no crash.

## Related (separate from this fix)

- Accuracy report (same tester): the TestFlight build ships the **base.en** STT model; the local/dev default is **small.en** (measurably better WER). Filing that thread separately — it's a release-config / core call, not this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)