### PR TITLE
fix(harness): apply the ANTHROPIC_BASE_URL rule at every live-API entry point

### DIFF
--- a/crates/evals/examples/eval.rs
+++ b/crates/evals/examples/eval.rs
@@ -50,7 +50,11 @@ async fn run() -> Result<(), String> {
         if corpus.is_empty() { return Err("no scenarios matched --scenario".into()); }
     }
 
-    let provider = Arc::new(AnthropicProvider::new(api_key, &model));
+    // from_env, not new: the key and host are a matched pair, and a PPQ-issued
+    // key sent to api.anthropic.com 401s. This runner previously ignored
+    // ANTHROPIC_BASE_URL while examples/walk.rs honored it, so a local .env
+    // that worked for one silently failed the other.
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, &model));
     let mut reports = Vec::new();
     for scenario in &corpus {
         eprintln!("running {} ...", scenario.id);

--- a/crates/evals/tests/grader_hermetic.rs
+++ b/crates/evals/tests/grader_hermetic.rs
@@ -90,7 +90,8 @@ async fn real_api_eval_is_well_formed() {
     let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/fixtures");
     let deck = evals::corpus::load_corpus(dir).unwrap().into_iter()
         .find(|s| s.id == "deck_walk_contacts").unwrap();
-    let provider = std::sync::Arc::new(harness::AnthropicProvider::new(api_key, "claude-haiku-4-5"));
+    let provider =
+        std::sync::Arc::new(harness::AnthropicProvider::from_env(api_key, "claude-haiku-4-5"));
     let report = evals::run::run_scenario(&deck, provider, "claude-haiku-4-5").await.unwrap();
     // well-formed: metrics in range, cost recorded (R9)
     assert!((0.0..=1.0).contains(&report.score.f_half));

--- a/crates/harness/src/providers/anthropic.rs
+++ b/crates/harness/src/providers/anthropic.rs
@@ -33,6 +33,33 @@ impl AnthropicProvider {
         self.base_url = base_url.trim_end_matches('/').to_string();
         self
     }
+
+    /// Applies a base-URL override only when there is one to apply.
+    ///
+    /// Empty and whitespace-only mean "no override", NOT "override with the
+    /// empty string" — an exported-but-blank `ANTHROPIC_BASE_URL` must fall
+    /// through to the Anthropic default rather than POST to `/v1/messages`.
+    pub fn with_base_url_opt(self, base_url: Option<&str>) -> Self {
+        match base_url.map(str::trim).filter(|b| !b.is_empty()) {
+            Some(base) => self.with_base_url(base),
+            None => self,
+        }
+    }
+
+    /// Builds a provider honoring an ambient `ANTHROPIC_BASE_URL`.
+    ///
+    /// **The key and the host are a matched pair.** A PPQ-issued key works only
+    /// against PPQ's host; a direct `sk-ant-` key works only against Anthropic's.
+    /// Mismatching them yields a 401 that surfaces far downstream — in the iOS
+    /// app it degrades every walk to "saved offline", which is exactly what
+    /// shipped in builds #24-#32 (see the note in `.github/workflows/release.yml`).
+    ///
+    /// Every entry point that builds a provider from ambient env should use this
+    /// rather than rolling its own read, so the pairing rule is applied uniformly.
+    pub fn from_env(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self::new(api_key, model)
+            .with_base_url_opt(std::env::var("ANTHROPIC_BASE_URL").ok().as_deref())
+    }
 }
 
 #[derive(Deserialize)]
@@ -145,6 +172,28 @@ mod tests {
         assert_eq!(body["max_tokens"], 256);
         assert_eq!(body["messages"][0]["role"], "user");
         assert_eq!(body["tools"][0]["name"], "echo");
+    }
+
+    #[test]
+    fn base_url_opt_applies_a_real_override() {
+        let p = AnthropicProvider::new("k", "m").with_base_url_opt(Some("https://api.ppq.ai"));
+        assert_eq!(p.base_url, "https://api.ppq.ai");
+    }
+
+    #[test]
+    fn base_url_opt_treats_absent_and_blank_as_no_override() {
+        // An exported-but-empty ANTHROPIC_BASE_URL is the trap: naively applying
+        // it would POST to "/v1/messages" with no host. Blank means "default".
+        for raw in [None, Some(""), Some("   "), Some("\n")] {
+            let p = AnthropicProvider::new("k", "m").with_base_url_opt(raw);
+            assert_eq!(p.base_url, "https://api.anthropic.com", "raw = {raw:?}");
+        }
+    }
+
+    #[test]
+    fn base_url_opt_still_normalizes_a_trailing_slash() {
+        let p = AnthropicProvider::new("k", "m").with_base_url_opt(Some("https://api.ppq.ai/"));
+        assert_eq!(p.base_url, "https://api.ppq.ai");
     }
 
     #[tokio::test]

--- a/crates/murmur-core/examples/walk.rs
+++ b/crates/murmur-core/examples/walk.rs
@@ -143,13 +143,7 @@ async fn run() -> Result<(), String> {
     println!("session: {}", session.id);
 
     // Process it.
-    let mut provider = AnthropicProvider::new(api_key, MODEL);
-    if let Ok(base) = std::env::var("ANTHROPIC_BASE_URL") {
-        if !base.trim().is_empty() {
-            provider = provider.with_base_url(base);
-        }
-    }
-    let provider = Arc::new(provider);
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, MODEL));
     let store = Arc::new(Mutex::new(store));
     let memory = Arc::new(Mutex::new(memory));
     let processor = SessionProcessor::new(

--- a/crates/murmur-core/tests/anthropic_smoke.rs
+++ b/crates/murmur-core/tests/anthropic_smoke.rs
@@ -47,7 +47,7 @@ async fn real_anthropic_site_walk() {
     let store = Arc::new(Mutex::new(store));
 
     let processor = SessionProcessor::new(
-        Arc::new(AnthropicProvider::new(api_key, MODEL)),
+        Arc::new(AnthropicProvider::from_env(api_key, MODEL)),
         store.clone(),
         Arc::new(Mutex::new(Memory::default())),
         Arc::new(NullMemoryStore),


### PR DESCRIPTION
## Thinking

**The key and the host are a matched pair.** A PPQ-issued key works only against PPQ's host; a direct `sk-ant-` key only against Anthropic's. Mismatch them and you get a 401 that surfaces far downstream — in the iOS app it degrades every walk to "saved offline". That's the bug that shipped in builds #24–#32, already documented in `release.yml`.

Four entry points build a provider from ambient env. **Only one applied that rule.**

| Entry point | Honored `ANTHROPIC_BASE_URL`? |
|---|---|
| `murmur-core/examples/walk.rs` | yes |
| `evals/examples/eval.rs` | **no** |
| `evals/tests/grader_hermetic.rs` | **no** |
| `murmur-core/tests/anthropic_smoke.rs` | **no** |

So a local `.env` that works fine for `walk` silently 401s the eval runner. I hit this setting up the Sonnet 5 eval comparison — the run would have failed with a `Provider(HTTP 401…)` that looks nothing like "your key and host don't match."

`from_env` puts the rule in one place instead of copied three times and forgotten once.

## The subtle half

The empty-string case is the actual trap. An exported-but-blank `ANTHROPIC_BASE_URL` must fall through to the Anthropic default — **not** override with `""` and POST to a hostless `/v1/messages`. `with_base_url_opt` trims and treats blank as absent, and it's public and pure precisely so that behavior is testable without mutating process env (which is racy under a parallel test runner, and `set_var` is unsafe on current Rust).

## Verification

- **486 tests pass, 0 fail** (483 + 3 new). Clippy clean.
- New coverage: a real override applies; `None` / `""` / `"   "` / `"\n"` all fall through to `https://api.anthropic.com`; trailing-slash normalization still happens through the new path.
- The three `#[ignore]`d live-API tests are unchanged in behavior when no override is set — they just stop being wrong when one *is* set.

## Not in this PR

Isaac's local `.env` turned out to be **correctly paired** (PPQ key + PPQ host) — my earlier read that it was misconfigured was wrong. I added a comment block to it locally recording the pairing rule and the deliberate asymmetry with CI (the secret named `PPQ_API_KEY` holds a *direct Anthropic* key with no override — also correct, despite the name). `.env` is gitignored, so that's local-only and no secret goes near git.