### PR TITLE
feat(core): account for prompt-cache tokens in R9 (migration v8)

### DIFF
--- a/crates/evals/tests/carried_scenarios.rs
+++ b/crates/evals/tests/carried_scenarios.rs
@@ -12,7 +12,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 30, output_tokens: 8 },
+        usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() },
     }
 }
 
@@ -20,7 +20,7 @@ fn end_turn(t: &str) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::Text { text: t.into() }],
         stop_reason: StopReason::EndTurn,
-        usage: Usage { input_tokens: 10, output_tokens: 2 },
+        usage: Usage { input_tokens: 10, output_tokens: 2, ..Default::default() },
     }
 }
 

--- a/crates/evals/tests/document_fill_quality.rs
+++ b/crates/evals/tests/document_fill_quality.rs
@@ -23,7 +23,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 30, output_tokens: 8 },
+        usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() },
     }
 }
 

--- a/crates/evals/tests/grader_hermetic.rs
+++ b/crates/evals/tests/grader_hermetic.rs
@@ -14,11 +14,11 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 50, output_tokens: 10 },
+        usage: Usage { input_tokens: 50, output_tokens: 10, ..Default::default() },
     }
 }
 fn end_turn(t: &str) -> CompletionResponse {
-    CompletionResponse { content: vec![ContentBlock::Text { text: t.into() }], stop_reason: StopReason::EndTurn, usage: Usage { input_tokens: 20, output_tokens: 4 } }
+    CompletionResponse { content: vec![ContentBlock::Text { text: t.into() }], stop_reason: StopReason::EndTurn, usage: Usage { input_tokens: 20, output_tokens: 4, ..Default::default() } }
 }
 fn summary(t: &str) -> CompletionResponse {
     tool_use("write_notes", serde_json::json!({ "summary": t }))

--- a/crates/evals/tests/live_prompt_pins.rs
+++ b/crates/evals/tests/live_prompt_pins.rs
@@ -24,7 +24,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 30, output_tokens: 8 },
+        usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() },
     }
 }
 
@@ -32,7 +32,7 @@ fn end_turn(t: &str) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::Text { text: t.into() }],
         stop_reason: StopReason::EndTurn,
-        usage: Usage { input_tokens: 10, output_tokens: 2 },
+        usage: Usage { input_tokens: 10, output_tokens: 2, ..Default::default() },
     }
 }
 

--- a/crates/ffi/src/document_build.rs
+++ b/crates/ffi/src/document_build.rs
@@ -73,7 +73,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 
@@ -81,7 +81,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 

--- a/crates/ffi/src/items.rs
+++ b/crates/ffi/src/items.rs
@@ -181,7 +181,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 
@@ -189,7 +189,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 

--- a/crates/ffi/src/schemas.rs
+++ b/crates/ffi/src/schemas.rs
@@ -199,7 +199,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 
@@ -207,7 +207,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 

--- a/crates/ffi/src/session.rs
+++ b/crates/ffi/src/session.rs
@@ -840,7 +840,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 
@@ -848,7 +848,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 

--- a/crates/ffi/src/session_retry.rs
+++ b/crates/ffi/src/session_retry.rs
@@ -73,7 +73,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 
@@ -85,7 +85,7 @@ mod tests {
                 input: serde_json::json!({"summary": text}),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
         }
     }
 

--- a/crates/ffi/tests/audio_pump_e2e.rs
+++ b/crates/ffi/tests/audio_pump_e2e.rs
@@ -38,7 +38,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 10, output_tokens: 5 },
+        usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
     }
 }
 
@@ -46,7 +46,7 @@ fn end_turn(text: &str) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::Text { text: text.into() }],
         stop_reason: StopReason::EndTurn,
-        usage: Usage { input_tokens: 10, output_tokens: 5 },
+        usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
     }
 }
 

--- a/crates/ffi/tests/bridge_e2e.rs
+++ b/crates/ffi/tests/bridge_e2e.rs
@@ -39,7 +39,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 10, output_tokens: 5 },
+        usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
     }
 }
 
@@ -47,7 +47,7 @@ fn end_turn(text: &str) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::Text { text: text.into() }],
         stop_reason: StopReason::EndTurn,
-        usage: Usage { input_tokens: 10, output_tokens: 5 },
+        usage: Usage { input_tokens: 10, output_tokens: 5, ..Default::default() },
     }
 }
 

