### PR TITLE
feat: jobs on the board — surface the model core has had since v1

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -571,11 +571,28 @@ public protocol MurmurEngineProtocol : AnyObject {
     func buildDocument(sessionId: String, kind: String) async throws  -> DocumentPayload
     
     /**
+     * Create a job from a name. Returns the created job so the board picks up
+     * the minted id and timestamps in one round-trip (the
+     * `save_document_schema` precedent).
+     *
+     * An empty or whitespace-only name is REJECTED rather than coerced to a
+     * placeholder (R6): a job called "Untitled" is worse than an error,
+     * because it looks deliberate and the operator has no idea which one it
+     * was meant to be.
+     */
+    func createJob(name: String) throws  -> Job
+    
+    /**
      * Live schemas, id order (built-ins first). `Some(trade)` filters to
      * that trade plus template-agnostic (NULL-trade) schemas; `None`
      * returns everything live.
      */
     func listDocumentSchemas(tradeKey: String?) throws  -> [DocumentSchema]
+    
+    /**
+     * Live jobs, newest first.
+     */
+    func listJobs() throws  -> [Job]
     
     /**
      * Core's entire file contract (Plan 11 D4): every live photo filename,
@@ -681,6 +698,11 @@ public protocol MurmurEngineProtocol : AnyObject {
      * thrown (R7). Trade change is a union — nothing is removed (D6-15).
      */
     func seedVocabulary(trade: String, version: UInt32, terms: [String]) throws  -> SeedReport
+    
+    /**
+     * Move a job between active / done / archived. Returns the updated job.
+     */
+    func setJobStatus(id: String, status: String) throws  -> Job
     
     /**
      * App-open zombie sweep (carry-note, Plan 04): a `Recording` session left
@@ -876,6 +898,24 @@ open func buildDocument(sessionId: String, kind: String)async throws  -> Documen
 }
     
     /**
+     * Create a job from a name. Returns the created job so the board picks up
+     * the minted id and timestamps in one round-trip (the
+     * `save_document_schema` precedent).
+     *
+     * An empty or whitespace-only name is REJECTED rather than coerced to a
+     * placeholder (R6): a job called "Untitled" is worse than an error,
+     * because it looks deliberate and the operator has no idea which one it
+     * was meant to be.
+     */
+open func createJob(name: String)throws  -> Job {
+    return try  FfiConverterTypeJob.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_create_job(self.uniffiClonePointer(),
+        FfiConverterString.lower(name),$0
+    )
+})
+}
+    
+    /**
      * Live schemas, id order (built-ins first). `Some(trade)` filters to
      * that trade plus template-agnostic (NULL-trade) schemas; `None`
      * returns everything live.
@@ -884,6 +924,16 @@ open func listDocumentSchemas(tradeKey: String?)throws  -> [DocumentSchema] {
     return try  FfiConverterSequenceTypeDocumentSchema.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
     uniffi_ffi_fn_method_murmurengine_list_document_schemas(self.uniffiClonePointer(),
         FfiConverterOptionString.lower(tradeKey),$0
+    )
+})
+}
+    
+    /**
+     * Live jobs, newest first.
+     */
+open func listJobs()throws  -> [Job] {
+    return try  FfiConverterSequenceTypeJob.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_list_jobs(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -1067,6 +1117,18 @@ open func seedVocabulary(trade: String, version: UInt32, terms: [String])throws 
         FfiConverterString.lower(trade),
         FfiConverterUInt32.lower(version),
         FfiConverterSequenceString.lower(terms),$0
+    )
+})
+}
+    
+    /**
+     * Move a job between active / done / archived. Returns the updated job.
+     */
+open func setJobStatus(id: String, status: String)throws  -> Job {
+    return try  FfiConverterTypeJob.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_set_job_status(self.uniffiClonePointer(),
+        FfiConverterString.lower(id),
+        FfiConverterString.lower(status),$0
     )
 })
 }
@@ -2611,6 +2673,164 @@ public func FfiConverterTypeEngineConfig_lower(_ value: EngineConfig) -> RustBuf
 }
 
 
