### PR TITLE
feat(ios): Document Builder — author document structure on dam's schema seam

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -228,7 +228,7 @@ struct AppRoot: View {
 
 struct GalleryRoot: View {
     enum Dest: String, Hashable, CaseIterable {
-        case components, onboarding, jobs, capture, document, vocab
+        case components, onboarding, jobs, capture, document, vocab, structure
 
         var title: String {
             switch self {
@@ -238,6 +238,7 @@ struct GalleryRoot: View {
             case .capture: return "02 · CAPTURE"
             case .document: return "04 · DOCUMENT REVIEW"
             case .vocab: return "05 · FIELD VOCABULARY"
+            case .structure: return "06 · DOCUMENT BUILDER"
             }
         }
     }
@@ -300,6 +301,10 @@ struct GalleryRoot: View {
                 case .capture: CaptureScreen(trade: Fixtures.landscape)
                 case .document: DocumentReviewScreen(trade: Fixtures.landscape)
                 case .vocab: VocabularyView(model: AppModel())
+            // The Document Builder is the surface most in need of design
+            // iteration without a Rust build — the demo engine seeds it
+            // with built-ins, so `screen=structure` is a full editor.
+            case .structure: DocumentBuilderView(model: AppModel())
                 }
             }
         }

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -367,4 +367,117 @@ final class DemoWalkEngine: WalkEngine {
             send: trade.send
         )
     }
+
+    // MARK: Document schemas (Plan 19) — in-memory demo conformance.
+
+    /// Mirrors the subset of `domain::builtin_schemas()` a demo needs: enough
+    /// doc types to exercise the picker, across more than one trade so the
+    /// `tradeKey` filter is actually visible. Marked `isBuiltin` so the editor
+    /// steers toward Duplicate, matching real-core behavior where these are
+    /// seeded rows shared across devices.
+    private static func seededSchemas() -> [DocumentSchemaModel] {
+        func lineItems(_ priced: Bool) -> SchemaSectionModel {
+            SchemaSectionModel(
+                key: "line_items",
+                kind: "line_items",
+                label: priced ? "Items & pricing" : "Items",
+                priced: priced,
+                fields: [
+                    SchemaFieldModel(
+                        key: "items", kind: "line_items", label: "Captured items", fill: "walk"
+                    )
+                ]
+            )
+        }
+        func terms(_ text: String) -> SchemaSectionModel {
+            SchemaSectionModel(
+                key: "terms",
+                kind: "static",
+                label: "Terms",
+                priced: false,
+                fields: [
+                    SchemaFieldModel(
+                        key: "terms_body",
+                        kind: "static",
+                        label: "Terms",
+                        fill: "static",
+                        staticValue: text
+                    )
+                ]
+            )
+        }
+        return [
+            DocumentSchemaModel(
+                id: "builtin-estimate",
+                kind: "estimate",
+                label: "Estimate",
+                numberPrefix: "EST",
+                tradeKey: "landscape",
+                sections: [lineItems(true), terms("50% deposit due on acceptance.")],
+                isBuiltin: true
+            ),
+            DocumentSchemaModel(
+                id: "builtin-invoice",
+                kind: "invoice",
+                label: "Invoice",
+                numberPrefix: "INV",
+                tradeKey: "landscape",
+                sections: [lineItems(true), terms("Net 30.")],
+                isBuiltin: true
+            ),
+            DocumentSchemaModel(
+                id: "builtin-condition",
+                kind: "condition",
+                label: "Condition Report",
+                numberPrefix: "COND",
+                tradeKey: "property",
+                sections: [lineItems(false)],
+                isBuiltin: true
+            ),
+            DocumentSchemaModel(
+                id: "builtin-inspection",
+                kind: "inspection",
+                label: "Inspection Report",
+                numberPrefix: "IR",
+                tradeKey: "inspection",
+                totalKind: "static",
+                totalLabelKey: "findings",
+                sections: [lineItems(false)],
+                isBuiltin: true
+            ),
+        ]
+    }
+
+    private var schemas: [DocumentSchemaModel] = DemoWalkEngine.seededSchemas()
+    /// Monotonic counter standing in for core's UUIDv7 minting on create.
+    private var nextSchemaOrdinal = 1
+
+    func listDocumentSchemas(tradeKey: String?) -> [DocumentSchemaModel] {
+        guard let tradeKey else { return schemas }
+        // nil tradeKey on a schema means "all trades" — it must survive the
+        // filter, mirroring core's resolution.
+        return schemas.filter { $0.tradeKey == nil || $0.tradeKey == tradeKey }
+    }
+
+    func saveDocumentSchema(_ schema: DocumentSchemaModel) -> DocumentSchemaModel {
+        var saved = schema
+        if saved.id.isEmpty {
+            saved.id = "custom-\(nextSchemaOrdinal)"
+            nextSchemaOrdinal += 1
+        }
+        // A saved copy is the operator's, never a built-in — duplicating a
+        // built-in and saving must produce an editable row, not another
+        // undeletable default.
+        saved.isBuiltin = false
+        if let index = schemas.firstIndex(where: { $0.id == saved.id }) {
+            schemas[index] = saved
+        } else {
+            schemas.append(saved)
+        }
+        return saved
+    }
+
+    func removeDocumentSchema(id: String) {
+        schemas.removeAll { $0.id == id }
+    }
 }