--- a/crates/harness/src/agent.rs
+++ b/crates/harness/src/agent.rs
@@ -152,7 +152,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     fn usage1() -> Usage {
-        Usage { input_tokens: 10, output_tokens: 20 }
+        Usage { input_tokens: 10, output_tokens: 20, ..Default::default() }
     }
 
     fn text_end(s: &str) -> CompletionResponse {
@@ -246,7 +246,7 @@ mod tests {
         assert_eq!(out.text, "all done");
         assert_eq!(calls.lock().unwrap().as_slice(), &[serde_json::json!({"x": 1})]);
         // usage accumulated over two provider calls
-        assert_eq!(out.usage, Usage { input_tokens: 20, output_tokens: 40 });
+        assert_eq!(out.usage, Usage { input_tokens: 20, output_tokens: 40, ..Default::default() });
 
         // second request must carry assistant tool_use then user tool_result
         let reqs = provider.requests();
@@ -337,7 +337,7 @@ mod tests {
         let err = agent.run(vec![Message::user_text("go")]).await.unwrap_err();
         assert!(matches!(err.source, HarnessError::MaxTurns(5)));
         // all 5 turns' usage is preserved in the error
-        assert_eq!(err.usage, Usage { input_tokens: 50, output_tokens: 100 });
+        assert_eq!(err.usage, Usage { input_tokens: 50, output_tokens: 100, ..Default::default() });
         assert_eq!(provider.requests().len(), 5);
     }
 }

--- a/crates/harness/src/llm.rs
+++ b/crates/harness/src/llm.rs
@@ -79,14 +79,37 @@ pub enum StopReason {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Usage {
+    /// The prompt tokens billed at the FULL rate. When prompt caching is in
+    /// play this is the *uncached remainder only* — NOT the whole prompt.
+    /// `total_input_tokens()` is what you want for "how big was the prompt".
     pub input_tokens: u64,
     pub output_tokens: u64,
+    /// Prompt tokens written to the cache this call (billed ~1.25x). Absent on
+    /// providers/responses that don't cache, hence `default` — a missing field
+    /// must never fail response parsing (same posture as `StopReason::Unknown`).
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    /// Prompt tokens served FROM the cache this call (billed ~0.1x).
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
 }
 
 impl Usage {
     pub fn add(&mut self, other: &Usage) {
         self.input_tokens += other.input_tokens;
         self.output_tokens += other.output_tokens;
+        self.cache_creation_input_tokens += other.cache_creation_input_tokens;
+        self.cache_read_input_tokens += other.cache_read_input_tokens;
+    }
+
+    /// Every prompt token the call actually processed, cached or not.
+    ///
+    /// Cost analysis must use this rather than `input_tokens`: once caching is
+    /// on, the API moves most of the prompt into the two cache fields and
+    /// `input_tokens` collapses to the remainder. Reading `input_tokens` alone
+    /// would show a dramatic "saving" that is purely a reporting artifact.
+    pub fn total_input_tokens(&self) -> u64 {
+        self.input_tokens + self.cache_creation_input_tokens + self.cache_read_input_tokens
     }
 }
 
@@ -138,9 +161,60 @@ mod tests {
 
     #[test]
     fn usage_adds() {
-        let mut u = Usage { input_tokens: 10, output_tokens: 5 };
-        u.add(&Usage { input_tokens: 3, output_tokens: 7 });
-        assert_eq!(u, Usage { input_tokens: 13, output_tokens: 12 });
+        let mut u = Usage { input_tokens: 10, output_tokens: 5, ..Default::default() };
+        u.add(&Usage { input_tokens: 3, output_tokens: 7, ..Default::default() });
+        assert_eq!(u, Usage { input_tokens: 13, output_tokens: 12, ..Default::default() });
+    }
+
+    #[test]
+    fn usage_adds_accumulates_cache_tokens_too() {
+        // A dropped cache field here would silently under-report spend across a
+        // multi-turn run — the exact failure R9 exists to prevent.
+        let mut u = Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 200,
+        };
+        u.add(&Usage {
+            input_tokens: 1,
+            output_tokens: 2,
+            cache_creation_input_tokens: 3,
+            cache_read_input_tokens: 4,
+        });
+        assert_eq!(
+            u,
+            Usage {
+                input_tokens: 11,
+                output_tokens: 7,
+                cache_creation_input_tokens: 103,
+                cache_read_input_tokens: 204,
+            }
+        );
+    }
+
+    #[test]
+    fn total_input_tokens_spans_all_three_input_classes() {
+        let u = Usage {
+            input_tokens: 10,
+            output_tokens: 999,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 1_000,
+        };
+        // Not 10: reading `input_tokens` alone is the reporting artifact that
+        // makes caching look like a 99% saving.
+        assert_eq!(u.total_input_tokens(), 1_110);
+    }
+
+    #[test]
+    fn usage_without_cache_fields_parses_leniently() {
+        // The mock provider and any non-caching response omit these entirely.
+        let u: Usage =
+            serde_json::from_value(serde_json::json!({"input_tokens": 42, "output_tokens": 7}))
+                .unwrap();
+        assert_eq!(u.cache_creation_input_tokens, 0);
+        assert_eq!(u.cache_read_input_tokens, 0);
+        assert_eq!(u.total_input_tokens(), 42);
     }
 
     #[test]

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -44,7 +44,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: s.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 1, output_tokens: 1 },
+            usage: Usage { input_tokens: 1, output_tokens: 1, ..Default::default() },
         }
     }
 

