### PR TITLE
fix(ios): pause STT when backgrounded — stop the whisper Metal-GPU crash (build 56)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -435,6 +435,36 @@ final class AppModel {
         }
     }
 
+    /// True while a walk is auto-paused because the app went to the background
+    /// (distinct from a user's manual PAUSE) — so we auto-resume on return
+    /// without overriding a deliberate pause.
+    private(set) var pausedByBackground = false
+
+    /// Pause/resume STT across app background transitions. Whisper runs its
+    /// encode on the **Metal GPU**, and iOS forbids GPU work while an app is
+    /// backgrounded — a compute that runs in the background hits `ggml_abort`
+    /// (SIGABRT) and crashes the walk (field crash, build 56). Since the
+    /// pocket-recording fix (#248) keeps the app alive in the background instead
+    /// of suspending it, we must stop feeding whisper when we lose the
+    /// foreground: pause on background, auto-resume on return. (The keep-screen-
+    /// awake in #248 means a normal pocketed walk never backgrounds; this covers
+    /// the manual power-button lock / incoming call / app-switch cases.)
+    func handleBackgroundTransition(backgrounded: Bool) {
+        guard phase == .walking else { return }
+        if backgrounded {
+            guard !isPaused else { return }   // don't fight a manual pause
+            isPaused = true
+            source?.pause()
+            audioSource?.pause()
+            pausedByBackground = true
+        } else if pausedByBackground {
+            pausedByBackground = false
+            isPaused = false
+            source?.resume()
+            audioSource?.resume()
+        }
+    }
+
     /// Walk-time capture (Plan 11 D7 / sac design pass): one tap, zero
     /// confirm — the shot pins to the item being spoken (`lastCapturedID`,
     /// dam's D3 rule) or attaches session-level when the board is still

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -33,6 +33,7 @@ struct RootRouter: View {
 struct AppRoot: View {
     @State private var model: AppModel
     @State private var needsOnboarding: Bool
+    @Environment(\.scenePhase) private var scenePhase
     private let live: Bool?
     private let wavwalk: Bool
     private let autoflowRounds: Int
@@ -123,6 +124,13 @@ struct AppRoot: View {
             .transition(.opacity)
         } else {
             appFlow
+                // Whisper's Metal GPU encode aborts if it runs while the app is
+                // backgrounded (SIGABRT via ggml_abort) — pause STT the moment we
+                // leave the foreground, resume when we're back. `.active` is the
+                // only safe-for-GPU state; `.inactive`/`.background` both stop it.
+                .onChange(of: scenePhase) { _, phase in
+                    model.handleBackgroundTransition(backgrounded: phase != .active)
+                }
         }
     }
 


### PR DESCRIPTION
## The crash (from Isaac's TestFlight report, build 56)

`EXC_CRASH (SIGABRT)` on the STT pump thread:
```
abort → ggml_abort → ggml_metal_synchronize → ggml_backend_sched_graph_compute
→ whisper_encode_internal → whisper_full_with_state → WhisperDecoder::decode
→ SttStream::poll → WalkSession::start_pump
```

## Root cause

whisper runs its encode on the **Metal GPU**, and **iOS forbids GPU work while an app is backgrounded** — any Metal compute that runs after backgrounding aborts (`ggml_abort` → SIGABRT).

This was **exposed by the pocket-recording fix (#248)**: before it, backgrounding *suspended* the app (whisper stopped, walk lost — the original bug). After it, the app stays **alive** in the background (audio mode), so whisper keeps computing on Metal → crash. Keep-screen-awake (#248) prevents *auto*-lock, but a **manual power-button lock, an incoming call, Control Center, or an app-switch** still backgrounds it → crash. That's almost certainly what the tester hit.

## Fix (app-side mitigation)

Observe `scenePhase`; the instant we leave `.active`, **pause STT** (stop feeding whisper → no Metal compute in the background), and **auto-resume** on return. Tracked by `pausedByBackground` so it doesn't override a user's manual PAUSE. Complements #248: a normal pocketed walk stays foreground (screen awake) and never pauses; this only trips on real background events, turning a crash into a pause.

## Verification

- `BUILD SUCCEEDED` (real-core).
- ⚠️ **On-device:** start a walk → lock the phone (or take a call) → should **pause, not crash** → unlock → resumes.

## Durable fix — @dam (core)

Small residual race: if a Metal compute is already in-flight at the exact instant of backgrounding, it can still abort before the pause lands. The real fix is core-side — whisper must not synchronize Metal while backgrounded: **defer decode to foreground (keep buffering audio), or CPU-fallback, or catch the Metal command-buffer error instead of `ggml_abort`.** That also unlocks *true* screen-off pocket transcription. This app-side pause is the immediate crash-stopper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)