--- a/apps/ios/Sources/Engine/DocumentSchemaModel.swift
+++ b/apps/ios/Sources/Engine/DocumentSchemaModel.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+// App-side mirror of the core `DocumentSchema` seam (Plan 19, #244).
+//
+// Mirrored rather than used directly, for the same reason `DocumentModel` and
+// `NotesModel` are: the demo engine has to work in a clean checkout where
+// `#if canImport(MurmurCoreFFI)` is false and the FFI types don't exist. A view
+// that referenced `MurmurCoreFFI.DocumentSchema` would compile only in
+// real-core mode, which would make the Document Builder undemoable — exactly
+// the surface most in need of design iteration without a Rust build.
+//
+// Conversion to/from the FFI records lives in `MurmurEngine`, the one file that
+// is already FFI-conditional.
+
+/// The kinds core accepts. Mirrors `VALID_*` in `murmur-core::domain`.
+///
+/// These are duplicated deliberately: `save_document_schema` validates against
+/// the Rust allowlists and REJECTS anything else (R6, reject-never-coerce), so
+/// the editor must only ever offer legal values. A picker that could author an
+/// invalid kind would produce a save error the operator can't act on.
+enum SchemaKinds {
+    static let section = ["line_items", "static", "filled"]
+    static let field = ["line_items", "text", "long_text", "currency", "quantity", "date", "static"]
+    static let fill = ["walk", "manual", "static"]
+}
+
+struct SchemaFieldModel: Identifiable, Hashable {
+    /// Stable identity for SwiftUI list moves/deletes. NOT the core `key` —
+    /// the operator can rename a field, and a re-keyed row must not read as a
+    /// different row mid-edit.
+    let id: UUID
+    var key: String
+    /// One of `SchemaKinds.field`.
+    var kind: String
+    var label: String
+    /// One of `SchemaKinds.fill`.
+    var fill: String
+    /// The authored constant when `fill == "static"`; nil otherwise.
+    var staticValue: String?
+
+    init(
+        id: UUID = UUID(),
+        key: String,
+        kind: String,
+        label: String,
+        fill: String,
+        staticValue: String? = nil
+    ) {
+        self.id = id
+        self.key = key
+        self.kind = kind
+        self.label = label
+        self.fill = fill
+        self.staticValue = staticValue
+    }
+}
+
+struct SchemaSectionModel: Identifiable, Hashable {
+    let id: UUID
+    var key: String
+    /// One of `SchemaKinds.section`.
+    var kind: String
+    var label: String
+    /// Whether the captured-items table carries amounts.
+    var priced: Bool
+    var fields: [SchemaFieldModel]
+
+    init(
+        id: UUID = UUID(),
+        key: String,
+        kind: String,
+        label: String,
+        priced: Bool,
+        fields: [SchemaFieldModel]
+    ) {
+        self.id = id
+        self.key = key
+        self.kind = kind
+        self.label = label
+        self.priced = priced
+        self.fields = fields
+    }
+}
+
+struct DocumentSchemaModel: Identifiable, Hashable {
+    /// Empty means "create" — core mints a UUIDv7. A built-in's fixed id or a
+    /// prior save's id means upsert.
+    var id: String
+    /// Stable key: a built-in ("estimate") or a custom one ("hoa_addendum").
+    var kind: String
+    var label: String
+    /// Core mints `<prefix>-NNNN`; the app never invents document numbers.
+    var numberPrefix: String
+    /// Which trade this belongs to; nil = all.
+    var tradeKey: String?
+    var totalKind: String
+    var totalLabelKey: String
+    var sections: [SchemaSectionModel]
+    var schemaVersion: UInt32
+
+    /// Built-ins ship seeded from core and carry the sentinel device id.
+    /// Surfaced so the editor can steer toward "duplicate" rather than
+    /// in-place edits of a shared default.
+    var isBuiltin: Bool
+
+    init(
+        id: String = "",
+        kind: String,
+        label: String,
+        numberPrefix: String,
+        tradeKey: String? = nil,
+        totalKind: String = "sum",
+        totalLabelKey: String = "total",
+        sections: [SchemaSectionModel] = [],
+        schemaVersion: UInt32 = 1,
+        isBuiltin: Bool = false
+    ) {
+        self.id = id
+        self.kind = kind
+        self.label = label
+        self.numberPrefix = numberPrefix
+        self.tradeKey = tradeKey
+        self.totalKind = totalKind
+        self.totalLabelKey = totalLabelKey
+        self.sections = sections
+        self.schemaVersion = schemaVersion
+        self.isBuiltin = isBuiltin
+    }
+}
+
+// MARK: - Validation
+
+/// The one rule the editor must enforce before offering Save.
+///
+/// Core's `validate_schema` rejects a schema with 0 or 2+ `line_items`
+/// sections, empty `kind`/`label`/`number_prefix`, or any kind outside the
+/// allowlists. Checking here is not duplication for its own sake — it turns a
+/// post-hoc save failure into a disabled button with a reason attached, which
+/// is the difference between a usable editor and a guessing game. Core remains
+/// the authority; this is a courtesy gate in front of it.
+enum SchemaValidation {
+    static func firstProblem(in schema: DocumentSchemaModel) -> String? {
+        if schema.label.trimmingCharacters(in: .whitespaces).isEmpty {
+            return "Give the document type a name."
+        }
+        if schema.kind.trimmingCharacters(in: .whitespaces).isEmpty {
+            return "Give the document type an internal key."
+        }
+        let prefix = schema.numberPrefix.trimmingCharacters(in: .whitespaces)
+        if prefix.isEmpty {
+            return "Give the document type a number prefix, like EST."
+        }
+        let lineItemSections = schema.sections.filter { $0.kind == "line_items" }.count
+        if lineItemSections == 0 {
+            return "Add a line-items section — that's where the walk's items land."
+        }
+        if lineItemSections > 1 {
+            return "Only one line-items section is supported."
+        }
+        for section in schema.sections {
+            if section.label.trimmingCharacters(in: .whitespaces).isEmpty {
+                return "Every section needs a name."
+            }
+            for field in section.fields
+            where field.label.trimmingCharacters(in: .whitespaces).isEmpty {
+                return "Every field in “\(section.label)” needs a name."
+            }
+        }
+        return nil
+    }
+}

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -370,5 +370,93 @@ final class MurmurEngine: WalkEngine {
             capturedAt: ref.capturedAt
         )
     }