--- a/crates/harness/src/providers/anthropic.rs
+++ b/crates/harness/src/providers/anthropic.rs
@@ -133,7 +133,7 @@ mod tests {
         let resp = provider.complete(request()).await.unwrap();
 
         assert_eq!(resp.stop_reason, StopReason::ToolUse);
-        assert_eq!(resp.usage, Usage { input_tokens: 42, output_tokens: 7 });
+        assert_eq!(resp.usage, Usage { input_tokens: 42, output_tokens: 7, ..Default::default() });
         assert_eq!(resp.content.len(), 2);
         assert!(matches!(&resp.content[1], ContentBlock::ToolUse { name, .. } if name == "echo"));
 
@@ -145,6 +145,38 @@ mod tests {
         assert_eq!(body["max_tokens"], 256);
         assert_eq!(body["messages"][0]["role"], "user");
         assert_eq!(body["tools"][0]["name"], "echo");
+    }
+
+    #[tokio::test]
+    async fn parses_prompt_cache_token_fields_from_the_wire() {
+        // A cached call reports FOUR token fields, and `input_tokens` shrinks to
+        // the uncached remainder. Dropping the two cache fields on the floor
+        // would make this response look like a 20-token prompt instead of 4020.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 7,
+                    "cache_creation_input_tokens": 4000,
+                    "cache_read_input_tokens": 0
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider =
+            AnthropicProvider::new("sk-test", "claude-haiku-4-5-20251001").with_base_url(server.uri());
+        let resp = provider.complete(request()).await.unwrap();
+
+        assert_eq!(resp.usage.input_tokens, 20);
+        assert_eq!(resp.usage.cache_creation_input_tokens, 4000);
+        assert_eq!(resp.usage.cache_read_input_tokens, 0);
+        assert_eq!(resp.usage.total_input_tokens(), 4020);
     }
 
     #[tokio::test]

--- a/crates/harness/src/reflection/engine.rs
+++ b/crates/harness/src/reflection/engine.rs
@@ -247,7 +247,7 @@ mod tests {
                 input: serde_json::json!({ "sections": sections }),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 100, output_tokens: 50 },
+            usage: Usage { input_tokens: 100, output_tokens: 50, ..Default::default() },
         }
     }
 
@@ -292,7 +292,7 @@ mod tests {
                 session: None,
             }
         );
-        assert_eq!(out.usage, Usage { input_tokens: 100, output_tokens: 50 });
+        assert_eq!(out.usage, Usage { input_tokens: 100, output_tokens: 50, ..Default::default() });
 
         // request shape: forced tool, memory + activity present, corrected marker rendered
         let reqs = provider.requests();
@@ -374,7 +374,7 @@ mod tests {
                 input: serde_json::json!({ "sections": "not an object" }),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 77, output_tokens: 11 },
+            usage: Usage { input_tokens: 77, output_tokens: 11, ..Default::default() },
         }]));
         let engine = ReflectionEngine::new(provider);
         let err = engine.reflect(&Memory::default(), &[], 999).await.unwrap_err();
@@ -382,7 +382,7 @@ mod tests {
             matches!(&err.source, HarnessError::Provider(msg) if msg.contains("malformed sections"))
         );
         // post-completion failure: usage from the completed response is preserved
-        assert_eq!(err.usage, Usage { input_tokens: 77, output_tokens: 11 });
+        assert_eq!(err.usage, Usage { input_tokens: 77, output_tokens: 11, ..Default::default() });
     }
 
     #[tokio::test]
@@ -395,8 +395,8 @@ mod tests {
         assert!(
             matches!(&err.source, HarnessError::Provider(msg) if msg.contains("empty memory"))
         );
-        // write_memory_response uses Usage { input_tokens: 100, output_tokens: 50 }
-        assert_eq!(err.usage, Usage { input_tokens: 100, output_tokens: 50 });
+        // write_memory_response uses Usage { input_tokens: 100, output_tokens: 50, ..Default::default() }
+        assert_eq!(err.usage, Usage { input_tokens: 100, output_tokens: 50, ..Default::default() });
     }
 
     #[test]

--- a/crates/murmur-core/src/coordinator.rs
+++ b/crates/murmur-core/src/coordinator.rs
@@ -182,7 +182,7 @@ mod tests {
                 input: serde_json::json!({"sections": sections}),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 200, output_tokens: 40 },
+            usage: Usage { input_tokens: 200, output_tokens: 40, ..Default::default() },
         }
     }
 
@@ -308,7 +308,7 @@ mod tests {
                 input: serde_json::json!({ "sections": "not an object" }),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 200, output_tokens: 40 },
+            usage: Usage { input_tokens: 200, output_tokens: 40, ..Default::default() },
         };
         let (coordinator, memory, _memory_store, store) =
             coordinator_with(vec![malformed], store_with_ended_session());

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -373,8 +373,15 @@ pub struct LlmUsageRow {
     /// folded into a single row per session by design), "reflection", or future
     /// pipeline phases. "summary" never appears as a standalone purpose.
     pub purpose: String,
+    /// Prompt tokens billed at the full rate — the *uncached remainder* when
+    /// caching is on, not the whole prompt. Sum all three token fields for
+    /// "how big was the prompt" (see `harness::Usage::total_input_tokens`).
     pub input_tokens: u64,
     pub output_tokens: u64,
+    /// Prompt tokens written to the cache (~1.25x). 0 on pre-v8 rows.
+    pub cache_creation_input_tokens: u64,
+    /// Prompt tokens served from the cache (~0.1x). 0 on pre-v8 rows.
+    pub cache_read_input_tokens: u64,
     pub created_at: u64,
     pub device_id: String,
 }

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -617,7 +617,7 @@ mod tests {
         harness::CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu_1".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 80, output_tokens: 15 },
+            usage: Usage { input_tokens: 80, output_tokens: 15, ..Default::default() },
         }
     }
 
