### PR TITLE
feat(ios): route the model through the proxy instead of a baked key

### DIFF
--- a/apps/ios/Sources/App/EngineResolution.swift
+++ b/apps/ios/Sources/App/EngineResolution.swift
@@ -125,6 +125,55 @@ func resolveSttModelPath(_ args: [String]) -> String? {
     return nil
 }
 
+/// How this build reaches the model: what to send as the credential, and where.
+private struct ResolvedCredential {
+    let apiKey: String
+    let baseURL: String?
+    /// For logging only — never log either value itself.
+    let via: String
+}
+
+/// Prefers the proxy; falls back to a direct key for local development.
+///
+/// An env var beats Info.plist for both, so a simulator run can be pointed at
+/// a staging proxy (or a personal key) without regenerating the project — the
+/// pre-existing `ANTHROPIC_BASE_URL` override behavior, generalized.
+private func resolveCredential() -> ResolvedCredential? {
+    func plist(_ key: String) -> String? {
+        (Bundle.main.object(forInfoDictionaryKey: key) as? String)
+            .flatMap { $0.isEmpty ? nil : $0 }
+    }
+    func env(_ key: String) -> String? {
+        ProcessInfo.processInfo.environment[key].flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    // 1. Proxy. Both halves are required — a URL without the shared secret
+    //    would be rejected by the proxy on every call, and silently falling
+    //    back to a direct key there would defeat the point of configuring one.
+    if let proxyURL = env("JEFE_PROXY_URL") ?? plist("JEFE_PROXY_URL"),
+       let appSecret = env("JEFE_APP_SECRET") ?? plist("JEFE_APP_SECRET") {
+        // Wire format the proxy parses: jefe.<installId>.<appSecret>.
+        return ResolvedCredential(
+            apiKey: "jefe.\(InstallIdentity.current()).\(appSecret)",
+            baseURL: proxyURL,
+            via: "proxy"
+        )
+    }
+
+    // 2. Direct key (local dev). PPQ_API_KEY is the historical Info.plist name;
+    //    the key and the base URL are a MATCHED PAIR (a PPQ key only works
+    //    against PPQ's host, a direct sk-ant- key only against Anthropic's).
+    if let apiKey = env("ANTHROPIC_API_KEY") ?? plist("PPQ_API_KEY") {
+        return ResolvedCredential(
+            apiKey: apiKey,
+            baseURL: env("ANTHROPIC_BASE_URL") ?? plist("ANTHROPIC_BASE_URL"),
+            via: "direct-key"
+        )
+    }
+
+    return nil
+}
+
 @MainActor
 func resolveEngine(demo: Bool) -> WalkEngine? {
     if demo {
@@ -132,18 +181,30 @@ func resolveEngine(demo: Bool) -> WalkEngine? {
         return nil
     }
     #if canImport(MurmurCoreFFI)
-    guard
-        let apiKey = Bundle.main.object(forInfoDictionaryKey: "PPQ_API_KEY") as? String,
-        !apiKey.isEmpty
-    else {
-        engineLog.notice("engine=demo (no PPQ_API_KEY configured)")
-        return nil // no key configured -> demo path (D10)
+    // Two ways to reach the model, tried in this order:
+    //
+    //   1. THE PROXY (what ships). `JEFE_PROXY_URL` + `JEFE_APP_SECRET` in
+    //      Info.plist. The real sk-ant- key lives in Cloudflare and never
+    //      enters a build, which is the whole point — a key baked into
+    //      Info.plist is extractable from any downloaded IPA.
+    //   2. A DIRECT KEY (local dev only). The pre-proxy path, kept so dam and
+    //      anyone else can run real-core against a personal key without
+    //      standing up a proxy.
+    //
+    // Neither configured -> demo (D10), unchanged.
+    //
+    // No core or FFI change is needed for any of this: the provider already
+    // sends `config.api_key` as both `x-api-key` and `Authorization: Bearer`,
+    // and `EngineConfig` already carries `base_url`. The install credential
+    // rides in through that same field and the proxy swaps it for the real
+    // key, so this is a config change end to end.
+    let resolved = resolveCredential()
+    guard let resolved else {
+        engineLog.notice("engine=demo (neither a proxy nor a direct key is configured)")
+        return nil
     }
-    // Env var wins (ad-hoc override via SIMCTL_CHILD_…), else the value baked
-    // into Info.plist by generate.sh — so icon-tap launches hit the right
-    // provider without any environment plumbing.
-    let baseURL = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"]
-        ?? (Bundle.main.object(forInfoDictionaryKey: "ANTHROPIC_BASE_URL") as? String)
+    let apiKey = resolved.apiKey
+    let baseURL = resolved.baseURL
     // iOS does not pre-create Application Support; murmur-core opens its SQLite
     // store at dbPath and panics if the parent directory is missing. Ensure it
     // exists before handing the path to the engine.
@@ -177,7 +238,12 @@ func resolveEngine(demo: Bool) -> WalkEngine? {
         sttVadRmsThreshold: stt.vadRms,
         sttNoSpeechProbThreshold: stt.noSpeechProb
     )
-    engineLog.notice("engine=real (murmur-core MurmurEngine, key len=\(apiKey.count, privacy: .public))")
+    // `via` and a length only — never the credential itself. On the proxy path
+    // the credential embeds the shared app secret, so logging it would put the
+    // secret in device logs and any sysdiagnose the user ever shares.
+    engineLog.notice(
+        "engine=real (murmur-core MurmurEngine, via=\(resolved.via, privacy: .public), key len=\(apiKey.count, privacy: .public))"
+    )
     // Throwing constructor (no panics across FFI): if the store can't open,
     // fall back to the demo path rather than crash at launch (D10). The
     // Application Support dir is created above, before this fallible init, so a

--- a/apps/ios/Sources/App/Info.plist
+++ b/apps/ios/Sources/App/Info.plist
@@ -24,6 +24,10 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>JEFE_APP_SECRET</key>
+	<string>$(JEFE_APP_SECRET)</string>
+	<key>JEFE_PROXY_URL</key>
+	<string>$(JEFE_PROXY_URL)</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Photos you take during a walk pin to the item you're describing and land in the finished document.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/apps/ios/Sources/App/InstallIdentity.swift
+++ b/apps/ios/Sources/App/InstallIdentity.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Security
+
+/// A stable, anonymous per-install id, used to meter and rate-limit this
+/// install at the proxy.
+///
+/// Keychain-backed rather than `UserDefaults` on purpose: keychain items
+/// survive app deletion and reinstall, `UserDefaults` does not. Since the
+/// proxy's free-tier allowance is keyed on this id, a `UserDefaults` id would
+/// reset the allowance on every reinstall — a one-tap bypass.
+///
+/// This identifies an INSTALL, not a person. It is a random UUID with no
+/// device identifier in it, it never leaves the device except as an opaque
+/// string in the proxy credential, and it is not linkable to anything else.
+///
+/// It is also not a security boundary. Anyone can mint an arbitrary id and
+/// send it; what makes that bounded is the proxy's per-install and global
+/// spend caps, and — in Phase 2 — App Attest proving the caller is a genuine
+/// unmodified build (see services/proxy/README.md).
+enum InstallIdentity {
+    private static let service = "app.jefe.install"
+    private static let account = "install-id"
+
+    /// The id for this install, minting and persisting one on first call.
+    static func current() -> String {
+        if let existing = read() { return existing }
+        let fresh = UUID().uuidString.lowercased()
+        write(fresh)
+        // Return `fresh` even if the write failed. A keychain failure must not
+        // block a walk: the caller still gets a usable id, metering still
+        // works for this launch, and the only cost is that the id may not
+        // persist. Failing the walk over a bookkeeping problem would be a far
+        // worse trade for someone standing on a job site.
+        return fresh
+    }
+
+    private static func read() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8),
+              !value.isEmpty
+        else { return nil }
+        return value
+    }
+
+    private static func write(_ value: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        // Delete-then-add rather than update: simpler, and idempotent if a
+        // partial item somehow exists.
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = Data(value.utf8)
+        // AfterFirstUnlock, not WhenUnlocked: a walk can finish and process
+        // with the screen locked in a pocket (the background-audio path), and
+        // the id has to be readable then.
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -32,6 +32,13 @@ targets:
         # Provider base URL (e.g. https://api.ppq.ai). Same injection flow as
         # the key; empty => provider default (api.anthropic.com).
         ANTHROPIC_BASE_URL: "$(ANTHROPIC_BASE_URL)"
+        # The proxy (services/proxy). When BOTH are set they win over the
+        # direct key above, and no Anthropic key is present in the build at
+        # all — which is the point: a key in Info.plist is extractable from any
+        # downloaded IPA. Same build-variable injection as the key; neither
+        # tracked value ever holds a secret.
+        JEFE_PROXY_URL: "$(JEFE_PROXY_URL)"
+        JEFE_APP_SECRET: "$(JEFE_APP_SECRET)"
         CFBundleDisplayName: Jefe
         CFBundleName: Jefe
         # Fixed paper-and-ink theme: lock light appearance so system dark mode

--- a/services/proxy/wrangler.toml
+++ b/services/proxy/wrangler.toml
@@ -15,9 +15,9 @@ PER_INSTALL_DAILY_CAP_USD = "2"
 
 [[kv_namespaces]]
 binding = "METER"
-# Replace with the id printed by:
-#   wrangler kv namespace create METER
-id = "REPLACE_ME"
+# Created 2026-07-26 via `wrangler kv namespace create METER`.
+# Not a secret — a namespace id is useless without account credentials.
+id = "b23e593ab16e469b8a60167557cb3fac"
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Thinking

Closes the App Store launch blocker from the app side. **The proxy is deployed and verified live** at `https://jefe-proxy.damsac-app.workers.dev`:

| Check | Result |
|---|---|
| Real Claude call through the proxy | ✅ returned `PROXY OK` |
| Bad credential | ✅ 401 `credential rejected` |
| Missing secrets | ✅ 500 `proxy is not configured` (fails closed) |
| Spend metering | ✅ $0.000044 for 14 in / 6 out on Haiku — **matches the hand calculation exactly** |

Resolution is now two paths, tried in order:

1. **The proxy (what ships)** — `JEFE_PROXY_URL` + `JEFE_APP_SECRET` in Info.plist. **No Anthropic key exists in the build at all**, which is the entire point: a key in Info.plist is extractable from any downloaded IPA.
2. **A direct key (local dev only)** — the pre-proxy path, kept so real-core can run against a personal key without standing up a proxy.

Neither configured still means demo (D10), unchanged.

**No core or FFI change was needed.** The provider already sends `config.api_key` as both `x-api-key` and `Authorization`, and `EngineConfig` already carries `base_url` — so the install credential rides in through that same field and the proxy swaps it for the real key. Config change end to end.

## Decisions

- **Both halves of the proxy config are required together.** A URL without the shared secret is rejected on every call, and silently falling back to a direct key there would defeat the point of having configured one.
- **`InstallIdentity` is Keychain-backed, not `UserDefaults`.** Keychain items survive app deletion and reinstall; `UserDefaults` doesn't. Since the proxy's free-tier allowance keys on this id, a `UserDefaults` id would reset the allowance on every reinstall — a one-tap bypass. `AfterFirstUnlock` because a pocket walk finishes and processes with the screen locked.
- **A keychain write failure still returns a usable id** rather than failing the walk. Losing persistence is a bookkeeping problem; failing a walk on a job site is not.
- **The `engine=real` log reports `via=proxy|direct-key` and a length, never the credential.** On the proxy path it embeds the shared app secret, so logging it would put that secret into device logs and any sysdiagnose the user shares.

Also commits the KV namespace id in `wrangler.toml`. Not a secret — a namespace id is useless without account credentials — but it must be tracked or a redeploy loses the binding. Verified no real secret lands in any tracked file; Info.plist carries build-variable references only.

## Verification

`BUILD SUCCEEDED` (iPhone 17 sim).

**Not yet exercised end-to-end from the app** — that needs a real-core build (`build-ffi.sh` + `project-real.yml`), so the proxy path is verified by construction plus the live curl round-trip, not by an actual walk. Worth doing before this ships to TestFlight.

## Before this reaches a real build

CI must supply the two new build settings on the archive, the same way it supplies `PPQ_API_KEY` today — `JEFE_PROXY_URL` as a plain var and `JEFE_APP_SECRET` as a repo secret. **Not in this PR**, since it changes the release lane; happy to follow up.

## Still Phase 1

⚠️ **App Attest (Phase 2) remains required before the listing goes public.** That endpoint is currently protected by a secret extractable from any downloaded IPA — the $25/day global and $2/day per-install caps are what actually bound the loss. See `services/proxy/README.md` and #254 §4.5.1.