+
+    // MARK: Document schemas (Plan 19) — passthrough + conversion.
+
+    func listDocumentSchemas(tradeKey: String?) throws -> [DocumentSchemaModel] {
+        try engine.listDocumentSchemas(tradeKey: tradeKey).map(Self.schema)
+    }
+
+    func saveDocumentSchema(_ schema: DocumentSchemaModel) throws -> DocumentSchemaModel {
+        Self.schema(try engine.saveDocumentSchema(schema: Self.ffiSchema(schema)))
+    }
+
+    func removeDocumentSchema(id: String) throws {
+        try engine.removeDocumentSchema(id: id)
+    }
+
+    /// The sentinel `device_id` core stamps on seeded rows
+    /// (`domain::BUILTIN_SCHEMA_DEVICE_ID`). Keep in sync.
+    private static let builtinDeviceId = "builtin"
+
+    private nonisolated static func schema(_ s: MurmurCoreFFI.DocumentSchema) -> DocumentSchemaModel {
+        DocumentSchemaModel(
+            id: s.id,
+            kind: s.kind,
+            label: s.label,
+            numberPrefix: s.numberPrefix,
+            tradeKey: s.tradeKey,
+            totalKind: s.totalKind,
+            totalLabelKey: s.totalLabelKey,
+            sections: s.sections.map { section in
+                SchemaSectionModel(
+                    key: section.key,
+                    kind: section.kind,
+                    label: section.label,
+                    priced: section.priced,
+                    fields: section.fields.map { field in
+                        SchemaFieldModel(
+                            key: field.key,
+                            kind: field.kind,
+                            label: field.label,
+                            fill: field.fill,
+                            staticValue: field.staticValue
+                        )
+                    }
+                )
+            },
+            schemaVersion: s.schemaVersion,
+            isBuiltin: s.deviceId == builtinDeviceId
+        )
+    }
+
+    private nonisolated static func ffiSchema(
+        _ s: DocumentSchemaModel
+    ) -> MurmurCoreFFI.DocumentSchema {
+        // createdAt/updatedAt/deviceId are core's to own: it stamps them on
+        // write from its own clock and device id. Sending zeros rather than
+        // guesses keeps the app from inventing sync metadata it has no
+        // authority over — the same posture as never minting document numbers.
+        MurmurCoreFFI.DocumentSchema(
+            id: s.id,
+            kind: s.kind,
+            label: s.label,
+            numberPrefix: s.numberPrefix,
+            tradeKey: s.tradeKey,
+            totalKind: s.totalKind,
+            totalLabelKey: s.totalLabelKey,
+            sections: s.sections.map { section in
+                MurmurCoreFFI.SchemaSection(
+                    key: section.key,
+                    kind: section.kind,
+                    label: section.label,
+                    priced: section.priced,
+                    fields: section.fields.map { field in
+                        MurmurCoreFFI.SchemaField(
+                            key: field.key,
+                            kind: field.kind,
+                            label: field.label,
+                            fill: field.fill,
+                            staticValue: field.staticValue
+                        )
+                    }
+                )
+            },
+            schemaVersion: s.schemaVersion,
+            createdAt: 0,
+            updatedAt: 0,
+            deviceId: ""
+        )
+    }
 }
 #endif

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -251,6 +251,28 @@ protocol WalkEngine: AnyObject {
     ) async throws -> PhotoModel
     func listPhotos(sessionId: String) throws -> [PhotoModel]
     func removePhoto(photoId: String) throws
