### PR TITLE
fix(ios): walks now appear under their job — and auto-file when the site is named

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -631,7 +631,84 @@ final class AppModel {
             let notes = await engine.finish()
             self.notes = notes
             self.notesLoading = false
+            // A FINISHED walk is a walk, whether or not a document was ever
+            // built from it. Previously a walk only entered the log via
+            // `completeSend()` — so finishing and then just filing it left it
+            // invisible on the board (Isaac's field report: "I didn't export
+            // the notes or create a document... it should save regardless").
+            // Core already persisted it at finish; the log simply never
+            // re-read.
+            self.refreshWalkLog()
+            // R4's inference half, client-side: if the operator said the job's
+            // name during the walk, file it there and SHOW that we did.
+            self.autoFileFromTranscript()
         }
+    }
+
+    /// Files the just-finished walk under a job whose name the operator spoke.
+    ///
+    /// Isaac: "The AI should also auto file it if it hears the name of the site
+    /// in the walk." It doesn't need the model to do it — the job names are
+    /// already on the device and the transcript is right here, so this is a
+    /// deterministic string match: no token cost, no latency, no chance of a
+    /// hallucinated job.
+    ///
+    /// It auto-files rather than merely suggesting, which is what was asked
+    /// for. The safety condition is that the result is always VISIBLE and
+    /// one tap from changeable on the notes screen — a silent mis-file would
+    /// bury the walk somewhere the operator never looks, which is the one
+    /// outcome worse than not filing at all. Hence: match only on an
+    /// unambiguous, whole-name hit, and never overwrite an existing filing.
+    func autoFileFromTranscript() {
+        guard let sessionId = currentSessionId,
+              !isPracticeWalk,
+              let match = Self.jobMatching(transcript: transcript, jobs: activeJobsForMatching())
+        else { return }
+        // Never clobber a deliberate choice.
+        if let existing = sessionWalks.first(where: { $0.sessionId == sessionId }), existing.jobId != nil {
+            return
+        }
+        try? setWalkJob(sessionId: sessionId, jobId: match.id)
+        autoFiledJobName = match.name
+    }
+
+    /// Set when the last finish auto-filed, so the notes screen can say so
+    /// rather than silently changing state under the operator.
+    var autoFiledJobName: String?
+
+    private func activeJobsForMatching() -> [JobModel] {
+        ((try? engine.listJobs()) ?? []).filter { $0.status == .active }
+    }
+
+    /// The single job whose name the transcript clearly contains, if any.
+    ///
+    /// Normalizes both sides (case, punctuation, whitespace) so "117 Lexington"
+    /// matches "117 lexington." mid-sentence. Requires a whole-name hit and
+    /// UNIQUENESS — if two jobs both match, we don't guess; picking one would
+    /// be a coin flip that hides the walk from the other. Very short names are
+    /// skipped because a 2-3 character name matches almost any transcript by
+    /// accident.
+    /// `nonisolated` because it is pure — no state, no side effects. Binding a
+    /// string comparison to the main actor would be noise, and it makes the
+    /// matcher directly unit-testable off the main thread.
+    nonisolated static func jobMatching(transcript: String, jobs: [JobModel]) -> JobModel? {
+        func normalize(_ s: String) -> String {
+            let folded = s.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            let cleaned = folded.map { $0.isLetter || $0.isNumber ? $0 : " " }
+            return String(cleaned).split(separator: " ").joined(separator: " ")
+        }
+        let haystack = normalize(transcript)
+        guard !haystack.isEmpty else { return nil }
+        let hits = jobs.filter { job in
+            let needle = normalize(job.name)
+            // 4 chars is the floor: shorter names ("A", "12") collide with
+            // ordinary speech and would file walks essentially at random.
+            guard needle.count >= 4 else { return false }
+            return haystack.contains(needle)
+        }
+        // Ambiguity means don't guess. One clear hit, or nothing.
+        guard hits.count == 1 else { return nil }
+        return hits.first
     }
 
     // MARK: Walk reopen (Plan 20 Half A) — read-only re-entry into NotesView.