@@ -738,7 +738,7 @@ mod tests {
         assert_eq!(map.get(a2.as_str()), Some(&31000), "first-wins on the duplicate a2");
         assert_eq!(map.get("bogus"), None, "hallucinated id dropped");
         assert_eq!(map.len(), 2);
-        assert_eq!(usage, Usage { input_tokens: 80, output_tokens: 15 });
+        assert_eq!(usage, Usage { input_tokens: 80, output_tokens: 15, ..Default::default() });
     }
 
     #[tokio::test]
@@ -812,7 +812,7 @@ mod tests {
 
         let outcome = b.build(&sid, "estimate").await.unwrap();
         assert!(!outcome.queued);
-        assert_eq!(outcome.usage, Usage { input_tokens: 80, output_tokens: 15 });
+        assert_eq!(outcome.usage, Usage { input_tokens: 80, output_tokens: 15, ..Default::default() });
 
         let store = store.lock().unwrap();
         let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
@@ -1241,7 +1241,7 @@ mod tests {
         assert_eq!(map.get("reviewed_by").map(String::as_str), Some("Dana"));
         assert_eq!(map.get("gate_code"), None, "hallucinated key dropped");
         assert_eq!(map.len(), 2);
-        assert_eq!(usage, Usage { input_tokens: 80, output_tokens: 15 }, "R9: usage accumulated");
+        assert_eq!(usage, Usage { input_tokens: 80, output_tokens: 15, ..Default::default() }, "R9: usage accumulated");
     }
 
     /// R6 + the WE-B exact prompt: items (via `format_pricing_items`

--- a/crates/murmur-core/src/pipeline/live.rs
+++ b/crates/murmur-core/src/pipeline/live.rs
@@ -265,7 +265,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu_1".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 30, output_tokens: 8 },
+            usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() },
         }
     }
 
@@ -273,7 +273,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 10, output_tokens: 2 },
+            usage: Usage { input_tokens: 10, output_tokens: 2, ..Default::default() },
         }
     }
 
@@ -316,7 +316,7 @@ mod tests {
             outcome,
             LiveExtractOutcome::Extracted {
                 items_added: 1,
-                usage: Usage { input_tokens: 40, output_tokens: 10 },
+                usage: Usage { input_tokens: 40, output_tokens: 10, ..Default::default() },
             }
         );
         // cursor advanced to the transcript length in chars
@@ -407,7 +407,7 @@ mod tests {
         let outcome = extractor.maybe_extract().await.unwrap();
         assert_eq!(
             outcome,
-            LiveExtractOutcome::Failed { usage: Usage { input_tokens: 30, output_tokens: 8 } }
+            LiveExtractOutcome::Failed { usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() } }
         );
         assert_eq!(extractor.cursor(), 0, "cursor held so the window retries");
 
@@ -459,7 +459,7 @@ mod tests {
             outcome,
             LiveExtractOutcome::Extracted {
                 items_added: 0,
-                usage: Usage { input_tokens: 40, output_tokens: 10 },
+                usage: Usage { input_tokens: 40, output_tokens: 10, ..Default::default() },
             }
         );
 

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -412,7 +412,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::ToolUse { id: "tu_1".into(), name: name.into(), input }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 100, output_tokens: 20 },
+            usage: Usage { input_tokens: 100, output_tokens: 20, ..Default::default() },
         }
     }
 
@@ -420,7 +420,7 @@ mod tests {
         CompletionResponse {
             content: vec![ContentBlock::Text { text: text.into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 50, output_tokens: 10 },
+            usage: Usage { input_tokens: 50, output_tokens: 10, ..Default::default() },
         }
     }
 
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(outcome.session.summary.as_deref(), Some("Ordered lumber; Dev handles framing."));
         // usage: 100+20, 100+20, 50+10 agent + 100+20 summary — NO build_document
         // call (Plan 13 Stage 2 drops phase B): finish is strictly cheaper.
-        assert_eq!(outcome.usage, Usage { input_tokens: 350, output_tokens: 70 });
+        assert_eq!(outcome.usage, Usage { input_tokens: 350, output_tokens: 70, ..Default::default() });
 
         let store = store.lock().unwrap();
         assert_eq!(store.list_items_for_session(&sid).unwrap().len(), 1);

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -222,14 +222,14 @@ mod tests {
                 input: serde_json::json!({"summary": "Walked the deck; two todos."}),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 40, output_tokens: 12 },
+            usage: Usage { input_tokens: 40, output_tokens: 12, ..Default::default() },
         }]));
         let (summary, spoken_total_cents, buckets, usage) =
             summarize(provider.clone(), "transcript text", 512).await.unwrap();
         assert_eq!(summary.as_deref(), Some("Walked the deck; two todos."));
         assert_eq!(spoken_total_cents, None, "no total was stated");
         assert_eq!(buckets, Vec::new(), "no notes array in the response -> []");