+
+    // Document structure as data (Plan 19 / #244). These drive the Document
+    // Builder: the operator reorders sections, adds fields, and spins up doc
+    // types we don't ship, and the walk fills whatever they authored.
+    //
+    // Engine-keyed, not session-scoped: schemas are OPERATOR-scoped and outlive
+    // any one walk, which is why the Builder is reachable from the board rather
+    // than from the notes screen.
+    //
+    // Throwing for the vocabulary reasons plus one more: `save` runs core's
+    // `validate_schema`, which REJECTS rather than coerces (R6) — an unknown
+    // section/field/fill kind, or anything other than exactly one `line_items`
+    // section. The editor gates on `SchemaValidation` first so that error is
+    // normally unreachable, but core stays the authority and the UI surfaces
+    // what it says rather than crashing.
+    //
+    // `save` returns the PERSISTED schema so the editor picks up the id and
+    // timestamps core minted, in one round-trip (the add/remove-vocabulary
+    // precedent). Pass an empty `id` to create.
+    func listDocumentSchemas(tradeKey: String?) throws -> [DocumentSchemaModel]
+    func saveDocumentSchema(_ schema: DocumentSchemaModel) throws -> DocumentSchemaModel
+    func removeDocumentSchema(id: String) throws
     func liveLivePhotoFilenames() throws -> [String]   // for the sweep
 
     /// App-open zombie sweep: a `Recording` session left behind by a crash or

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -244,7 +244,7 @@ struct CustomizeView: View {
     @Bindable var model: AppModel
     @Environment(\.dismiss) private var dismiss
     @State private var tab: Tab = .paperwork
-    private enum Tab { case paperwork, words }
+    private enum Tab { case paperwork, structure, words }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -265,7 +265,8 @@ struct CustomizeView: View {
             .padding(.bottom, 12)
 
             HStack(spacing: 0) {
-                tabButton("PAPERWORK", .paperwork)
+                tabButton("LOOK", .paperwork)
+                tabButton("STRUCTURE", .structure)
                 tabButton("WORDS", .words)
             }
 
@@ -279,6 +280,13 @@ struct CustomizeView: View {
                 LetterheadStudioView(model: model, embedded: true)
                     .opacity(tab == .paperwork ? 1 : 0)
                     .allowsHitTesting(tab == .paperwork)
+                // Same keep-alive reasoning as the letterhead tab, and for the
+                // same reason: the schema editor holds an uncommitted @State
+                // draft, so tearing it down on a tab hop would silently discard
+                // half-finished section and field edits.
+                DocumentBuilderView(model: model, embedded: true)
+                    .opacity(tab == .structure ? 1 : 0)
+                    .allowsHitTesting(tab == .structure)
                 VocabularyView(model: model, embedded: true)
                     .opacity(tab == .words ? 1 : 0)
                     .allowsHitTesting(tab == .words)

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -1,0 +1,565 @@
+import SwiftUI
+
+// The Document Builder — the STRUCTURE half of customizable paperwork, on top
+// of dam's `DocumentSchema` seam (#244). Operators reorder and rename sections,
+// add fields, and spin up document types we don't ship; the walk then fills
+// whatever they authored.
+//
+// Two things worth knowing about this screen's role:
+//
+// 1. It is ALSO the confirm step for "upload your own template". Inference
+//    produces a DRAFT schema and hands it here pre-populated instead of empty;
+//    the operator confirms, and only then is it saved. That is what keeps
+//    upload from being "trust the model to read a stranger's document on every
+//    walk" — the comprehension pass runs once, under human review. So this is
+//    built once and serves both paths.
+//
+// 2. Core is the authority on what's legal. `save_document_schema` runs
+//    `validate_schema`, which REJECTS rather than coerces (R6). The editor
+//    only ever offers allowlisted kinds and gates Save on `SchemaValidation`,
+//    so that rejection is normally unreachable — but when it does fire, the
+//    message is surfaced verbatim rather than swallowed.
+//
+// Reached from the board header, same sheet pattern as the Letterhead Studio.
+struct DocumentBuilderView: View {
+    @Bindable var model: AppModel
+    /// Drop this screen's own header when hosted inside the My Business sheet.
+    let embedded: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var schemas: [DocumentSchemaModel] = []
+    @State private var editing: DocumentSchemaModel?
+    @State private var loadError: String?
+
+    init(model: AppModel, embedded: Bool = false) {
+        self.model = model
+        self.embedded = embedded
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if !embedded { header }
+            if let editing {
+                SchemaEditor(
+                    schema: editing,
+                    onCancel: { self.editing = nil },
+                    onSave: { save($0) },
+                    onDelete: editing.isBuiltin || editing.id.isEmpty
+                        ? nil : { delete(editing) }
+                )
+            } else {
+                list
+            }
+        }
+        .background(Theme.C.paper)
+        .onAppear(perform: load)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack {
+            Text("DOCUMENT BUILDER")
+                .font(Theme.F.mono(11, .semibold))
+                .tracking(1.4)
+                .foregroundStyle(Theme.C.ink60)
+            Spacer()
+            Button("CLOSE") { dismiss() }
+                .font(Theme.F.mono(11, .semibold))
+                .tracking(1.0)
+                .foregroundStyle(Theme.C.ink60)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.C.hairline).frame(height: 1)
+        }
+    }
+
+    // MARK: Doc-type list
+
+    private var list: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Your walks fill these documents. Duplicate one to change what's in it.")
+                    .font(Theme.F.ui(14, .regular))
+                    .foregroundStyle(Theme.C.ink60)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+                    .padding(.bottom, 18)
+
+                if let loadError {
+                    ErrorNote(text: loadError)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 12)
+                }
+
+                ForEach(schemas) { schema in
+                    Button { editing = schema } label: {
+                        SchemaRow(schema: schema)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Button {
+                    editing = DocumentSchemaModel(
+                        kind: "",
+                        label: "",
+                        numberPrefix: "",
+                        tradeKey: model.trade.key,
+                        sections: [Self.starterLineItems()]
+                    )
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "plus")
+                        Text("NEW DOCUMENT TYPE")
+                            .font(Theme.F.mono(11, .semibold))
+                            .tracking(1.2)
+                    }
+                    .foregroundStyle(Theme.C.orangeDeep)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 18)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    /// A new type starts WITH a line-items section, because core requires
+    /// exactly one and an operator has no way to know that. Starting empty
+    /// would mean every new document type opens in an invalid state.
+    private static func starterLineItems() -> SchemaSectionModel {
+        SchemaSectionModel(
+            key: "line_items",
+            kind: "line_items",
+            label: "Items",
+            priced: true,
+            fields: [
+                SchemaFieldModel(
+                    key: "items", kind: "line_items", label: "Captured items", fill: "walk"
+                )
+            ]
+        )
+    }
+
+    // MARK: Engine round-trips
+
+    private func load() {
+        do {
+            schemas = try model.engine.listDocumentSchemas(tradeKey: model.trade.key)
+            loadError = nil
+        } catch {
+            // Leave whatever is on screen intact rather than blanking the list
+            // (the vocabulary editor's posture).
+            loadError = "Couldn't load document types: \(error.localizedDescription)"
+        }
+    }
+
+    private func save(_ schema: DocumentSchemaModel) {
+        do {
+            _ = try model.engine.saveDocumentSchema(schema)
+            editing = nil
+            load()
+        } catch {
+            loadError = "Couldn't save: \(error.localizedDescription)"
+            editing = nil
+        }
+    }
+
+    private func delete(_ schema: DocumentSchemaModel) {
+        do {
+            try model.engine.removeDocumentSchema(id: schema.id)
+            editing = nil
+            load()
+        } catch {
+            loadError = "Couldn't delete: \(error.localizedDescription)"
+            editing = nil
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct SchemaRow: View {
+    let schema: DocumentSchemaModel
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(schema.label.isEmpty ? "Untitled" : schema.label)
+                    .font(Theme.F.serif(17, .semibold))
+                    .foregroundStyle(Theme.C.ink)
+                Text(summary)
+                    .font(Theme.F.mono(10, .regular))
+                    .tracking(0.6)
+                    .foregroundStyle(Theme.C.ink35)
+            }
+            Spacer()
+            if schema.isBuiltin {
+                Text("DEFAULT")
+                    .font(Theme.F.mono(8, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(Theme.C.paperDeep)
+            }
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Theme.C.ink35)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .contentShape(Rectangle())
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
+        }
+    }
+
+    private var summary: String {
+        let sections = schema.sections.count
+        let fields = schema.sections.reduce(0) { $0 + $1.fields.count }
+        return "\(schema.numberPrefix)-0000  ·  \(sections) SECTIONS  ·  \(fields) FIELDS"
+    }
+}
+
+private struct ErrorNote: View {
+    let text: String
+    var body: some View {
+        Text(text)
+            .font(Theme.F.ui(13, .regular))
+            .foregroundStyle(Theme.C.redTag)
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Theme.C.redTint)
+    }
+}
+
+// MARK: - Editor
+
+private struct SchemaEditor: View {
+    @State private var draft: DocumentSchemaModel
+    private let original: DocumentSchemaModel
+    let onCancel: () -> Void
+    let onSave: (DocumentSchemaModel) -> Void
+    /// nil for built-ins and unsaved drafts — neither can be deleted.
+    let onDelete: (() -> Void)?
+
+    init(
+        schema: DocumentSchemaModel,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (DocumentSchemaModel) -> Void,
+        onDelete: (() -> Void)?
+    ) {
+        self.original = schema
+        _draft = State(initialValue: schema)
+        self.onCancel = onCancel
+        self.onSave = onSave
+        self.onDelete = onDelete
+    }
+
+    private var problem: String? { SchemaValidation.firstProblem(in: draft) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            editorBar
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    if draft.isBuiltin { builtinNote }
+                    identity
+                    sections
+                    addSectionButton
+                    if let onDelete, !draft.isBuiltin { deleteButton(onDelete) }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 18)
+            }
+        }
+    }
+
+    private var editorBar: some View {
+        HStack {
+            Button("CANCEL", action: onCancel)
+                .font(Theme.F.mono(11, .semibold))
+                .foregroundStyle(Theme.C.ink60)
+            Spacer()
+            Button("SAVE") { onSave(draft) }
+                .font(Theme.F.mono(11, .semibold))
+                .foregroundStyle(problem == nil ? Theme.C.orangeDeep : Theme.C.ink35)
+                .disabled(problem != nil)
+        }
+        .tracking(1.0)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.C.hairline).frame(height: 1)
+        }
+        .overlay(alignment: .bottomLeading) {
+            // Say WHY Save is unavailable. A disabled button with no reason is
+            // the most common way an editor like this becomes unusable.
+            if let problem {
+                Text(problem)
+                    .font(Theme.F.ui(12, .regular))
+                    .foregroundStyle(Theme.C.ink60)
+                    .padding(.horizontal, 20)
+                    .offset(y: 18)
+            }
+        }
+        .padding(.bottom, problem == nil ? 0 : 18)
+    }
+
+    private var builtinNote: some View {
+        Text(
+            "This is a default document type. Saving changes creates your own copy — "
+                + "the default stays available."
+        )
+        .font(Theme.F.ui(13, .regular))
+        .foregroundStyle(Theme.C.ink60)
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.C.orangeTint)
+    }
+
+    private var identity: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            FieldLabel("DOCUMENT TYPE")
+            LabeledField(title: "Name", text: $draft.label, placeholder: "Estimate")
+                .onChange(of: draft.label) { _, new in
+                    // Derive the stable key from the name until the operator is
+                    // saved once. After that the key is frozen: it is what core
+                    // resolves `buildDocument(kind:)` against, so renaming a
+                    // saved type must not silently orphan its documents.
+                    if original.id.isEmpty { draft.kind = Self.slug(new) }
+                }
+            LabeledField(
+                title: "Number prefix", text: $draft.numberPrefix, placeholder: "EST"
+            )
+            Text("Documents will be numbered \(prefixPreview)-0001, -0002, and so on.")
+                .font(Theme.F.mono(10, .regular))
+                .foregroundStyle(Theme.C.ink35)
+        }
+    }
+
+    private var prefixPreview: String {
+        let p = draft.numberPrefix.trimmingCharacters(in: .whitespaces).uppercased()
+        return p.isEmpty ? "EST" : p
+    }
+
+    private static func slug(_ s: String) -> String {
+        s.lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "_" }
+            .joined()
+            .split(separator: "_", omittingEmptySubsequences: true)
+            .joined(separator: "_")
+    }
+
+    private var sections: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            FieldLabel("SECTIONS")
+            ForEach($draft.sections) { $section in
+                SectionCard(
+                    section: $section,
+                    canDelete: section.kind != "line_items",
+                    onDelete: { draft.sections.removeAll { $0.id == section.id } },
+                    onMoveUp: { move(section.id, by: -1) },
+                    onMoveDown: { move(section.id, by: 1) }
+                )
+            }
+        }
+    }
+
+    private func move(_ id: UUID, by offset: Int) {
+        guard let i = draft.sections.firstIndex(where: { $0.id == id }) else { return }
+        let target = i + offset
+        guard draft.sections.indices.contains(target) else { return }
+        draft.sections.swapAt(i, target)
+    }
+
+    private var addSectionButton: some View {
+        Button {
+            draft.sections.append(
+                SchemaSectionModel(
+                    key: "section_\(draft.sections.count + 1)",
+                    kind: "filled",
+                    label: "",
+                    priced: false,
+                    fields: []
+                )
+            )
+        } label: {
+            Label("ADD SECTION", systemImage: "plus")
+                .font(Theme.F.mono(11, .semibold))
+                .tracking(1.2)
+                .foregroundStyle(Theme.C.orangeDeep)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func deleteButton(_ action: @escaping () -> Void) -> some View {
+        Button("DELETE THIS DOCUMENT TYPE", action: action)
+            .font(Theme.F.mono(11, .semibold))
+            .tracking(1.0)
+            .foregroundStyle(Theme.C.redTag)
+            .padding(.top, 8)
+    }
+}
+
+// MARK: - Section card
+
+private struct SectionCard: View {
+    @Binding var section: SchemaSectionModel
+    let canDelete: Bool
+    let onDelete: () -> Void
+    let onMoveUp: () -> Void
+    let onMoveDown: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                TextField("Section name", text: $section.label)
+                    .font(Theme.F.serif(16, .semibold))
+                    .foregroundStyle(Theme.C.ink)
+                Spacer()
+                Button(action: onMoveUp) { Image(systemName: "arrow.up") }
+                Button(action: onMoveDown) { Image(systemName: "arrow.down") }
+                if canDelete {
+                    Button(action: onDelete) { Image(systemName: "trash") }
+                        .foregroundStyle(Theme.C.redTag)
+                }
+            }
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Theme.C.ink60)
+
+            if section.kind == "line_items" {
+                // The one section every document must have, and the only one
+                // whose contents aren't authored field-by-field: it's where the
+                // walk's captured items land.
+                Text("The items from your walk land here.")
+                    .font(Theme.F.ui(13, .regular))
+                    .foregroundStyle(Theme.C.ink60)
+                Toggle("Show prices", isOn: $section.priced)
+                    .font(Theme.F.ui(14, .regular))
+                    .tint(Theme.C.orange)
+            } else {
+                ForEach($section.fields) { $field in
+                    FieldCard(
+                        field: $field,
+                        onDelete: { section.fields.removeAll { $0.id == field.id } }
+                    )
+                }
+                Button {
+                    section.fields.append(
+                        SchemaFieldModel(
+                            key: "field_\(section.fields.count + 1)",
+                            kind: "text",
+                            label: "",
+                            fill: "walk"
+                        )
+                    )
+                } label: {
+                    Label("Add field", systemImage: "plus")
+                        .font(Theme.F.ui(13, .regular))
+                        .foregroundStyle(Theme.C.orangeDeep)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(14)
+        .background(Theme.C.sheet)
+        .overlay(Rectangle().stroke(Theme.C.hairline, lineWidth: 1))
+    }
+}
+
+// MARK: - Field card
+
+private struct FieldCard: View {
+    @Binding var field: SchemaFieldModel
+    let onDelete: () -> Void
+
+    /// Plain-language labels for the fill modes. "walk" / "manual" / "static"
+    /// are core's vocabulary, not a contractor's.
+    private static let fillLabels: [(value: String, label: String)] = [
+        ("walk", "From the walk"),
+        ("manual", "I fill it in"),
+        ("static", "Always the same"),
+    ]
+
+    private static let kindLabels: [(value: String, label: String)] = [
+        ("text", "Short text"),
+        ("long_text", "Paragraph"),
+        ("currency", "Amount"),
+        ("quantity", "Quantity"),
+        ("date", "Date"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                TextField("Field name", text: $field.label)
+                    .font(Theme.F.ui(14, .regular))
+                Button(action: onDelete) { Image(systemName: "minus.circle") }
+                    .foregroundStyle(Theme.C.ink35)
+            }
+            HStack(spacing: 8) {
+                Picker("Type", selection: $field.kind) {
+                    ForEach(Self.kindLabels, id: \.value) { Text($0.label).tag($0.value) }
+                }
+                Picker("Fill", selection: $field.fill) {
+                    ForEach(Self.fillLabels, id: \.value) { Text($0.label).tag($0.value) }
+                }
+            }
+            .pickerStyle(.menu)
+            .font(Theme.F.mono(10, .regular))
+            .tint(Theme.C.orangeDeep)
+
+            if field.fill == "static" {
+                TextField(
+                    "Text that always appears",
+                    text: Binding(
+                        get: { field.staticValue ?? "" },
+                        set: { field.staticValue = $0 }
+                    )
+                )
+                .font(Theme.F.ui(13, .regular))
+                .padding(8)
+                .background(Theme.C.paperDeep)
+            }
+        }
+        .padding(.vertical, 6)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
+        }
+    }
+}
+
+// MARK: - Small shared bits
+
+private struct FieldLabel: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+    var body: some View {
+        Text(text)
+            .font(Theme.F.mono(10, .semibold))
+            .tracking(1.4)
+            .foregroundStyle(Theme.C.ink35)
+    }
+}
+
+private struct LabeledField: View {
+    let title: String
+    @Binding var text: String
+    let placeholder: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(Theme.F.ui(12, .regular))
+                .foregroundStyle(Theme.C.ink60)
+            TextField(placeholder, text: $text)
+                .font(Theme.F.ui(16, .regular))
+                .padding(10)
+                .background(Theme.C.sheet)
+                .overlay(Rectangle().stroke(Theme.C.hairline, lineWidth: 1))
+        }
+    }
+}