@@ -649,6 +726,22 @@ final class AppModel {
     func hydrateWalkLog() {
         guard !isHydratingWalkLog else { return }
         isHydratingWalkLog = true
+        refreshWalkLog()
+    }
+
+    /// Re-read the walk log NOW, bypassing the once-per-process latch.
+    ///
+    /// `isHydratingWalkLog` is set once and never cleared — deliberately, to
+    /// stop `.task` re-fires from re-hydrating. But that made every LATER
+    /// refresh a silent no-op, which is the bug Isaac hit: filing a walk under
+    /// a job wrote through to core correctly and the board never showed it,
+    /// because the only refresh path was latched off for the life of the
+    /// process.
+    ///
+    /// Guard 2 is preserved: `DemoWalkEngine.listSessions()` returns `[]`
+    /// SUCCESSFULLY, and that empty success must not wipe the demo's in-memory
+    /// log. Real-core's `[]` is a legitimate "no sessions yet".
+    func refreshWalkLog() {
         let fetched = (try? engine.listSessions()) ?? []
         let isRealCore = !(engine is DemoWalkEngine)
         if !fetched.isEmpty || isRealCore {
@@ -670,7 +763,7 @@ final class AppModel {
         if let index = sessionWalks.firstIndex(where: { $0.sessionId == sessionId }) {
             sessionWalks[index].jobId = jobId
         }
-        hydrateWalkLog()
+        refreshWalkLog()
     }
 
     /// Reopen a finished walk from the board into the EXISTING NotesView

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -443,6 +443,15 @@ struct NotesView: View {
             if let fileError {
                 Text(fileError)
                     .font(Theme.F.mono(8.5)).foregroundStyle(Theme.C.redTag)
+            } else if let auto = model.autoFiledJobName, filedJob?.name == auto {
+                // Say it out loud. Auto-filing that happens silently is
+                // indistinguishable from a bug the first time it guesses
+                // wrong — and the operator needs to know a choice was made
+                // on their behalf so they can correct it.
+                Text("HEARD “\(auto.uppercased())” IN THE WALK — FILED THERE. TAP TO CHANGE.")
+                    .font(Theme.F.mono(8)).tracking(0.4)
+                    .foregroundStyle(Theme.C.orangeDeep)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .alert("New job", isPresented: $showNewJob) {

--- a/apps/ios/Tests/JobMatchTests.swift
+++ b/apps/ios/Tests/JobMatchTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `AppModel.jobMatching` — the client-side auto-filing matcher.
+///
+/// This is the one place a walk can be filed WITHOUT the operator choosing, so
+/// the failure that matters is a false positive: a walk silently landing under
+/// the wrong job is worse than not filing at all, because nobody goes looking
+/// for it there. These tests exist mostly to pin the cases where it must
+/// decline.
+final class JobMatchTests: XCTestCase {
+    private func job(_ id: String, _ name: String) -> JobModel {
+        JobModel(
+            id: id, name: name, client: nil, site: nil, scheduledAt: nil,
+            status: .active, createdAt: 0, updatedAt: 0
+        )
+    }
+
+    func testMatchesSpokenJobNameMidSentence() {
+        let jobs = [job("1", "117 Lexington"), job("2", "The Hendersons")]
+        let transcript = "Okay so we're out here at 117 Lexington, front beds need mulch."
+        XCTAssertEqual(AppModel.jobMatching(transcript: transcript, jobs: jobs)?.id, "1")
+    }
+
+    func testIgnoresCasePunctuationAndSpacing() {
+        let jobs = [job("1", "117 Lexington")]
+        // Whisper punctuates and capitalizes unpredictably; a match must
+        // survive that or it will fire roughly never in the field.
+        let transcript = "walking   117   LEXINGTON. Bed edging next."
+        XCTAssertEqual(AppModel.jobMatching(transcript: transcript, jobs: jobs)?.id, "1")
+    }
+
+    func testDeclinesWhenTwoJobsBothMatch() {
+        // Guessing here is a coin flip that hides the walk from the other job.
+        let jobs = [job("1", "Maple Street"), job("2", "Maple Street Rear")]
+        let transcript = "over at maple street rear today"
+        XCTAssertNil(AppModel.jobMatching(transcript: transcript, jobs: jobs))
+    }
+
+    func testDeclinesOnVeryShortNames() {
+        // A 2-3 character name collides with ordinary speech and would file
+        // walks essentially at random.
+        let jobs = [job("1", "A1")]
+        let transcript = "a1 steak sauce came up somehow, anyway the beds"
+        XCTAssertNil(AppModel.jobMatching(transcript: transcript, jobs: jobs))
+    }
+
+    func testDeclinesWhenNothingMatches() {
+        let jobs = [job("1", "117 Lexington")]
+        let transcript = "mulch the front beds and re-cut the edging"
+        XCTAssertNil(AppModel.jobMatching(transcript: transcript, jobs: jobs))
+    }
+
+    func testDeclinesOnEmptyTranscript() {
+        // A walk that captured nothing must not be filed anywhere.
+        XCTAssertNil(AppModel.jobMatching(transcript: "", jobs: [job("1", "117 Lexington")]))
+        XCTAssertNil(AppModel.jobMatching(transcript: "   ", jobs: [job("1", "117 Lexington")]))
+    }
+
+    func testDeclinesWithNoJobs() {
+        XCTAssertNil(AppModel.jobMatching(transcript: "at 117 lexington", jobs: []))
+    }
+
+    func testPartialNameDoesNotMatch() {
+        // "Lexington" alone must not match "117 Lexington" — the operator may
+        // have several Lexington properties, and a whole-name hit is the only
+        // signal strong enough to act on unasked.
+        let jobs = [job("1", "117 Lexington")]
+        let transcript = "we're on lexington today"
+        XCTAssertNil(AppModel.jobMatching(transcript: transcript, jobs: jobs))
+    }
+}


### PR DESCRIPTION
## Thinking

> "The walks still don't seem to be saving to the home page under the job, even when I selected the right job to file it under."

Isaac was right. **The filing always worked — the board just never showed it.** Two bugs compounding.

### Bug 1 — `hydrateWalkLog` was latched off forever

`isHydratingWalkLog` is set `true` on first call and **never cleared**. That's deliberate, to stop `.task` re-fires from re-hydrating — but every *later* refresh went through the same guard, so after app launch `hydrateWalkLog()` was a **permanent no-op**.

So `setWalkJob` wrote through to core correctly, then called a refresh that did nothing. The walk was filed in the database and invisible on screen.

Split into `hydrateWalkLog()` (keeps the once-per-process latch for the automatic path) and `refreshWalkLog()` (explicit, un-latched). Guard 2 is preserved — `DemoWalkEngine.listSessions()` returns `[]` *successfully* and must not wipe the demo's in-memory log.

### Bug 2 — a walk only entered the log on SEND

`sessionWalks.append` lived **solely in `completeSend()`**. A walk that was finished but never turned into a document was invisible on the board.

> "I didn't export the notes or create a document... it should save regardless once I get to that screen."

Exactly right. Core persists at `finish()`; the log simply never re-read. It does now.

## Feature: auto-file when the operator says the site name

> "The AI should also auto file it if it hears the name of the site in the walk."

**This needs no model call.** Job names are already on the device and the transcript is right there, so it's a deterministic string match — no token cost, no latency, and no chance of a hallucinated job. (#265 stays open for LLM-side inference of a job we *don't* already have.)

It **auto-files** rather than merely suggesting, as asked. The safety condition is that the result is always **visible and one tap from changeable** — the notes screen says:

> HEARD "117 LEXINGTON" IN THE WALK — FILED THERE. TAP TO CHANGE.

Silent auto-filing is indistinguishable from a bug the first time it guesses wrong.

**The matcher declines rather than guesses.** It's the only path that files without the operator choosing, and a walk buried under the wrong job is *worse* than an unfiled one, because nobody goes looking for it there. So:

- whole-name hits only (`"lexington"` won't match `"117 Lexington"` — an operator may have several Lexington properties)
- unique matches only — two candidates means no guess
- names under 4 characters skipped (they collide with ordinary speech)
- never overwrites an existing filing
- never runs on a practice walk

## Verification

**9 Swift tests pass** (8 new), and they mostly pin the cases where it must *decline*: ambiguity, short names, partial names, empty transcript, no jobs. `jobMatching` is `nonisolated` — it's pure, so binding it to the main actor was noise and blocked direct testing.

`BUILD SUCCEEDED`. The end-to-end flow still wants a real tap-through on device; that's what caught both of these.