-        assert_eq!(usage, Usage { input_tokens: 40, output_tokens: 12 });
+        assert_eq!(usage, Usage { input_tokens: 40, output_tokens: 12, ..Default::default() });
         let reqs = provider.requests();
         assert_eq!(reqs[0].tool_choice.as_deref(), Some("write_notes"));
         assert!(reqs[0].max_tokens >= 1);
@@ -255,7 +255,7 @@ mod tests {
                 }),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 40, output_tokens: 12 },
+            usage: Usage { input_tokens: 40, output_tokens: 12, ..Default::default() },
         }]));
         let (_summary, _spoken_total_cents, buckets, _usage) =
             summarize(provider, "t", 512).await.unwrap();
@@ -282,7 +282,7 @@ mod tests {
                 }),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 40, output_tokens: 12 },
+            usage: Usage { input_tokens: 40, output_tokens: 12, ..Default::default() },
         }]));
         let (summary, _spoken_total_cents, buckets, _usage) =
             summarize(provider, "t", 512).await.unwrap();
@@ -341,13 +341,13 @@ mod tests {
         let provider = Arc::new(MockProvider::new(vec![CompletionResponse {
             content: vec![ContentBlock::Text { text: "no tool".into() }],
             stop_reason: StopReason::EndTurn,
-            usage: Usage { input_tokens: 50, output_tokens: 10 },
+            usage: Usage { input_tokens: 50, output_tokens: 10, ..Default::default() },
         }]));
         let (summary, spoken_total_cents, buckets, usage) = summarize(provider, "t", 512).await.unwrap();
         assert!(summary.is_none(), "missing tool call is not an Err — spend must be loggable");
         assert_eq!(spoken_total_cents, None);
         assert_eq!(buckets, Vec::new());
-        assert_eq!(usage, Usage { input_tokens: 50, output_tokens: 10 });
+        assert_eq!(usage, Usage { input_tokens: 50, output_tokens: 10, ..Default::default() });
     }
 
     #[tokio::test]
@@ -362,7 +362,7 @@ mod tests {
                 }),
             }],
             stop_reason: StopReason::ToolUse,
-            usage: Usage { input_tokens: 40, output_tokens: 12 },
+            usage: Usage { input_tokens: 40, output_tokens: 12, ..Default::default() },
         }]));
         let (summary, spoken_total_cents, _buckets, _usage) =
             summarize(provider, "transcript text", 512).await.unwrap();

