### PR TITLE
fix(stt): ship small.en again — accuracy over speed (field report)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,14 @@ concurrency:
 env:
   # Model choice + sha256 digests live in apps/ios/fetch-whisper-model.sh (the
   # same script ./generate.sh uses locally) — this is the default it fetches.
-  WHISPER_MODEL: base.en
-  MODEL_FILENAME: ggml-base.en-q5_1.bin
+  # small.en (2026-07-23): field accuracy > raw speed. base.en shipped on the
+  # first external build and a tester reported worse transcription + inaccurate
+  # notes — small.en is spike-validated better on every WER/hallucination axis.
+  # It was demoted 2026-07-10 for felt lag on iPhone 16e, but that was BEFORE
+  # the Plan 20 whisper warm-up (#245); re-verify live RTF on device before a
+  # wide roll-out. One-line revert if it lags: base.en + ggml-base.en-q5_1.bin.
+  WHISPER_MODEL: small.en
+  MODEL_FILENAME: ggml-small.en-q5_1.bin
 
 jobs:
   release:

--- a/apps/ios/Sources/App/EngineResolution.swift
+++ b/apps/ios/Sources/App/EngineResolution.swift
@@ -83,8 +83,9 @@ func resolveSttKnobs(_ args: [String]) -> SttKnobs {
 /// (superseded by the in-app mode chip — this now only reports an EXPLICIT
 /// arg; absent args defer to the user's persisted choice in AppModel.)
 /// scripted on sim (Metal STT SIGTRAPs on MTLSimDevice; QA assumes scripted),
-/// **live** on device. CAVEAT: small.en caused felt lag on iPhone 16e (sac,
-/// 2026-07-10); base.en is now default — `sttmodel=small.en`/`live=0` opts back in.
+/// **live** on device. NOTE: small.en is the default again (2026-07-23,
+/// accuracy) after a brief base.en demotion for lag — `sttmodel=base.en` opts
+/// back to the faster model if live RTF lags on a slower device.
 func resolveLive(_ args: [String]) -> Bool? {
     if args.contains("live=1") { return true }
     if args.contains("live=0") { return false }
@@ -92,10 +93,13 @@ func resolveLive(_ args: [String]) -> Bool? {
 }
 
 /// Resolves the bundled whisper model path from the `sttmodel=base.en|small.en`
-/// launch arg (default **base.en**). small.en (spike-validated on every
-/// measured WER/hallucination axis, `spikes/stt-whisper/RESULTS.md`) was
-/// DEMOTED 2026-07-10 after real-device lag on iPhone 16e — `sttmodel=
-/// small.en` (or `STT_MODEL=small.en` before `./generate.sh`) opts back in.
+/// launch arg (default **small.en**). small.en is spike-validated better on
+/// every measured WER/hallucination axis (`spikes/stt-whisper/RESULTS.md`); it
+/// was briefly demoted to base.en 2026-07-10 for felt lag on iPhone 16e, then
+/// RE-PROMOTED 2026-07-23 after a field tester reported worse transcription on
+/// the base.en external build — accuracy is the product. (The Plan 20 warm-up
+/// #245 also landed since the lag finding.) `sttmodel=base.en` opts back to
+/// the faster model if live RTF lags on a slower device.
 ///
 /// Falls back to whichever model IS bundled if the requested one isn't
 /// present — same "degrade, never crash" posture as the rest of engine
@@ -103,7 +107,7 @@ func resolveLive(_ args: [String]) -> Bool? {
 func resolveSttModelPath(_ args: [String]) -> String? {
     let requested = args
         .first(where: { $0.hasPrefix("sttmodel=") })
-        .map { String($0.dropFirst("sttmodel=".count)) } ?? "base.en"
+        .map { String($0.dropFirst("sttmodel=".count)) } ?? "small.en"
     let fallback = requested == "base.en" ? "small.en" : "base.en"
     for name in [requested, fallback] {
         if let path = Bundle.main.path(forResource: "ggml-\(name)-q5_1", ofType: "bin") {

--- a/apps/ios/generate.sh
+++ b/apps/ios/generate.sh
@@ -76,11 +76,11 @@ EOF
 # at every measured SNR, ~free RTF headroom on the Mac proxy) but DEMOTED
 # 2026-07-10 after real-device lag on iPhone 16e (sac's felt-lag datapoint —
 # the T5 device tier the Mac-proxy numbers couldn't answer; CANON 2026-07-10).
-# Default model is back to base.en — override with STT_MODEL=small.en for the
-# accuracy opt-in (matches the `sttmodel=` runtime launch arg in
-# GalleryApp.swift). fetch-whisper-model.sh caches on sha256, so repeat runs
-# of generate.sh don't re-download once the file is verified present.
-STT_MODEL="${STT_MODEL:-base.en}"
+# Default model is small.en (2026-07-23, accuracy — matches release.yml + the
+# runtime default in EngineResolution.swift). Override with STT_MODEL=base.en
+# for the faster model if you hit live lag. fetch-whisper-model.sh caches on
+# sha256, so repeat runs of generate.sh don't re-download once verified present.
+STT_MODEL="${STT_MODEL:-small.en}"
 if ./fetch-whisper-model.sh "$STT_MODEL"; then
   # Exactly ONE model may be bundled: project.yml globs Sources/ wholesale, so
   # if both ggml bins are on disk (e.g. a default small.en run followed by a


### PR DESCRIPTION
## Thinking

Field report from an external tester: **worse transcription + inaccurate notes** on the first external build, compared to earlier builds.

Root cause: the external build ships **base.en**, but Isaac's earlier (local) testing used **small.en** — which is spike-validated better on every measured WER / hallucination axis (`spikes/stt-whisper/RESULTS.md`, ~4.7% vs 5.8% WER, better in noise). So the tester literally got the less accurate model. base.en was a **2026-07-10 demotion** after small.en showed felt lag on the iPhone 16e.

Accuracy is the product (the whole value is trustworthy notes/paperwork), so this re-promotes small.en — in all three places that pick a model, so TestFlight, device, and local builds agree:
- `release.yml` — the CI/TestFlight bundled model
- `EngineResolution.swift` — the app's runtime default
- `generate.sh` — the local build default

## ⚠️ Caveat — must re-verify live RTF on device

small.en is ~2× slower to transcribe. The 07-10 lag finding **predates the Plan 20 whisper warm-up (#245)**, so it may be fine now — but a live walk needs to keep up on a mid-range iPhone before a wide roll-out. **Test a real walk for lag before shipping to all testers.** One-line revert if it lags: `base.en` (+ `ggml-base.en-q5_1.bin`) in the three spots.

Runtime escape hatch unchanged: `sttmodel=base.en` launch arg opts back to the faster model.

## Verification

- `BUILD SUCCEEDED` (real-core; `ggml-small.en-q5_1.bin` is the bundled resource, so the new default resolves).
- Live accuracy/lag: **on-device, yours to confirm.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)