+/**
+ * FFI mirror of `murmur_core::Job` (murmur-core stays UniFFI-free — every
+ * record lives on this side of the boundary, the `NotesEntry` precedent).
+ */
+public struct Job {
+    public var id: String
+    /**
+     * What the operator calls it. The ONLY field the create UI collects —
+     * contractors name jobs however they think of them ("Alder Court",
+     * "the Hendersons", "412 Alder Ct"), and forcing that into separate
+     * client/site fields would impose a taxonomy they didn't ask for.
+     */
+    public var name: String
+    /**
+     * Reserved: the model carries these and sync round-trips them, but the
+     * app doesn't collect them yet.
+     */
+    public var client: String?
+    public var site: String?
+    /**
+     * Unix seconds; `None` = unscheduled/backlog.
+     */
+    public var scheduledAt: UInt64?
+    /**
+     * One of `VALID_JOB_STATUSES`.
+     */
+    public var status: String
+    public var createdAt: UInt64
+    public var updatedAt: UInt64
+    public var deviceId: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, 
+        /**
+         * What the operator calls it. The ONLY field the create UI collects —
+         * contractors name jobs however they think of them ("Alder Court",
+         * "the Hendersons", "412 Alder Ct"), and forcing that into separate
+         * client/site fields would impose a taxonomy they didn't ask for.
+         */name: String, 
+        /**
+         * Reserved: the model carries these and sync round-trips them, but the
+         * app doesn't collect them yet.
+         */client: String?, site: String?, 
+        /**
+         * Unix seconds; `None` = unscheduled/backlog.
+         */scheduledAt: UInt64?, 
+        /**
+         * One of `VALID_JOB_STATUSES`.
+         */status: String, createdAt: UInt64, updatedAt: UInt64, deviceId: String) {
+        self.id = id
+        self.name = name
+        self.client = client
+        self.site = site
+        self.scheduledAt = scheduledAt
+        self.status = status
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deviceId = deviceId
+    }
+}
+
+
+
+extension Job: Equatable, Hashable {
+    public static func ==(lhs: Job, rhs: Job) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.name != rhs.name {
+            return false
+        }
+        if lhs.client != rhs.client {
+            return false
+        }
+        if lhs.site != rhs.site {
+            return false
+        }
+        if lhs.scheduledAt != rhs.scheduledAt {
+            return false
+        }
+        if lhs.status != rhs.status {
+            return false
+        }
+        if lhs.createdAt != rhs.createdAt {
+            return false
+        }
+        if lhs.updatedAt != rhs.updatedAt {
+            return false
+        }
+        if lhs.deviceId != rhs.deviceId {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+        hasher.combine(client)
+        hasher.combine(site)
+        hasher.combine(scheduledAt)
+        hasher.combine(status)
+        hasher.combine(createdAt)
+        hasher.combine(updatedAt)
+        hasher.combine(deviceId)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeJob: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Job {
+        return
+            try Job(
+                id: FfiConverterString.read(from: &buf), 
+                name: FfiConverterString.read(from: &buf), 
+                client: FfiConverterOptionString.read(from: &buf), 
+                site: FfiConverterOptionString.read(from: &buf), 
+                scheduledAt: FfiConverterOptionUInt64.read(from: &buf), 
+                status: FfiConverterString.read(from: &buf), 
+                createdAt: FfiConverterUInt64.read(from: &buf), 
+                updatedAt: FfiConverterUInt64.read(from: &buf), 
+                deviceId: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Job, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.name, into: &buf)
+        FfiConverterOptionString.write(value.client, into: &buf)
+        FfiConverterOptionString.write(value.site, into: &buf)
+        FfiConverterOptionUInt64.write(value.scheduledAt, into: &buf)
+        FfiConverterString.write(value.status, into: &buf)
+        FfiConverterUInt64.write(value.createdAt, into: &buf)
+        FfiConverterUInt64.write(value.updatedAt, into: &buf)
+        FfiConverterString.write(value.deviceId, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeJob_lift(_ buf: RustBuffer) throws -> Job {
+    return try FfiConverterTypeJob.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeJob_lower(_ value: Job) -> RustBuffer {
+    return FfiConverterTypeJob.lower(value)
+}
+
+
 public struct NotesEntry {
     public var bucket: NotesBucket
     public var label: String
@@ -3436,6 +3656,13 @@ public enum EngineError {
      */
     case Schema(message: String)
     
+    /**
+     * A job operation failed — an empty name, an unknown status, a
+     * missing/deleted id, a poisoned lock, or a store error. Recoverable —
+     * surface, don't crash. Contains store/validation strings only.
+     */
+    case Job(message: String)
+    
 }
 
 
@@ -3488,6 +3715,10 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 10: return .Job(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -3517,6 +3748,8 @@ public struct FfiConverterTypeEngineError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(8))
         case .Schema(_ /* message is ignored*/):
             writeInt(&buf, Int32(9))
+        case .Job(_ /* message is ignored*/):
+            writeInt(&buf, Int32(10))
 
         
         }
@@ -4002,6 +4235,31 @@ fileprivate struct FfiConverterSequenceTypeDocumentSchema: FfiConverterRustBuffe
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeJob: FfiConverterRustBuffer {
+    typealias SwiftType = [Job]
+
+    public static func write(_ value: [Job], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeJob.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [Job] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [Job]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeJob.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeNotesEntry: FfiConverterRustBuffer {
     typealias SwiftType = [NotesEntry]
 
@@ -4200,7 +4458,13 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ffi_checksum_method_murmurengine_build_document() != 48464) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ffi_checksum_method_murmurengine_create_job() != 53936) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ffi_checksum_method_murmurengine_list_document_schemas() != 57223) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_list_jobs() != 47967) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_list_live_photo_filenames() != 39240) {
@@ -4237,6 +4501,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_seed_vocabulary() != 18954) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_set_job_status() != 52076) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_sweep_zombie_sessions() != 29924) {

--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -606,11 +606,6 @@ public protocol MurmurEngineProtocol : AnyObject {
      */
     func listPhotos(sessionId: String) throws  -> [PhotoRef]
     
-    /**
-     * The board walk log (D2/D3): every reopenable walk, newest first —
-     * never a transcript (Plan 04 lesson), never a Recording or tombstoned
-     * row. Read-only: safe at app-open alongside the sweeps (R4).
-     */
     func listSessions() throws  -> [WalkSummary]
     
     /**
@@ -703,6 +698,19 @@ public protocol MurmurEngineProtocol : AnyObject {
      * Move a job between active / done / archived. Returns the updated job.
      */
     func setJobStatus(id: String, status: String) throws  -> Job
+    
+    /**
+     * The board walk log (D2/D3): every reopenable walk, newest first —
+     * never a transcript (Plan 04 lesson), never a Recording or tombstoned
+     * row. Read-only: safe at app-open alongside the sweeps (R4).
+     * Files a walk under a job, or unfiles it with `None`.
+     *
+     * R4 ("no pre-labeling — the user corrects on the report") means this
+     * happens AFTER the walk, so it is deliberately allowed at any status.
+     * Re-filing is normal rather than exceptional: a walk misfiled months ago
+     * has to be movable.
+     */
+    func setSessionJob(sessionId: String, jobId: String?) throws 
     
     /**
      * App-open zombie sweep (carry-note, Plan 04): a `Recording` session left
@@ -961,11 +969,6 @@ open func listPhotos(sessionId: String)throws  -> [PhotoRef] {
 })
 }
     
-    /**
-     * The board walk log (D2/D3): every reopenable walk, newest first —
-     * never a transcript (Plan 04 lesson), never a Recording or tombstoned
-     * row. Read-only: safe at app-open alongside the sweeps (R4).
-     */
 open func listSessions()throws  -> [WalkSummary] {
     return try  FfiConverterSequenceTypeWalkSummary.lift(try rustCallWithError(FfiConverterTypeEngineError.lift) {
     uniffi_ffi_fn_method_murmurengine_list_sessions(self.uniffiClonePointer(),$0
@@ -1131,6 +1134,25 @@ open func setJobStatus(id: String, status: String)throws  -> Job {
         FfiConverterString.lower(status),$0
     )
 })
+}
+    
+    /**
+     * The board walk log (D2/D3): every reopenable walk, newest first —
+     * never a transcript (Plan 04 lesson), never a Recording or tombstoned
+     * row. Read-only: safe at app-open alongside the sweeps (R4).
+     * Files a walk under a job, or unfiles it with `None`.
+     *
+     * R4 ("no pre-labeling — the user corrects on the report") means this
+     * happens AFTER the walk, so it is deliberately allowed at any status.
+     * Re-filing is normal rather than exceptional: a walk misfiled months ago
+     * has to be movable.
+     */
+open func setSessionJob(sessionId: String, jobId: String?)throws  {try rustCallWithError(FfiConverterTypeEngineError.lift) {
+    uniffi_ffi_fn_method_murmurengine_set_session_job(self.uniffiClonePointer(),
+        FfiConverterString.lower(sessionId),
+        FfiConverterOptionString.lower(jobId),$0
+    )
+}
 }
     
     /**
@@ -3440,6 +3462,15 @@ public func FfiConverterTypeSeedReport_lower(_ value: SeedReport) -> RustBuffer 
 public struct WalkSummary {
     public var id: String
     /**
+     * The job this walk is filed under; `None` = unfiled.
+     *
+     * Core has always carried this (`sessions.job_id`); the FFI mirror
+     * simply dropped it, which is why the board could never group walks
+     * by job. Multiple walks per job is the common case — a property
+     * gets walked in March and again in June.
+     */
+    public var jobId: String?
+    /**
      * `doc_kind_for_template(template)` — advisory, for row labeling.
      */
     public var docKind: String
@@ -3464,6 +3495,14 @@ public struct WalkSummary {
     // declare one manually.
     public init(id: String, 
         /**
+         * The job this walk is filed under; `None` = unfiled.
+         *
+         * Core has always carried this (`sessions.job_id`); the FFI mirror
+         * simply dropped it, which is why the board could never group walks
+         * by job. Multiple walks per job is the common case — a property
+         * gets walked in March and again in June.
+         */jobId: String?, 
+        /**
          * `doc_kind_for_template(template)` — advisory, for row labeling.
          */docKind: String, status: WalkStatus, 
         /**
@@ -3477,6 +3516,7 @@ public struct WalkSummary {
          * Live items only.
          */itemCount: UInt32, hasDocument: Bool, queued: Bool) {
         self.id = id
+        self.jobId = jobId
         self.docKind = docKind
         self.status = status
         self.summary = summary
@@ -3492,6 +3532,9 @@ public struct WalkSummary {
 extension WalkSummary: Equatable, Hashable {
     public static func ==(lhs: WalkSummary, rhs: WalkSummary) -> Bool {
         if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.jobId != rhs.jobId {
             return false
         }
         if lhs.docKind != rhs.docKind {
@@ -3520,6 +3563,7 @@ extension WalkSummary: Equatable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(jobId)
         hasher.combine(docKind)
         hasher.combine(status)
         hasher.combine(summary)
@@ -3539,6 +3583,7 @@ public struct FfiConverterTypeWalkSummary: FfiConverterRustBuffer {
         return
             try WalkSummary(
                 id: FfiConverterString.read(from: &buf), 
+                jobId: FfiConverterOptionString.read(from: &buf), 
                 docKind: FfiConverterString.read(from: &buf), 
                 status: FfiConverterTypeWalkStatus.read(from: &buf), 
                 summary: FfiConverterString.read(from: &buf), 
@@ -3551,6 +3596,7 @@ public struct FfiConverterTypeWalkSummary: FfiConverterRustBuffer {
 
     public static func write(_ value: WalkSummary, into buf: inout [UInt8]) {
         FfiConverterString.write(value.id, into: &buf)
+        FfiConverterOptionString.write(value.jobId, into: &buf)
         FfiConverterString.write(value.docKind, into: &buf)
         FfiConverterTypeWalkStatus.write(value.status, into: &buf)
         FfiConverterString.write(value.summary, into: &buf)
@@ -4473,7 +4519,7 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ffi_checksum_method_murmurengine_list_photos() != 9711) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ffi_checksum_method_murmurengine_list_sessions() != 19041) {
+    if (uniffi_ffi_checksum_method_murmurengine_list_sessions() != 23419) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_list_vocabulary() != 10809) {
@@ -4504,6 +4550,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_set_job_status() != 52076) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ffi_checksum_method_murmurengine_set_session_job() != 33033) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ffi_checksum_method_murmurengine_sweep_zombie_sessions() != 29924) {

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -63,9 +63,14 @@ final class AppModel {
         let sessionId: String
         /// Mirror of `NotesModel.queued` for the reopened-notes gating banner.
         let queued: Bool
+        /// The job this walk is filed under; nil = unfiled. Set AFTER the walk
+        /// (R4: no pre-labeling), and re-settable — a walk filed to the wrong
+        /// job months ago has to be movable.
+        var jobId: String?
 
         init(time: String, docNo: String, docKind: String, sent: Bool,
-             sessionId: String, queued: Bool) {
+             sessionId: String, queued: Bool, jobId: String? = nil) {
+            self.jobId = jobId
             self.time = time
             self.docNo = docNo
             self.docKind = docKind
@@ -87,6 +92,7 @@ final class AppModel {
             self.sent = summary.hasDocument
             self.sessionId = summary.id
             self.queued = summary.queued
+            self.jobId = summary.jobId
         }
     }
     private(set) var sessionWalks: [WalkRecord] = []
@@ -648,6 +654,23 @@ final class AppModel {
         if !fetched.isEmpty || isRealCore {
             sessionWalks = fetched.map(WalkRecord.init)
         }
+    }
+
+    /// Files a walk under a job (or unfiles it with nil), then refreshes.
+    ///
+    /// Updates the in-memory record BEFORE re-reading, because the demo engine's
+    /// `listSessions()` returns `[]` by design (its log is in-memory) and
+    /// `hydrateWalkLog` deliberately declines to let that empty result wipe the
+    /// log. Without the optimistic update, filing would persist in the demo
+    /// engine and never appear — which would make the whole feature undemoable.
+    /// On real core the subsequent hydrate re-reads authoritative state, so the
+    /// optimistic value is immediately replaced by the stored one.
+    func setWalkJob(sessionId: String, jobId: String?) throws {
+        try engine.setSessionJob(sessionId: sessionId, jobId: jobId)
+        if let index = sessionWalks.firstIndex(where: { $0.sessionId == sessionId }) {
+            sessionWalks[index].jobId = jobId
+        }
+        hydrateWalkLog()
     }
 
     /// Reopen a finished walk from the board into the EXISTING NotesView

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -480,4 +480,62 @@ final class DemoWalkEngine: WalkEngine {
     func removeDocumentSchema(id: String) {
         schemas.removeAll { $0.id == id }
     }
+
+    // MARK: Jobs — in-memory demo conformance.
+
+    /// Seeded so the board has something to show in a clean checkout. Names
+    /// deliberately span the three ways contractors actually name work — a
+    /// place, a customer, an address — which is the argument for a single
+    /// free-text name field rather than structured client/site inputs.
+    private var jobs: [JobModel] = [
+        JobModel(id: "job-1", name: "Alder Court Lawn", client: nil, site: nil,
+                 scheduledAt: nil, status: .active, createdAt: 3, updatedAt: 3),
+        JobModel(id: "job-2", name: "The Hendersons", client: nil, site: nil,
+                 scheduledAt: nil, status: .active, createdAt: 2, updatedAt: 2),
+        JobModel(id: "job-3", name: "412 Maple — retaining wall", client: nil, site: nil,
+                 scheduledAt: nil, status: .done, createdAt: 1, updatedAt: 1),
+    ]
+    private var nextJobOrdinal = 4
+
+    func listJobs() -> [JobModel] {
+        // Newest first, matching the core query's ordering.
+        jobs.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func createJob(name: String) throws -> JobModel {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Mirror core's rejection rather than silently accepting: the demo
+        // engine exists to exercise the SAME error paths the editor will hit.
+        guard !trimmed.isEmpty else {
+            throw DemoEngineError.invalidInput("job name is empty")
+        }
+        let job = JobModel(
+            id: "job-\(nextJobOrdinal)", name: trimmed, client: nil, site: nil,
+            scheduledAt: nil, status: .active,
+            createdAt: UInt64(nextJobOrdinal), updatedAt: UInt64(nextJobOrdinal)
+        )
+        nextJobOrdinal += 1
+        jobs.append(job)
+        return job
+    }
+
+    @discardableResult
+    func setJobStatus(id: String, status: JobStatusModel) throws -> JobModel {
+        guard let index = jobs.firstIndex(where: { $0.id == id }) else {
+            throw DemoEngineError.invalidInput("no such job")
+        }
+        jobs[index].status = status
+        return jobs[index]
+    }
+}
+
+/// Errors the demo engine raises so the UI's error paths are exercised without
+/// a backend. The real engine surfaces `EngineError` from Rust.
+enum DemoEngineError: LocalizedError {
+    case invalidInput(String)
+    var errorDescription: String? {
+        switch self {
+        case .invalidInput(let message): return message
+        }
+    }
 }

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -483,6 +483,28 @@ final class DemoWalkEngine: WalkEngine {
 
     // MARK: Jobs — in-memory demo conformance.
 
+    /// Session -> job filings, the demo mirror of `sessions.job_id`.
+    private var sessionJobs: [String: String] = [:]
+
+    func setSessionJob(sessionId: String, jobId: String?) throws {
+        // Mirror core's rejection so the UI's error path is exercised without
+        // a backend: filing to a job that doesn't exist must fail loudly
+        // rather than silently losing the walk.
+        if let jobId {
+            guard jobs.contains(where: { $0.id == jobId }) else {
+                throw DemoEngineError.invalidInput("no such job")
+            }
+            sessionJobs[sessionId] = jobId
+        } else {
+            sessionJobs.removeValue(forKey: sessionId)
+        }
+    }
+
+    /// Demo-only read so the board can group its in-memory walks by job.
+    func demoJobId(forSession sessionId: String) -> String? {
+        sessionJobs[sessionId]
+    }
+
     /// Seeded so the board has something to show in a clean checkout. Names
     /// deliberately span the three ways contractors actually name work — a
     /// place, a customer, an address — which is the argument for a single

--- a/apps/ios/Sources/Engine/JobModel.swift
+++ b/apps/ios/Sources/Engine/JobModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// App-side mirror of the core `Job` record.
+///
+/// Mirrored rather than using the FFI type directly, for the same reason
+/// `DocumentSchemaModel` and `NotesModel` are: a view referencing
+/// `MurmurCoreFFI` compiles only in real-core mode, and the jobs board has to
+/// be demoable in a clean checkout.
+///
+/// Jobs have existed in murmur-core since v1 — `sessions.job_id` has always
+/// been a foreign key to them. Nothing was ever exposed to the app, so the
+/// board stayed session-flat. This is the missing surface, not a new model.
+struct JobModel: Identifiable, Hashable {
+    let id: String
+    /// What the operator calls it — the only field the create UI collects.
+    /// Contractors name jobs however they think of them ("Alder Court", "the
+    /// Hendersons", "412 Alder Ct"), and splitting that into client/site
+    /// fields would impose a taxonomy nobody asked for.
+    var name: String
+    /// Carried by the model and round-tripped by sync, not yet collected.
+    var client: String?
+    var site: String?
+    var scheduledAt: UInt64?
+    var status: JobStatusModel
+    var createdAt: UInt64
+    var updatedAt: UInt64
+}
+
+/// Mirrors core's `JobStatus`. Crosses the FFI boundary as a string so an
+/// unknown value surfaces as an allowlist error rather than being silently
+/// coerced (R6) — but is an enum app-side, where exhaustive matching is what
+/// we want.
+enum JobStatusModel: String, CaseIterable, Hashable {
+    case active
+    case done
+    case archived
+
+    /// Unknown strings map to `.active` at the app boundary ONLY as a
+    /// last-resort display fallback — core already rejects unknown values on
+    /// write, so this is unreachable in practice. It exists so a future core
+    /// status can't crash an older build.
+    init(fromCore raw: String) {
+        self = JobStatusModel(rawValue: raw) ?? .active
+    }
+}

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -371,6 +371,36 @@ final class MurmurEngine: WalkEngine {
         )
     }
 
+    // MARK: Jobs — passthrough + conversion.
+
+    func listJobs() throws -> [JobModel] {
+        try engine.listJobs().map(Self.job)
+    }
+
+    func createJob(name: String) throws -> JobModel {
+        Self.job(try engine.createJob(name: name))
+    }
+
+    @discardableResult
+    func setJobStatus(id: String, status: JobStatusModel) throws -> JobModel {
+        // rawValue is the wire contract: core validates against its own
+        // allowlist and returns the exact error for anything else (R6).
+        Self.job(try engine.setJobStatus(id: id, status: status.rawValue))
+    }
+
+    private nonisolated static func job(_ j: MurmurCoreFFI.Job) -> JobModel {
+        JobModel(
+            id: j.id,
+            name: j.name,
+            client: j.client,
+            site: j.site,
+            scheduledAt: j.scheduledAt,
+            status: JobStatusModel(fromCore: j.status),
+            createdAt: j.createdAt,
+            updatedAt: j.updatedAt
+        )
+    }
+
     // MARK: Document schemas (Plan 19) — passthrough + conversion.
 
     func listDocumentSchemas(tradeKey: String?) throws -> [DocumentSchemaModel] {

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -373,6 +373,10 @@ final class MurmurEngine: WalkEngine {
 
     // MARK: Jobs — passthrough + conversion.
 
+    func setSessionJob(sessionId: String, jobId: String?) throws {
+        try engine.setSessionJob(sessionId: sessionId, jobId: jobId)
+    }
+
     func listJobs() throws -> [JobModel] {
         try engine.listJobs().map(Self.job)
     }

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -174,6 +174,7 @@ extension MurmurEngine {
     static func walkSummary(_ summary: FFIWalkSummary) -> WalkSummary {
         WalkSummary(
             id: summary.id,
+            jobId: summary.jobId,
             docKind: summary.docKind,
             status: walkStatus(summary.status),
             summary: summary.summary,

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -273,6 +273,21 @@ protocol WalkEngine: AnyObject {
     func listDocumentSchemas(tradeKey: String?) throws -> [DocumentSchemaModel]
     func saveDocumentSchema(_ schema: DocumentSchemaModel) throws -> DocumentSchemaModel
     func removeDocumentSchema(id: String) throws
+
+    // Jobs — the board's organizing unit. Jobs have existed in murmur-core
+    // since v1 (`sessions.job_id` is a foreign key to them); nothing was ever
+    // exposed to the app, which is why the board is session-flat today.
+    //
+    // `create` takes only a name, deliberately: contractors name jobs however
+    // they think of them, and core REJECTS an empty name rather than coercing
+    // it to a placeholder (R6) — a job called "Untitled" looks deliberate and
+    // leaves the operator unable to tell which one it was meant to be.
+    //
+    // Returns the created/updated job so the board picks up core's minted id
+    // and timestamps in one round-trip (the saveDocumentSchema precedent).
+    func listJobs() throws -> [JobModel]
+    func createJob(name: String) throws -> JobModel
+    func setJobStatus(id: String, status: JobStatusModel) throws -> JobModel
     func liveLivePhotoFilenames() throws -> [String]   // for the sweep
 
     /// App-open zombie sweep: a `Recording` session left behind by a crash or

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -127,6 +127,10 @@ enum WalkStatus {
 /// session (a built walk).
 struct WalkSummary: Identifiable, Equatable {
     var id: String
+    /// The job this walk is filed under; nil = unfiled. Multiple walks
+    /// per job is the common case — a property walked in March and again
+    /// in June.
+    var jobId: String?
     var docKind: String
     var status: WalkStatus
     var summary: String
@@ -285,6 +289,13 @@ protocol WalkEngine: AnyObject {
     //
     // Returns the created/updated job so the board picks up core's minted id
     // and timestamps in one round-trip (the saveDocumentSchema precedent).
+    /// File a walk under a job, or unfile it with nil.
+    ///
+    /// R4 ("no pre-labeling — the user corrects on the report"): this runs
+    /// AFTER the walk, never before it. Re-filing is normal rather than
+    /// exceptional — a walk misfiled months ago has to be movable.
+    func setSessionJob(sessionId: String, jobId: String?) throws
+
     func listJobs() throws -> [JobModel]
     func createJob(name: String) throws -> JobModel
     func setJobStatus(id: String, status: JobStatusModel) throws -> JobModel

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -162,6 +162,35 @@ struct BoardView: View {
                             WalkLogRow(walk: walk)
                         }
                         .buttonStyle(.plain)
+                        // Filing lives in a context menu rather than a visible
+                        // control: the row's PRIMARY job is reopening the walk,
+                        // and a second button on every row would clutter the
+                        // one screen that has to stay scannable in sunlight.
+                        // A long-press secondary action is the iOS idiom for
+                        // exactly this. (Worth revisiting if it proves
+                        // undiscoverable — filing also belongs on the notes
+                        // screen, which is where R4 says correction happens.)
+                        .contextMenu {
+                            if activeJobs.isEmpty {
+                                Text("No jobs yet")
+                            } else {
+                                ForEach(activeJobs) { job in
+                                    Button {
+                                        fileWalk(walk, to: job.id)
+                                    } label: {
+                                        Label(job.name, systemImage:
+                                            walk.jobId == job.id ? "checkmark" : "folder")
+                                    }
+                                }
+                                if walk.jobId != nil {
+                                    Button(role: .destructive) {
+                                        fileWalk(walk, to: nil)
+                                    } label: {
+                                        Label("Unfile", systemImage: "xmark")
+                                    }
+                                }
+                            }
+                        }
                     }
                     if let reopenError = model.reopenError {
                         // F4 floor: the breadcrumb surfaces; chrome is sac's.
@@ -297,7 +326,9 @@ extension BoardView {
                     .padding(.top, 12)
             } else {
                 ForEach(activeJobs) { job in
-                    OperatorJobCard(job: job)
+                    OperatorJobCard(job: job, walks: walks(for: job.id)) { walk in
+                        model.reopenWalk(sessionId: walk.sessionId)
+                    }
                 }
             }
         }
@@ -324,6 +355,25 @@ extension BoardView {
         }
     }
 
+    /// Files (or unfiles) a walk, then re-reads the log so the job cards
+    /// reflect it. Re-reading rather than mutating in place keeps core as the
+    /// single source of truth for what is filed where.
+    func fileWalk(_ walk: AppModel.WalkRecord, to jobId: String?) {
+        guard !walk.sessionId.isEmpty else { return }  // legacy/demo row
+        do {
+            try model.setWalkJob(sessionId: walk.sessionId, jobId: jobId)
+            jobsError = nil
+        } catch {
+            jobsError = "Couldn't file walk: \(error.localizedDescription)"
+        }
+    }
+
+    /// The walks filed under a job, newest first — the "months later, what
+    /// happened on this job?" surface.
+    func walks(for jobId: String) -> [AppModel.WalkRecord] {
+        model.sessionWalks.filter { $0.jobId == jobId }
+    }
+
     func createJob() {
         let name = newJobName
         newJobName = ""
@@ -345,29 +395,71 @@ extension BoardView {
 /// persistence land, so it's built as a card rather than a row.
 private struct OperatorJobCard: View {
     let job: JobModel
+    let walks: [AppModel.WalkRecord]
+    let onOpenWalk: (AppModel.WalkRecord) -> Void
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
                 Text(job.name)
                     .font(Theme.F.serif(17, .semibold))
                     .foregroundStyle(Theme.C.ink)
                     .lineLimit(2)
-                // Placeholder until walks attach to jobs — stated honestly
-                // rather than faking a count we don't have yet.
-                Text("NO WALKS YET")
+                Spacer()
+                Text(walkCountLabel)
                     .font(Theme.F.mono(8.5))
                     .tracking(0.8)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(walks.isEmpty ? Theme.C.ink35 : Theme.C.orangeDeep)
             }
-            Spacer()
+            .padding(.horizontal, Theme.S.screenPad)
+            .padding(.top, 13)
+            .padding(.bottom, walks.isEmpty ? 13 : 8)
+
+            // The walks themselves — the "an email lands months later asking
+            // about this job" surface. Tapping reopens that walk's notes,
+            // which are the durable record; the document is regenerated from
+            // them on demand rather than stored.
+            ForEach(walks) { walk in
+                Button { onOpenWalk(walk) } label: {
+                    HStack(spacing: 10) {
+                        Rectangle()
+                            .fill(Theme.C.hairline)
+                            .frame(width: 1, height: 13)
+                        Text(walk.time)
+                            .font(Theme.F.mono(9.5))
+                            .foregroundStyle(Theme.C.ink60)
+                        Text(walk.docKind)
+                            .font(Theme.F.mono(9.5))
+                            .tracking(0.6)
+                            .foregroundStyle(Theme.C.ink35)
+                            .lineLimit(1)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(Theme.C.ink35)
+                    }
+                    .padding(.leading, Theme.S.screenPad + 2)
+                    .padding(.trailing, Theme.S.screenPad)
+                    .padding(.vertical, 7)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.bottom, walks.isEmpty ? 0 : 8)
         }
-        .padding(.horizontal, Theme.S.screenPad)
-        .padding(.vertical, 13)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
         .overlay(alignment: .bottom) {
             Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
+        }
+    }
+
+    private var walkCountLabel: String {
+        switch walks.count {
+        // Honest rather than a fake zero-state: an unfiled job genuinely has
+        // no walks, and long-pressing a walk is how one gets here.
+        case 0: return "NO WALKS YET"
+        case 1: return "1 WALK"
+        default: return "\(walks.count) WALKS"
         }
     }
 }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -156,39 +156,11 @@ struct BoardView: View {
                     // // sac: the reopen affordance visuals (chevron? row
                     // // sac: press state?) + the reopened banner are yours.
                     ForEach(model.sessionWalks) { walk in
-                        Button {
+                        WalkLogRow(walk: walk) {
                             model.reopenWalk(sessionId: walk.sessionId)
-                        } label: {
-                            WalkLogRow(walk: walk)
-                        }
-                        .buttonStyle(.plain)
-                        // Filing lives in a context menu rather than a visible
-                        // control: the row's PRIMARY job is reopening the walk,
-                        // and a second button on every row would clutter the
-                        // one screen that has to stay scannable in sunlight.
-                        // A long-press secondary action is the iOS idiom for
-                        // exactly this. (Worth revisiting if it proves
-                        // undiscoverable — filing also belongs on the notes
-                        // screen, which is where R4 says correction happens.)
-                        .contextMenu {
-                            if activeJobs.isEmpty {
-                                Text("No jobs yet")
-                            } else {
-                                ForEach(activeJobs) { job in
-                                    Button {
-                                        fileWalk(walk, to: job.id)
-                                    } label: {
-                                        Label(job.name, systemImage:
-                                            walk.jobId == job.id ? "checkmark" : "folder")
-                                    }
-                                }
-                                if walk.jobId != nil {
-                                    Button(role: .destructive) {
-                                        fileWalk(walk, to: nil)
-                                    } label: {
-                                        Label("Unfile", systemImage: "xmark")
-                                    }
-                                }
+                        } trailing: {
+                            FileChip(walk: walk, jobs: activeJobs) { jobId in
+                                fileWalk(walk, to: jobId)
                             }
                         }
                     }
@@ -615,33 +587,117 @@ struct CoachCallout: View {
 
 // MARK: - Session walk row (airport-board discipline, JobRow's bones)
 
-private struct WalkLogRow: View {
+/// One walk in the log.
+///
+/// Two independent targets, deliberately siblings rather than nested: tapping
+/// the row reopens the walk's notes, and the trailing chip files it under a
+/// job. A `Menu` inside the row's `Button` would fight it for taps.
+private struct WalkLogRow<Trailing: View>: View {
     let walk: AppModel.WalkRecord
+    let onOpen: () -> Void
+    @ViewBuilder var trailing: Trailing
 
     var body: some View {
-        HStack(spacing: 12) {
-            Text(walk.time)
-                .font(Theme.F.mono(11, .medium))
-                .foregroundStyle(Theme.C.ink)
-                .frame(width: 46, alignment: .leading)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(walk.docNo)
-                    .font(Theme.F.ui(14.5, .semibold))
-                    .lineLimit(1)
-                Text(walk.docKind.capitalized)
-                    .font(Theme.F.cond(11.5, .medium))
-                    .foregroundStyle(Theme.C.ink60)
-                    .lineLimit(1)
+        HStack(spacing: 8) {
+            Button(action: onOpen) {
+                HStack(spacing: 12) {
+                    Text(walk.time)
+                        .font(Theme.F.mono(11, .medium))
+                        .foregroundStyle(Theme.C.ink)
+                        .frame(width: 46, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(walk.docNo)
+                            .font(Theme.F.ui(14.5, .semibold))
+                            .lineLimit(1)
+                        Text(walk.docKind.capitalized)
+                            .font(Theme.F.cond(11.5, .medium))
+                            .foregroundStyle(Theme.C.ink60)
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 8)
+                    FieldTag(tag: TagFixture(
+                        kind: walk.sent ? .green : .plain,
+                        label: walk.sent ? "SENT" : "DISCARDED"
+                    ))
+                }
+                .contentShape(Rectangle())
             }
-            Spacer(minLength: 8)
-            FieldTag(tag: TagFixture(
-                kind: walk.sent ? .green : .plain,
-                label: walk.sent ? "SENT" : "DISCARDED"
-            ))
+            .buttonStyle(.plain)
+
+            trailing
         }
-        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.leading, Theme.S.screenPad)
+        .padding(.trailing, Theme.S.screenPad - 6)
         .padding(.vertical, 13)
         .opacity(walk.sent ? 1 : 0.55)
         .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
+    }
+}
+
+/// The filing affordance: a visible, tap-activated chip that also DISPLAYS the
+/// current filing.
+///
+/// Doing double duty is the point. A bare "FILE" button would say nothing about
+/// where a walk already sits, so the operator would have to open the menu to
+/// find out. Showing the job name instead means the common case — "which job is
+/// this under?" — is answered without any interaction at all.
+private struct FileChip: View {
+    let walk: AppModel.WalkRecord
+    let jobs: [JobModel]
+    let onFile: (String?) -> Void
+
+    private var filedJob: JobModel? { jobs.first { $0.id == walk.jobId } }
+
+    var body: some View {
+        Menu {
+            if jobs.isEmpty {
+                Text("No jobs yet — add one below")
+            } else {
+                ForEach(jobs) { job in
+                    Button {
+                        onFile(job.id)
+                    } label: {
+                        Label(job.name, systemImage:
+                            walk.jobId == job.id ? "checkmark" : "folder")
+                    }
+                }
+                if walk.jobId != nil {
+                    Divider()
+                    Button(role: .destructive) { onFile(nil) } label: {
+                        Label("Unfile", systemImage: "xmark")
+                    }
+                }
+            }
+        } label: {
+            if let filedJob {
+                Text(filedJob.name.uppercased())
+                    .font(Theme.F.mono(8, .semibold))
+                    .tracking(0.8)
+                    .foregroundStyle(Theme.C.orangeDeep)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 88, alignment: .trailing)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 8)
+                    .background(Theme.C.orangeTint)
+                    .contentShape(Rectangle())
+            } else {
+                // Unfiled reads as an invitation, not an error — most walks
+                // will sit unfiled for a while and that's fine.
+                Text("FILE")
+                    .font(Theme.F.mono(8, .semibold))
+                    .tracking(0.8)
+                    .foregroundStyle(Theme.C.ink35)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
+                            .foregroundStyle(Theme.C.ink35)
+                    )
+                    .contentShape(Rectangle())
+            }
+        }
+        .accessibilityLabel(filedJob.map { "Filed under \($0.name). Change." } ?? "File this walk")
     }
 }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -12,6 +12,14 @@ struct BoardView: View {
     // First-run coach mark, one-shot (survives relaunch). Cleared by resetcoach=1.
     @AppStorage(CoachMarks.startWalkKey) private var coachStartShown = false
 
+    // Jobs. Held here rather than on AppModel because nothing outside the board
+    // reads them yet; promote when walk-attachment lands and the notes screen
+    // needs the list too.
+    @State private var operatorJobs: [JobModel] = []
+    @State private var jobsError: String?
+    @State private var showNewJob = false
+    @State private var newJobName = ""
+
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 3) {
@@ -165,6 +173,12 @@ struct BoardView: View {
                             .padding(.top, 8)
                     }
                 }
+
+                // JOBS — the board's organizing unit, below TODAY on purpose.
+                // Walk-first (Isaac, 07-26): START WALK stays instant and
+                // unblocked at the truck door; jobs are where work accumulates,
+                // not a gate in front of recording it.
+                jobsSection
             } else {
                 MetaStrip(left: model.trade.boardMeta, right: "SYNCED 07:58")
 
@@ -218,6 +232,145 @@ struct BoardView: View {
 }
 
 // MARK: - Raised chip (clickable header buttons)
+
+// MARK: - Jobs section
+
+extension BoardView {
+    /// The jobs list plus its create affordance.
+    ///
+    /// Only ACTIVE jobs show. A contractor juggling ten live jobs does not want
+    /// last spring's finished work in the way; done/archived stay in the model
+    /// (and sync) but are out of the daily view.
+    var jobsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // SectionHead's grammar, composed inline rather than used directly:
+            // SectionHead draws its own full-width bottom rule, so putting the
+            // + beside it as a sibling shrinks the head and truncates the rule.
+            // Same padding, same labels, same heavy rule — one row.
+            HStack(spacing: 10) {
+                SectionLabel("JOBS")
+                Spacer()
+                SectionLabel("\(activeJobs.count) OPEN", color: Theme.C.orangeDeep)
+                Button { showNewJob = true } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Theme.C.orangeDeep)
+                        // Widen the tap target without moving the glyph — this
+                        // is a gloved-hands product.
+                        .frame(width: 30, height: 30)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("New job")
+            }
+            .padding(.leading, Theme.S.screenPad)
+            .padding(.trailing, Theme.S.screenPad - 8)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
+            .overlay(alignment: .bottom) {
+                Theme.C.ink.frame(height: 1.5)
+            }
+
+            if let jobsError {
+                Text(jobsError.uppercased())
+                    .font(Theme.F.mono(8.5))
+                    .tracking(0.4)
+                    .foregroundStyle(Theme.C.redTag)
+                    .padding(.horizontal, Theme.S.screenPad)
+                    .padding(.top, 8)
+            }
+
+            if activeJobs.isEmpty {
+                Text("NO JOBS YET — TAP + TO ADD ONE")
+                    .font(Theme.F.mono(8.5))
+                    .tracking(0.8)
+                    .foregroundStyle(Theme.C.ink35)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 22)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                            .foregroundStyle(Theme.C.ink35)
+                    )
+                    .padding(.horizontal, Theme.S.screenPad)
+                    .padding(.top, 12)
+            } else {
+                ForEach(activeJobs) { job in
+                    OperatorJobCard(job: job)
+                }
+            }
+        }
+        .onAppear(perform: loadJobs)
+        .alert("New job", isPresented: $showNewJob) {
+            TextField("Name", text: $newJobName)
+            Button("Cancel", role: .cancel) { newJobName = "" }
+            Button("Add") { createJob() }
+        } message: {
+            Text("Call it whatever you call it on site.")
+        }
+    }
+
+    var activeJobs: [JobModel] { operatorJobs.filter { $0.status == .active } }
+
+    func loadJobs() {
+        do {
+            operatorJobs = try model.engine.listJobs()
+            jobsError = nil
+        } catch {
+            // Leave whatever is on screen rather than blanking the list — the
+            // vocabulary/schema editors' posture.
+            jobsError = "Couldn't load jobs: \(error.localizedDescription)"
+        }
+    }
+
+    func createJob() {
+        let name = newJobName
+        newJobName = ""
+        do {
+            // Core rejects an empty name rather than coercing it (R6), so the
+            // error path is real and worth surfacing rather than pre-guarding
+            // into silence.
+            let created = try model.engine.createJob(name: name)
+            operatorJobs.insert(created, at: 0)
+            jobsError = nil
+        } catch {
+            jobsError = "Couldn't add job: \(error.localizedDescription)"
+        }
+    }
+}
+
+/// One job on the board. Deliberately quiet for now: this is where walks,
+/// documents, and notes will hang once walk-attachment and document
+/// persistence land, so it's built as a card rather than a row.
+private struct OperatorJobCard: View {
+    let job: JobModel
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(job.name)
+                    .font(Theme.F.serif(17, .semibold))
+                    .foregroundStyle(Theme.C.ink)
+                    .lineLimit(2)
+                // Placeholder until walks attach to jobs — stated honestly
+                // rather than faking a count we don't have yet.
+                Text("NO WALKS YET")
+                    .font(Theme.F.mono(8.5))
+                    .tracking(0.8)
+                    .foregroundStyle(Theme.C.ink35)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.vertical, 13)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
+        }
+    }
+}
 
 /// A compact "pressed block" — the START WALK button's raised look, chip-sized:
 /// a `face` cap sitting on a darker `edge` lip (3pt) so it reads as a button, not

--- a/crates/ffi/src/engine.rs
+++ b/crates/ffi/src/engine.rs
@@ -66,6 +66,11 @@ pub enum EngineError {
     /// only (never an api key).
     #[error("schema error: {0}")]
     Schema(String),
+    /// A job operation failed — an empty name, an unknown status, a
+    /// missing/deleted id, a poisoned lock, or a store error. Recoverable —
+    /// surface, don't crash. Contains store/validation strings only.
+    #[error("job error: {0}")]
+    Job(String),
 }
 
 /// Config crossing the FFI boundary. `api_key` is an opaque `String` from the

--- a/crates/ffi/src/jobs.rs
+++ b/crates/ffi/src/jobs.rs
@@ -1,0 +1,149 @@
+//! Job CRUD across UniFFI — the seam the jobs board builds on.
+//!
+//! Jobs have existed in `murmur-core` since v1 (`store/jobs.rs`, and
+//! `sessions.job_id` has always been a foreign key to them), but nothing was
+//! ever exposed to the app, so the board stayed session-flat. This module is
+//! the missing surface, not a new model.
+//!
+//! Engine-keyed, mirroring the schema/vocabulary CRUD discipline: lock →
+//! mutate → return a typed `EngineError`, never a panic (Plan 07 CANON).
+//!
+//! `status` crosses as a **String** for the same reason `kind`/`fill` do on
+//! `DocumentSchema` (Plan 19 Stage 7): a string lets the app send a bad value
+//! and get the exact allowlist error back, where an enum would make an unknown
+//! unrepresentable and the reject path untestable from Swift.
+
+use murmur_core::{Job as CoreJob, JobStatus, NewJob};
+
+use crate::engine::{EngineError, MurmurEngine};
+
+/// The status values `set_job_status` accepts. Mirrors `JobStatus`.
+pub const VALID_JOB_STATUSES: [&str; 3] = ["active", "done", "archived"];
+
+/// FFI mirror of `murmur_core::Job` (murmur-core stays UniFFI-free — every
+/// record lives on this side of the boundary, the `NotesEntry` precedent).
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct Job {
+    pub id: String,
+    /// What the operator calls it. The ONLY field the create UI collects —
+    /// contractors name jobs however they think of them ("Alder Court",
+    /// "the Hendersons", "412 Alder Ct"), and forcing that into separate
+    /// client/site fields would impose a taxonomy they didn't ask for.
+    pub name: String,
+    /// Reserved: the model carries these and sync round-trips them, but the
+    /// app doesn't collect them yet.
+    pub client: Option<String>,
+    pub site: Option<String>,
+    /// Unix seconds; `None` = unscheduled/backlog.
+    pub scheduled_at: Option<u64>,
+    /// One of `VALID_JOB_STATUSES`.
+    pub status: String,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub device_id: String,
+}
+
+fn status_str(status: JobStatus) -> String {
+    match status {
+        JobStatus::Active => "active",
+        JobStatus::Done => "done",
+        JobStatus::Archived => "archived",
+    }
+    .to_string()
+}
+
+fn status_from_str(raw: &str) -> Option<JobStatus> {
+    match raw {
+        "active" => Some(JobStatus::Active),
+        "done" => Some(JobStatus::Done),
+        "archived" => Some(JobStatus::Archived),
+        _ => None,
+    }
+}
+
+fn job_from_core(job: CoreJob) -> Job {
+    Job {
+        id: job.id,
+        name: job.name,
+        client: job.client,
+        site: job.site,
+        scheduled_at: job.scheduled_at,
+        status: status_str(job.status),
+        created_at: job.created_at,
+        updated_at: job.updated_at,
+        device_id: job.device_id,
+    }
+}
+
+#[uniffi::export]
+impl MurmurEngine {
+    /// Live jobs, newest first.
+    pub fn list_jobs(&self) -> Result<Vec<Job>, EngineError> {
+        let store = self.store.lock().map_err(|_| Self::job_err("store lock poisoned"))?;
+        let jobs = store.list_jobs().map_err(|e| Self::job_err(e.to_string()))?;
+        Ok(jobs.into_iter().map(job_from_core).collect())
+    }
+
+    /// Create a job from a name. Returns the created job so the board picks up
+    /// the minted id and timestamps in one round-trip (the
+    /// `save_document_schema` precedent).
+    ///
+    /// An empty or whitespace-only name is REJECTED rather than coerced to a
+    /// placeholder (R6): a job called "Untitled" is worse than an error,
+    /// because it looks deliberate and the operator has no idea which one it
+    /// was meant to be.
+    pub fn create_job(&self, name: String) -> Result<Job, EngineError> {
+        if name.trim().is_empty() {
+            return Err(Self::job_err("job name is empty"));
+        }
+        let store = self.store.lock().map_err(|_| Self::job_err("store lock poisoned"))?;
+        let job = store
+            .create_job(NewJob { name: name.trim().to_string(), ..Default::default() })
+            .map_err(|e| Self::job_err(e.to_string()))?;
+        Ok(job_from_core(job))
+    }
+
+    /// Move a job between active / done / archived. Returns the updated job.
+    pub fn set_job_status(&self, id: String, status: String) -> Result<Job, EngineError> {
+        let parsed = status_from_str(&status).ok_or_else(|| {
+            Self::job_err(format!(
+                "invalid job status '{status}'; must be one of: {}",
+                VALID_JOB_STATUSES.join(", ")
+            ))
+        })?;
+        let store = self.store.lock().map_err(|_| Self::job_err("store lock poisoned"))?;
+        let job = store
+            .update_job_status(&id, parsed)
+            .map_err(|e| Self::job_err(e.to_string()))?;
+        Ok(job_from_core(job))
+    }
+}
+
+impl MurmurEngine {
+    fn job_err(msg: impl Into<String>) -> EngineError {
+        EngineError::Job(msg.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_round_trips_through_the_boundary() {
+        for raw in VALID_JOB_STATUSES {
+            let parsed = status_from_str(raw).expect("allowlisted status must parse");
+            assert_eq!(status_str(parsed), raw);
+        }
+    }
+
+    #[test]
+    fn unknown_status_is_rejected_not_coerced() {
+        // R6: an unknown value must surface as an error the app can show, not
+        // silently become Active — which would flip a finished job back to
+        // live work without anyone noticing.
+        assert!(status_from_str("in_progress").is_none());
+        assert!(status_from_str("").is_none());
+        assert!(status_from_str("ACTIVE").is_none(), "matching is exact, not case-folded");
+    }
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -11,6 +11,7 @@ pub mod document_build;
 pub mod engine;
 pub mod events;
 pub mod items;
+pub mod jobs;
 pub mod notes;
 pub mod photos;
 pub mod schemas;

--- a/crates/ffi/src/sessions_read.rs
+++ b/crates/ffi/src/sessions_read.rs
@@ -25,6 +25,13 @@ pub enum WalkStatus {
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct WalkSummary {
     pub id: String,
+    /// The job this walk is filed under; `None` = unfiled.
+    ///
+    /// Core has always carried this (`sessions.job_id`); the FFI mirror
+    /// simply dropped it, which is why the board could never group walks
+    /// by job. Multiple walks per job is the common case — a property
+    /// gets walked in March and again in June.
+    pub job_id: Option<String>,
     /// `doc_kind_for_template(template)` — advisory, for row labeling.
     pub doc_kind: String,
     pub status: WalkStatus,
@@ -57,6 +64,7 @@ pub(crate) fn walk_summary(core: &murmur_core::WalkSummary) -> WalkSummary {
         doc_kind: murmur_core::doc_kind_for_template(core.template.as_deref()).to_string(),
         status: walk_status(core.status),
         summary: core.summary.clone().unwrap_or_default(),
+        job_id: core.job_id.clone(),
         started_at: core.started_at,
         item_count: core.item_count.min(u32::MAX as u64) as u32,
         has_document: core.has_document,
@@ -69,6 +77,26 @@ impl MurmurEngine {
     /// The board walk log (D2/D3): every reopenable walk, newest first —
     /// never a transcript (Plan 04 lesson), never a Recording or tombstoned
     /// row. Read-only: safe at app-open alongside the sweeps (R4).
+    /// Files a walk under a job, or unfiles it with `None`.
+    ///
+    /// R4 ("no pre-labeling — the user corrects on the report") means this
+    /// happens AFTER the walk, so it is deliberately allowed at any status.
+    /// Re-filing is normal rather than exceptional: a walk misfiled months ago
+    /// has to be movable.
+    pub fn set_session_job(
+        &self,
+        session_id: String,
+        job_id: Option<String>,
+    ) -> Result<(), EngineError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|_| EngineError::Session("store lock poisoned".into()))?;
+        store
+            .set_session_job(&session_id, job_id.as_deref())
+            .map_err(|e| EngineError::Session(e.to_string()))
+    }
+
     pub fn list_sessions(&self) -> Result<Vec<WalkSummary>, EngineError> {
         let store = self
             .store
@@ -183,6 +211,9 @@ mod tests {
         let walks = engine.list_sessions().unwrap();
         let WalkSummary {
             id: _,
+            // An id, not content — the guard is about transcripts never
+            // crossing this boundary, and a foreign key carries none.
+            job_id: _,
             doc_kind: _,
             status: _,
             summary: _,
@@ -191,5 +222,47 @@ mod tests {
             has_document: _,
             queued: _,
         } = walks[0].clone();
+    }
+
+    #[tokio::test]
+    async fn set_session_job_files_unfiles_and_refiles() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let job = store
+            .create_job(murmur_core::NewJob { name: "Alder Court".into(), ..Default::default() })
+            .unwrap();
+        let other = store
+            .create_job(murmur_core::NewJob { name: "The Hendersons".into(), ..Default::default() })
+            .unwrap();
+        let s = store.start_session(None).unwrap();
+        store.end_session(&s.id).unwrap();
+        let engine = engine_over(store);
+
+        // Unfiled to start — R4: nothing is labeled before the walk.
+        assert_eq!(engine.list_sessions().unwrap()[0].job_id, None);
+
+        engine.set_session_job(s.id.clone(), Some(job.id.clone())).unwrap();
+        assert_eq!(engine.list_sessions().unwrap()[0].job_id, Some(job.id.clone()));
+
+        // Re-filing is normal, not exceptional: a walk misfiled months ago has
+        // to be movable to the right job.
+        engine.set_session_job(s.id.clone(), Some(other.id.clone())).unwrap();
+        assert_eq!(engine.list_sessions().unwrap()[0].job_id, Some(other.id));
+
+        // And it can be unfiled again.
+        engine.set_session_job(s.id.clone(), None).unwrap();
+        assert_eq!(engine.list_sessions().unwrap()[0].job_id, None);
+    }
+
+    #[tokio::test]
+    async fn set_session_job_rejects_unknown_ids() {
+        let store = Store::open_in_memory("device-a").unwrap();
+        let s = store.start_session(None).unwrap();
+        store.end_session(&s.id).unwrap();
+        let engine = engine_over(store);
+
+        // Filing to a job that doesn't exist must fail loudly. A silent
+        // zero-row update would look like it worked and lose the walk.
+        assert!(engine.set_session_job(s.id.clone(), Some("nope".into())).is_err());
+        assert!(engine.set_session_job("nope".into(), None).is_err());
     }
 }

--- a/crates/murmur-core/src/store/sessions.rs
+++ b/crates/murmur-core/src/store/sessions.rs
@@ -132,6 +132,33 @@ impl Store {
     /// selecting extraction vocabulary + document layout (Plan 07 D4). Only
     /// valid while the session is still recording — reprocessing must stay
     /// template-consistent, so the key can't be changed after the fact.
+    /// Files a session under a job, or unfiles it with `None`.
+    ///
+    /// Deliberately allowed at ANY status, unlike `set_session_template`.
+    /// R4 ("no pre-labeling — the user corrects on the report") means filing
+    /// happens AFTER the walk, on a session that is already Processed. A
+    /// Recording-only guard would make the rule unimplementable.
+    ///
+    /// Re-filing is normal, not exceptional: a walk misfiled to the wrong job
+    /// months ago has to be movable, so this is a plain idempotent update
+    /// rather than a one-shot assignment.
+    pub fn set_session_job(&self, id: &str, job_id: Option<&str>) -> Result<(), CoreError> {
+        // Existence check first so a bad id is NotFound rather than a silent
+        // zero-row update — filing to nowhere would look like it worked.
+        let _ = self.get_session(id)?;
+        if let Some(jid) = job_id {
+            // Validate the job too: SQLite enforces the FK, but surfacing
+            // NotFound here gives the caller the same error shape as a bad
+            // session id instead of an opaque constraint violation.
+            let _ = self.get_job(jid)?;
+        }
+        self.conn.execute(
+            "UPDATE sessions SET job_id = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![job_id, self.now() as i64, id],
+        )?;
+        Ok(())
+    }
+
     pub fn set_session_template(&self, id: &str, template: &str) -> Result<(), CoreError> {
         let session = self.get_session(id)?;
         if session.status != SessionStatus::Recording {


### PR DESCRIPTION
## Thinking

Isaac wants the home page organized by job: a general contractor juggles ~10 live jobs, and each should house that job's walks, documents, and notes.

**The happy discovery: core already models this.** `Job` carries `name` / `client` / `site` / `scheduled_at` plus a `JobStatus` of `Active | Done | Archived` — literally "10 jobs at any given time" — and **`sessions.job_id` has been a foreign key to it since v1**. Nothing was ever exposed to the app, which is the only reason the board is session-flat today.

So this is a missing **surface**, not a new model. That's why it's a small PR for a big-sounding feature.

## Three layers, mirroring the schema seam from #260

**1. FFI** (`crates/ffi/src/jobs.rs`) — `list_jobs` / `create_job` / `set_job_status`, plus `EngineError::Job`. `status` crosses as a **String** for the same reason `DocumentSchema`'s `kind`/`fill` do: a string lets the app send a bad value and get the exact allowlist error back, where an enum makes an unknown unrepresentable and the reject path untestable from Swift. `ffi.swift` regenerated — `check-bindings.sh` reports up to date.

**2. App seam + `JobModel`**, mirrored rather than using the FFI record directly so the board stays demoable in a clean checkout (the `DocumentSchemaModel` precedent). Demo conformance is in-memory, seeded with three names that deliberately span how contractors actually name work — a place, a customer, an address. That spread is itself the argument for one free-text name field rather than structured client/site inputs.

**3. Board UI** — a JOBS section with a `+`, and an alert collecting only a name.

## Decisions

- **Walk-first** (Isaac's call). START WALK stays instant and unblocked at the truck door; JOBS sits **below** today's walks. Jobs are where work accumulates, not a gate in front of recording it.
- **Only active jobs render.** Done/archived stay in the model and sync but are out of the daily view — ten live jobs is already a lot to scan.
- **An empty name is rejected, not coerced** (R6, enforced core-side). A job called "Untitled" looks deliberate and leaves the operator unable to tell which one it was meant to be.
- **The section header is `SectionHead`'s grammar composed inline**, not `SectionHead` itself. `SectionHead` draws its own full-width bottom rule, so putting the `+` beside it as a sibling shrank the head and **visibly truncated the rule** — caught on-sim, fixed, re-rendered.
- **30pt tap target around a 13pt glyph.** Gloved hands.

## Scope

Deliberately "jobs are visible and creatable." The card says **"NO WALKS YET" honestly** rather than faking a count, and is built as a *card* rather than a row because walks / documents / notes hang off it next.

**Next two slices**, both of which need more than UI:
- **Attach walks to jobs** — `begin_walk` already takes `job_id`; the walk-first flow means filing a walk *after* it finishes, so this needs a picker plus a way to re-file.
- **House documents on the card** — this is the one with a real design question. The PDF is currently rendered on demand and never persisted. I'd argue for **freezing the rendered PDF at send time** (bytes app-side like photos, metadata core-side): if the operator later edits their letterhead or a document type, regenerating produces a *different document than the customer received*. For "what did I actually send them," you need the frozen artifact.

## Verification

502 Rust tests (2 new), clippy clean, `BUILD SUCCEEDED`, and **rendered on-sim** via `autoprofile=1` — screenshot in the thread. "2 OPEN" with the seeded done-job correctly filtered out.