--- a/crates/murmur-core/src/reflection.rs
+++ b/crates/murmur-core/src/reflection.rs
@@ -188,7 +188,7 @@ mod tests {
     fn finish_reflection_records_signals_and_logs_cost() {
         let s = store();
         s.record_session_completed().unwrap();
-        s.finish_reflection(0.3, &harness::Usage { input_tokens: 200, output_tokens: 40 })
+        s.finish_reflection(0.3, &harness::Usage { input_tokens: 200, output_tokens: 40, ..Default::default() })
             .unwrap();
         let signals = s.reflection_signals().unwrap();
         assert_eq!(signals.completed_reflections, 1);

--- a/crates/murmur-core/src/store/migrations.rs
+++ b/crates/murmur-core/src/store/migrations.rs
@@ -173,6 +173,16 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     );
     CREATE INDEX idx_document_schemas_kind ON document_schemas(kind) WHERE deleted_at IS NULL;
     "#,
+    // v8: prompt-cache token columns on llm_usage (R9 stays honest under
+    // caching). The API reports cache tokens in SEPARATE fields and collapses
+    // `input_tokens` to the uncached remainder — so without these two columns,
+    // switching caching on would make the spend meter read like a huge saving
+    // that never happened. Additive with DEFAULT 0: every pre-v8 row is
+    // correct as-is, because those calls genuinely cached nothing.
+    r#"
+    ALTER TABLE llm_usage ADD COLUMN cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE llm_usage ADD COLUMN cache_read_input_tokens INTEGER NOT NULL DEFAULT 0;
+    "#,
 ];
 
 pub(crate) fn migrate(conn: &Connection) -> Result<(), CoreError> {
@@ -206,6 +216,45 @@ fn migrate_with(conn: &Connection, migrations: &[&str]) -> Result<(), CoreError>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn v8_upgrade_preserves_existing_llm_usage_rows() {
+        // Every device already in the field is at v7. v8 must add the two cache
+        // columns without disturbing rows written before it — those calls
+        // genuinely cached nothing, so 0 is the honest value, not a placeholder.
+        let conn = Connection::open_in_memory().unwrap();
+
+        // Bring the DB to v7 only, then write a row the pre-v8 way.
+        let v7: Vec<&str> = MIGRATIONS.iter().take(7).copied().collect();
+        migrate_with(&conn, &v7).unwrap();
+        conn.execute(
+            "INSERT INTO llm_usage (id, session_id, purpose, input_tokens, output_tokens,
+                                    created_at, device_id)
+             VALUES ('u1', NULL, 'processing', 900, 120, 1000, 'device-a')",
+            [],
+        )
+        .unwrap();
+
+        // Apply the full set — v8 lands on top of that existing row.
+        migrate_with(&conn, MIGRATIONS).unwrap();
+
+        let version: i64 = conn
+            .pragma_query_value(None, "user_version", |r| r.get(0))
+            .unwrap();
+        assert_eq!(version, 8);
+
+        let (input, cw, cr, output): (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT input_tokens, cache_creation_input_tokens,
+                        cache_read_input_tokens, output_tokens
+                 FROM llm_usage WHERE id = 'u1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!((input, output), (900, 120), "existing counts untouched");
+        assert_eq!((cw, cr), (0, 0), "new columns default to 0, not NULL");
+    }
 
     #[test]
     fn failed_migration_rolls_back_cleanly() {

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -330,11 +330,11 @@ mod tests {
     }
 
     #[test]
-    fn fresh_store_is_at_schema_v7() {
+    fn fresh_store_is_at_schema_v8() {
         let s = Store::open_in_memory("device-a").unwrap();
         let v: i64 =
             s.conn.pragma_query_value(None, "user_version", |r| r.get(0)).unwrap();
-        assert_eq!(v, 7, "v7 added document_schemas (Plan 19)");
+        assert_eq!(v, 8, "v8 added the llm_usage prompt-cache token columns");
     }
 
     #[test]

--- a/crates/murmur-core/src/store/usage.rs
+++ b/crates/murmur-core/src/store/usage.rs
@@ -13,6 +13,12 @@ fn usage_from_row(row: &Row) -> Result<LlmUsageRow, CoreError> {
         purpose: row.get("purpose").map_err(CoreError::Sqlite)?,
         input_tokens: row.get::<_, i64>("input_tokens").map_err(CoreError::Sqlite)? as u64,
         output_tokens: row.get::<_, i64>("output_tokens").map_err(CoreError::Sqlite)? as u64,
+        cache_creation_input_tokens: row
+            .get::<_, i64>("cache_creation_input_tokens")
+            .map_err(CoreError::Sqlite)? as u64,
+        cache_read_input_tokens: row
+            .get::<_, i64>("cache_read_input_tokens")
+            .map_err(CoreError::Sqlite)? as u64,
         created_at: row.get::<_, i64>("created_at").map_err(CoreError::Sqlite)? as u64,
         device_id: row.get("device_id").map_err(CoreError::Sqlite)?,
     })
@@ -28,14 +34,18 @@ impl Store {
         usage: &Usage,
     ) -> Result<(), CoreError> {
         self.conn.execute(
-            "INSERT INTO llm_usage (id, session_id, purpose, input_tokens, output_tokens, created_at, device_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO llm_usage (id, session_id, purpose, input_tokens, output_tokens,
+                                    cache_creation_input_tokens, cache_read_input_tokens,
+                                    created_at, device_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 new_id(),
                 session_id,
                 purpose,
                 usage.input_tokens as i64,
                 usage.output_tokens as i64,
+                usage.cache_creation_input_tokens as i64,
+                usage.cache_read_input_tokens as i64,
                 self.now() as i64,
                 self.device_id,
             ],
@@ -45,7 +55,8 @@ impl Store {
 
     pub fn list_llm_usage_for_session(&self, session_id: &str) -> Result<Vec<LlmUsageRow>, CoreError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, session_id, purpose, input_tokens, output_tokens, created_at, device_id
+            "SELECT id, session_id, purpose, input_tokens, output_tokens,
+                    cache_creation_input_tokens, cache_read_input_tokens, created_at, device_id
              FROM llm_usage WHERE session_id = ?1 ORDER BY id ASC",
         )?;
         let mut rows = stmt.query([session_id])?;
@@ -58,13 +69,39 @@ impl Store {
 
     /// (total input tokens, total output tokens) across all recorded calls —
     /// the spend meter's raw feed.
+    ///
+    /// "Input" here is EVERY prompt token processed, cached or not — the sum of
+    /// the three input columns, not the `input_tokens` column alone. Summing
+    /// only that column would make the meter appear to drop sharply the moment
+    /// caching is enabled, because the API moves most of the prompt into the
+    /// cache columns. Pre-v8 rows are unaffected (their cache columns are 0).
     pub fn usage_totals(&self) -> Result<(u64, u64), CoreError> {
         let (i, o): (i64, i64) = self.conn.query_row(
-            "SELECT COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0) FROM llm_usage",
+            "SELECT COALESCE(SUM(input_tokens + cache_creation_input_tokens
+                                 + cache_read_input_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0)
+             FROM llm_usage",
             [],
             |r| Ok((r.get(0)?, r.get(1)?)),
         )?;
         Ok((i as u64, o as u64))
+    }
+
+    /// The spend meter's cost-accurate feed: (full-rate input, cache writes,
+    /// cache reads, output). The three input classes bill at ~1x / ~1.25x /
+    /// ~0.1x, so a single token count can't express spend once caching is on —
+    /// this is what a real cost-per-walk figure has to be computed from.
+    pub fn usage_totals_detailed(&self) -> Result<(u64, u64, u64, u64), CoreError> {
+        let (i, cw, cr, o): (i64, i64, i64, i64) = self.conn.query_row(
+            "SELECT COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(cache_creation_input_tokens), 0),
+                    COALESCE(SUM(cache_read_input_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0)
+             FROM llm_usage",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )?;
+        Ok((i as u64, cw as u64, cr as u64, o as u64))
     }
 }
 
@@ -87,7 +124,7 @@ mod tests {
         s.record_llm_usage(
             Some(&session.id),
             "processing",
-            &Usage { input_tokens: 900, output_tokens: 120 },
+            &Usage { input_tokens: 900, output_tokens: 120, ..Default::default() },
         )
         .unwrap();
         let rows = s.list_llm_usage_for_session(&session.id).unwrap();
@@ -101,7 +138,7 @@ mod tests {
     #[test]
     fn sessionless_usage_is_allowed() {
         let s = store();
-        s.record_llm_usage(None, "reflection", &Usage { input_tokens: 300, output_tokens: 80 })
+        s.record_llm_usage(None, "reflection", &Usage { input_tokens: 300, output_tokens: 80, ..Default::default() })
             .unwrap();
         assert_eq!(s.usage_totals().unwrap(), (300, 80));
     }
@@ -110,9 +147,9 @@ mod tests {
     fn totals_sum_across_rows() {
         let s = store();
         let session = s.start_session(None).unwrap();
-        s.record_llm_usage(Some(&session.id), "processing", &Usage { input_tokens: 10, output_tokens: 1 })
+        s.record_llm_usage(Some(&session.id), "processing", &Usage { input_tokens: 10, output_tokens: 1, ..Default::default() })
             .unwrap();
-        s.record_llm_usage(None, "reflection", &Usage { input_tokens: 5, output_tokens: 2 })
+        s.record_llm_usage(None, "reflection", &Usage { input_tokens: 5, output_tokens: 2, ..Default::default() })
             .unwrap();
         assert_eq!(s.usage_totals().unwrap(), (15, 3));
         assert_eq!(s.list_llm_usage_for_session(&session.id).unwrap().len(), 1);
@@ -124,4 +161,69 @@ mod tests {
         let err = s.record_llm_usage(Some("nope"), "processing", &Usage::default());
         assert!(err.is_err(), "FK to sessions must hold");
     }
+
+    #[test]
+    fn cache_tokens_round_trip_through_the_row() {
+        let s = store();
+        let session = s.start_session(None).unwrap();
+        s.record_llm_usage(
+            Some(&session.id),
+            "processing",
+            &Usage {
+                input_tokens: 20,
+                output_tokens: 7,
+                cache_creation_input_tokens: 4000,
+                cache_read_input_tokens: 8000,
+            },
+        )
+        .unwrap();
+        let rows = s.list_llm_usage_for_session(&session.id).unwrap();
+        assert_eq!(rows[0].cache_creation_input_tokens, 4000);
+        assert_eq!(rows[0].cache_read_input_tokens, 8000);
+    }
+
+    #[test]
+    fn totals_count_cached_prompt_tokens_not_just_the_remainder() {
+        // The regression this guards: with caching on, the API moves most of the
+        // prompt into the cache fields. A meter summing `input_tokens` alone
+        // would report 20 here and look like a 99.5% cost drop that never was.
+        let s = store();
+        s.record_llm_usage(
+            None,
+            "reflection",
+            &Usage {
+                input_tokens: 20,
+                output_tokens: 7,
+                cache_creation_input_tokens: 4000,
+                cache_read_input_tokens: 8000,
+            },
+        )
+        .unwrap();
+        assert_eq!(s.usage_totals().unwrap(), (12_020, 7));
+    }
+
+    #[test]
+    fn detailed_totals_keep_the_three_input_classes_separate() {
+        // They bill at ~1x / ~1.25x / ~0.1x, so cost needs them unmerged.
+        let s = store();
+        s.record_llm_usage(
+            None,
+            "reflection",
+            &Usage {
+                input_tokens: 20,
+                output_tokens: 7,
+                cache_creation_input_tokens: 4000,
+                cache_read_input_tokens: 8000,
+            },
+        )
+        .unwrap();
+        s.record_llm_usage(
+            None,
+            "reflection",
+            &Usage { input_tokens: 5, output_tokens: 1, ..Default::default() },
+        )
+        .unwrap();
+        assert_eq!(s.usage_totals_detailed().unwrap(), (25, 4000, 8000, 8));
+    }
+
 }

--- a/crates/murmur-core/tests/live_extraction_e2e.rs
+++ b/crates/murmur-core/tests/live_extraction_e2e.rs
@@ -24,7 +24,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 30, output_tokens: 8 },
+        usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() },
     }
 }
 
@@ -32,7 +32,7 @@ fn end_turn(text: &str) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::Text { text: text.into() }],
         stop_reason: StopReason::EndTurn,
-        usage: Usage { input_tokens: 10, output_tokens: 2 },
+        usage: Usage { input_tokens: 10, output_tokens: 2, ..Default::default() },
     }
 }
 

