### PR TITLE
perf(core): cache the agent loop's stable prefix

### DIFF
--- a/crates/harness/src/agent.rs
+++ b/crates/harness/src/agent.rs
@@ -83,6 +83,11 @@ impl Agent {
                     tools: self.tool_specs(),
                     max_tokens: self.config.max_tokens,
                     tool_choice: None,
+                    // The one place caching pays: this loop re-sends
+                    // `messages.clone()` every turn behind a byte-identical
+                    // `system` + `tools` prefix, so turn N reads what turn N-1
+                    // wrote. See CompletionRequest::cache_prefix.
+                    cache_prefix: true,
                 })
                 .await
                 .map_err(|e| RunError { source: e, usage })?;
@@ -263,6 +268,41 @@ mod tests {
                 content: "saved".into(),
                 is_error: false,
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn every_turn_opts_into_prefix_caching() {
+        // The loop re-sends the whole conversation behind a byte-identical
+        // system + tools prefix, so turn N reads what turn N-1 wrote. Missing
+        // the flag on ANY turn breaks the chain: that request writes a fresh
+        // entry at ~1.25x instead of reading the existing one at ~0.1x.
+        let mut reg = ToolRegistry::new();
+        reg.register(Recorder {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            reply: Ok("saved".into()),
+        });
+        let (agent, provider) = agent_with(
+            vec![
+                tool_call("recorder", serde_json::json!({"x": 1})),
+                tool_call("recorder", serde_json::json!({"x": 2})),
+                text_end("done"),
+            ],
+            reg,
+        );
+        agent.run(vec![Message::user_text("go")]).await.unwrap();
+
+        let reqs = provider.requests();
+        assert_eq!(reqs.len(), 3);
+        assert!(
+            reqs.iter().all(|r| r.cache_prefix),
+            "every turn must opt in, not just the first"
+        );
+        // The prefix that gets cached has to actually be stable, or the reads
+        // never hit — this is the invariant the flag depends on.
+        assert!(
+            reqs.iter().all(|r| r.system == reqs[0].system && r.tools == reqs[0].tools),
+            "system + tools must be byte-identical across turns"
         );
     }
 

--- a/crates/harness/src/llm.rs
+++ b/crates/harness/src/llm.rs
@@ -63,6 +63,16 @@ pub struct CompletionRequest {
     pub max_tokens: u32,
     /// Force the model to call this tool by name (None = model decides).
     pub tool_choice: Option<String>,
+    /// Ask the provider to cache this request's stable prefix.
+    ///
+    /// Opt-in per request, NOT a global provider setting, because caching only
+    /// pays when the same prefix is sent more than once. A cache write bills at
+    /// ~1.25x and a read at ~0.1x, so break-even is two requests: a single-shot
+    /// call (`summarize`, the forced `build_document` call, reflection) would
+    /// pay the write premium and never read it back. Only `Agent::run` sets
+    /// this, because only it re-sends a growing conversation with a
+    /// byte-identical `system` + `tools` prefix on every turn.
+    pub cache_prefix: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -57,6 +57,7 @@ mod tests {
             tools: vec![],
             max_tokens: 100,
             tool_choice: None,
+            cache_prefix: false,
         };
         let r1 = mock.complete(req.clone()).await.unwrap();
         let r2 = mock.complete(req.clone()).await.unwrap();
@@ -75,6 +76,7 @@ mod tests {
             tools: vec![],
             max_tokens: 1,
             tool_choice: None,
+            cache_prefix: false,
         };
         let err = mock.complete(req).await.unwrap_err();
         assert!(matches!(err, crate::HarnessError::Provider(_)));

--- a/crates/harness/src/providers/anthropic.rs
+++ b/crates/harness/src/providers/anthropic.rs
@@ -55,6 +55,20 @@ impl LlmProvider for AnthropicProvider {
         if let Some(name) = &req.tool_choice {
             body["tool_choice"] = serde_json::json!({"type": "tool", "name": name});
         }
+        if req.cache_prefix {
+            // Top-level cache_control auto-places the breakpoint on the last
+            // cacheable block, which is exactly the multi-turn pattern: each
+            // turn extends the cached prefix, and the previous turn's entry is
+            // still a valid read point. Placing it by hand would mean tracking
+            // block indices across turns for no gain.
+            //
+            // Silently a no-op below the model's minimum cacheable prefix
+            // (4096 tokens on Haiku 4.5) — no error, and no write premium
+            // either, since nothing is cached. That is what makes it safe to
+            // set unconditionally on the agent path, where live extraction's
+            // small prefix sits under the bar and processing's does not.
+            body["cache_control"] = serde_json::json!({"type": "ephemeral"});
+        }
 
         let resp = self
             .client
@@ -106,6 +120,7 @@ mod tests {
             }],
             max_tokens: 256,
             tool_choice: None,
+            cache_prefix: false,
         }
     }
 