### PR DESCRIPTION
## Thinking

The app-side half of Paperwork Structure v2 (#234), on top of the `DocumentSchema` seam dam landed in **#244**. Operators reorder and rename sections, add fields, and spin up document types we don't ship; the walk fills whatever they authored.

**This screen is also the confirm step for "upload your own template."** Inference produces a *draft* schema and hands it here pre-populated instead of empty; the operator confirms, and only then is it saved. That's what keeps upload from being "trust the model to read a stranger's document on every walk" — comprehension runs once, under human review. Built once, serves both paths, which is why it comes *before* the upload work rather than after it.

## Three pieces

**1. App-side model types.** Mirrored rather than using the FFI records directly, for the same reason `DocumentModel` and `NotesModel` are: a view referencing `MurmurCoreFFI` types compiles only in real-core mode, which would make the Builder undemoable — and this is exactly the surface most in need of design iteration without a Rust build.

**2. The `WalkEngine` seam** — `list` / `save` / `remove`. Engine-keyed rather than session-scoped, because schemas are **operator**-scoped and outlive any one walk (which is also why the entry point is the board, not the notes screen). Demo conformance is in-memory, seeded from a subset of `builtin_schemas()` across more than one trade so the `tradeKey` filter is actually exercised.

`MurmurEngine` converts and passes through, deliberately sending `0`/`""` for `created_at`/`updated_at`/`device_id` — core stamps those from its own clock and device id, and the app has no authority to invent sync metadata. Same posture as never minting document numbers.

**3. The editor**, on a new STRUCTURE tab in My Business plus a `screen=structure` gallery entry. Both hosts keep the tab alive via ZStack+opacity for the reason #247 established: the editor holds an uncommitted `@State` draft, so a `switch` would silently discard half-finished edits on a tab hop.

## Editor decisions

- **Core rejects rather than coerces (R6)**, so the editor only offers allowlisted kinds and gates Save on `SchemaValidation`. The disabled Save button **always states why** — a disabled control with no reason is how an editor like this becomes a guessing game.
- **A new doc type starts with a line-items section**, because core requires exactly one and an operator has no way to know that. Starting empty would mean every new type opens in an invalid state.
- **`kind` is derived from the name only until first save, then frozen.** It's what `buildDocument(kind:)` resolves against, so renaming a saved type must not orphan its documents.
- **Fill modes are relabelled for a contractor** — "From the walk" / "I fill it in" / "Always the same". `walk`/`manual`/`static` is core's vocabulary, not theirs.
- **Built-ins steer toward duplicate-on-save**, and a saved copy clears `isBuiltin` so it's editable and deletable rather than another undeletable default.

## Verification

`BUILD SUCCEEDED` (iPhone 17 sim, demo engine) **and rendered on-sim** via `screen=structure` — screenshot in the thread. The list shows the seeded built-ins with DEFAULT badges and section/field counts, and **only the `landscape` types appear**, so the `tradeKey` filter is visibly working rather than merely compiling.

Note SourceKit reports spurious "cannot find type" errors across these files (it can't resolve `WalkEngine` or even `UIKit` without a project index) — `xcodebuild` is the real check and it's clean.

## Next

The remaining upload work is the core half, and it's blocked on the one thing flagged in #254 §7: **`ContentBlock` has no image or document variant**, so the harness cannot send a PDF to the model at all. That's dam's call on shape. Everything app-side that upload needs now exists.