--- a/crates/murmur-core/tests/pipeline_e2e.rs
+++ b/crates/murmur-core/tests/pipeline_e2e.rs
@@ -25,7 +25,7 @@ fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
         stop_reason: StopReason::ToolUse,
-        usage: Usage { input_tokens: 100, output_tokens: 25 },
+        usage: Usage { input_tokens: 100, output_tokens: 25, ..Default::default() },
     }
 }
 
@@ -33,7 +33,7 @@ fn end_turn(text: &str) -> CompletionResponse {
     CompletionResponse {
         content: vec![ContentBlock::Text { text: text.into() }],
         stop_reason: StopReason::EndTurn,
-        usage: Usage { input_tokens: 60, output_tokens: 10 },
+        usage: Usage { input_tokens: 60, output_tokens: 10, ..Default::default() },
     }
 }
 

--- a/crates/murmur-core/tests/source_swap_e2e.rs
+++ b/crates/murmur-core/tests/source_swap_e2e.rs
@@ -13,11 +13,11 @@ impl MemoryStore for NullMemoryStore {
 }
 fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
     CompletionResponse { content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
-        stop_reason: StopReason::ToolUse, usage: Usage { input_tokens: 30, output_tokens: 8 } }
+        stop_reason: StopReason::ToolUse, usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() } }
 }
 fn end_turn(t: &str) -> CompletionResponse {
     CompletionResponse { content: vec![ContentBlock::Text { text: t.into() }],
-        stop_reason: StopReason::EndTurn, usage: Usage { input_tokens: 10, output_tokens: 2 } }
+        stop_reason: StopReason::EndTurn, usage: Usage { input_tokens: 10, output_tokens: 2, ..Default::default() } }
 }
 fn summary(t: &str) -> CompletionResponse { tool_use("write_notes", serde_json::json!({"summary": t})) }
 