@@ -145,6 +160,60 @@ mod tests {
         assert_eq!(body["max_tokens"], 256);
         assert_eq!(body["messages"][0]["role"], "user");
         assert_eq!(body["tools"][0]["name"], "echo");
+    }
+
+    #[tokio::test]
+    async fn cache_prefix_emits_top_level_cache_control() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider =
+            AnthropicProvider::new("sk-test", "claude-haiku-4-5").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest { cache_prefix: true, ..request() })
+            .await
+            .unwrap();
+
+        let received = &server.received_requests().await.unwrap()[0];
+        let body: serde_json::Value = serde_json::from_slice(&received.body).unwrap();
+        assert_eq!(body["cache_control"]["type"], "ephemeral");
+    }
+
+    #[tokio::test]
+    async fn no_cache_control_when_cache_prefix_is_off() {
+        // The single-shot paths (summarize, build_document, reflection) must not
+        // pay the ~1.25x cache-write premium for a prefix nothing will re-read.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider =
+            AnthropicProvider::new("sk-test", "claude-haiku-4-5").with_base_url(server.uri());
+        provider.complete(request()).await.unwrap(); // cache_prefix: false
+
+        let received = &server.received_requests().await.unwrap()[0];
+        let body: serde_json::Value = serde_json::from_slice(&received.body).unwrap();
+        assert!(
+            body.get("cache_control").is_none(),
+            "cache_control must be absent, not null: {body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/harness/src/reflection/engine.rs
+++ b/crates/harness/src/reflection/engine.rs
@@ -123,6 +123,9 @@ impl ReflectionEngine {
                 tools: vec![self.tool_spec()],
                 max_tokens: self.max_tokens,
                 tool_choice: Some(WRITE_MEMORY.into()),
+                // Single-shot forced call — a cache write here would bill at
+                // ~1.25x and never be read back.
+                cache_prefix: false,
             })
             .await
             .map_err(|e| RunError { source: e, usage: Usage::default() })?;

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -192,6 +192,9 @@ pub(crate) async fn price_items(
             tools: vec![price_items_tool_spec()],
             max_tokens,
             tool_choice: Some(PRICE_ITEMS.to_string()),
+            // One forced call, never re-sent — a cache write would bill ~1.25x
+            // with nothing to read it back.
+            cache_prefix: false,
         })
         .await?;
     usage.add(&response.usage);
@@ -303,6 +306,8 @@ pub(crate) async fn fill_fields(
             tools: vec![fill_fields_tool_spec()],
             max_tokens,
             tool_choice: Some(FILL_FIELDS.to_string()),
+            // Single-shot schema fill — see the PRICE_ITEMS note above.
+            cache_prefix: false,
         })
         .await?;
     usage.add(&response.usage);

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -125,6 +125,12 @@ pub(crate) async fn summarize(
             tools: vec![notes_tool_spec()],
             max_tokens,
             tool_choice: Some(WRITE_NOTES.into()),
+            // Single-shot. Note this call carries the SAME transcript the
+            // extraction agent just cached — but it can't read that cache: the
+            // system prompt and tool set both differ, and tools render at
+            // position 0, so the prefix diverges immediately. Sharing it would
+            // mean reshaping the two-phase split (see the v1 design doc §2.1).
+            cache_prefix: false,
         })
         .await?;
 


### PR DESCRIPTION
## Thinking

The first cost lever from #254 §2.1. Turns prompt caching on exactly where it pays, and nowhere else.

**Stacked on #255** — deliberately. The meter has to be able to *see* cache tokens before this lands, or R9 reports a saving that never happened (#254 §2.2). Merge #255 first; this PR's diff then reduces to the caching delta.

### Where it pays

`Agent::run` re-sends `messages.clone()` every turn behind a **byte-identical `system` + `tools` prefix**, so turn N reads what turn N-1 wrote. On the processing path that prefix carries the whole assembled transcript (`transcript_budget_tokens: 12_000`) across up to 16 turns. Modeled at ~70% off the processing-extraction leg — a long walk goes **~$0.43 → ~$0.25**.

### Why it's per-request, not a provider setting

Caching only pays when a prefix is sent twice: a write bills ~1.25x and a read ~0.1x, so break-even is two requests. The single-shot calls — `prompts::summarize`, `build_document`'s forced price/fill calls, reflection — would pay the write premium and never read it back. They stay off, explicitly, with the reason at each call site.

### What is *not* cached, and why (worth knowing before someone tries)

`summarize` carries the **same transcript the extraction agent just cached** — and cannot read that cache. Its system prompt and tool set both differ, and tools render at position 0, so the prefix diverges immediately. Sharing it means reshaping the two-phase split in `run_llm_phases`; that's dam's architecture and a separate change, not this one. Recorded as a comment at the call site so it isn't re-derived.

### One deliberate no-op

Live extraction also runs through `Agent::run` and so opts in, but its prefix sits under **Haiku 4.5's 4096-token minimum**. That's a silent no-op rather than waste: below the minimum nothing is cached, so no write premium is charged either. This is what makes it safe to set the flag on the agent path unconditionally instead of threading a per-caller policy.

## Implementation

One field (`CompletionRequest::cache_prefix`) and one body key. Top-level `cache_control` auto-places the breakpoint on the last cacheable block, which is already the correct multi-turn pattern — placing it by hand would mean tracking block indices across turns for no gain.

## Verification

- **494 tests pass, 0 fail** (491 + 3 new). Clippy clean.
- New coverage: the provider emits `cache_control` when the flag is set; **omits the key entirely** when it isn't (absent, not null); and `every_turn_opts_into_prefix_caching` drives a 3-turn run and asserts *every* request opts in — missing it on any single turn breaks the chain, since that request writes fresh at 1.25x instead of reading at 0.1x. That test also pins the invariant the whole thing rests on: `system` and `tools` byte-identical across turns.
- **Evals unaffected** — the mock provider ignores the flag, and caching is a billing change, not a behavioral one.

Next: the Sonnet 5 swap (#254 §2.3), which is the one that genuinely can regress and so lands against an eval comparison.