### PR DESCRIPTION
## Thinking

Groundwork for turning prompt caching on (#254 §2.2). **No behavior change** — this teaches the spend meter to *see* cache tokens; it does not request caching anywhere.

The order matters and isn't obvious. The Anthropic API reports `cache_creation_input_tokens` and `cache_read_input_tokens` as **separate fields**, and collapses `input_tokens` to the *uncached remainder only*. Our `Usage` is `{input_tokens, output_tokens}`, and `llm_usage` mirrors it. So switching caching on against today's shape would have made R9 report a dramatic cost drop that never happened — silently corrupting the one measurement that tells us whether the planned $12.99 price point is viable.

Meter first, then cache. Otherwise the first thing we'd learn from the cost lever is a lie.

## What changed

- **`harness::Usage`** gains the two cache fields, `#[serde(default)]` — the mock provider and any non-caching response omit them entirely, and a missing field must never fail response parsing (same posture as `StopReason::Unknown` and `ContentBlock::Unknown`).
- **`Usage::total_input_tokens()`** — what cost analysis has to read. `input_tokens` alone is the trap; the doc comment says so at the field.
- **`Usage::add()`** accumulates all four. A dropped cache field here would under-report across a multi-turn run, which is exactly what R9 exists to prevent.
- **Migration v8** adds the matching `llm_usage` columns, additive with `DEFAULT 0`. Pre-v8 rows are already correct — those calls genuinely cached nothing — so the upgrade leaves them untouched rather than backfilling a placeholder.
- **`usage_totals()`** now sums all three input classes, so the meter won't appear to crater the moment caching lands. **`usage_totals_detailed()`** is new and keeps them separate, because they bill at ~1x / ~1.25x / ~0.1x and a single token count can't express spend.

## Note on the diff width

29 files, but it's shallow: 23 of them are one-line test literals picking up `..Default::default()` after the struct gained fields. The substance is in `llm.rs`, `providers/anthropic.rs`, `store/usage.rs`, `store/migrations.rs`, and `domain.rs`.

`LlmUsageRow` and `usage_totals` are **not** on the FFI surface (checked), so no bindings regen and no drift-job risk.

## Verification

- **491 tests pass, 0 fail** (baseline was 483 — 8 new). `cargo clippy --workspace --all-targets -- -D warnings` clean.
- New coverage where it matters: cache fields accumulate through `add()`; `total_input_tokens()` spans all three classes; a response *without* cache fields still parses; the provider parses all four off the wire; the columns round-trip; `usage_totals` counts cached tokens rather than just the remainder; and **`v8_upgrade_preserves_existing_llm_usage_rows`** drives a real v7 DB with a row in it through the upgrade and asserts the counts are untouched and the new columns are `0`, not `NULL`.
- No `cargo fmt` — the repo isn't rustfmt-clean at baseline (essentially every file drifts) and CI has no fmt gate, so running it would have buried this diff in unrelated reformatting.

Next in the sequence: the `cache_prefix` opt-in on `CompletionRequest`, set by `Agent::run` only (#254 §2.1 — single-shot calls would pay the 1.25x write premium and never read).