### PR TITLE
fix(ios): a finished walk no longer says "DISCARDED"

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -63,6 +63,29 @@ final class AppModel {
         let sessionId: String
         /// Mirror of `NotesModel.queued` for the reopened-notes gating banner.
         let queued: Bool
+        /// What actually happened to this walk, for the board label.
+        ///
+        /// `sent` alone was a two-state guess derived from `hasDocument`, so a
+        /// walk that was finished but never turned into a document rendered as
+        /// "DISCARDED" at 55% opacity — actively alarming, and wrong: NOTHING
+        /// in WalkSummary records a discard. Now that a finished walk enters
+        /// the log immediately (it used to appear only on send), that mislabel
+        /// would have been the first thing an operator saw after every walk.
+        enum Disposition {
+            /// Processing hasn't finished — notes aren't readable yet.
+            case saving
+            /// Notes are saved. No document was built, which is a perfectly
+            /// ordinary end state, not a failure.
+            case saved
+            /// A document exists for this walk.
+            case documented
+        }
+
+        var disposition: Disposition {
+            if queued { return .saving }
+            return sent ? .documented : .saved
+        }
+
         /// The job this walk is filed under; nil = unfiled. Set AFTER the walk
         /// (R4: no pre-labeling), and re-settable — a walk filed to the wrong
         /// job months ago has to be movable.

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -628,10 +628,7 @@ private struct WalkLogRow<Trailing: View>: View {
                             .lineLimit(1)
                     }
                     Spacer(minLength: 8)
-                    FieldTag(tag: TagFixture(
-                        kind: walk.sent ? .green : .plain,
-                        label: walk.sent ? "SENT" : "DISCARDED"
-                    ))
+                    FieldTag(tag: walkTag(walk))
                 }
                 .contentShape(Rectangle())
             }
@@ -642,8 +639,20 @@ private struct WalkLogRow<Trailing: View>: View {
         .padding(.leading, Theme.S.screenPad)
         .padding(.trailing, Theme.S.screenPad - 6)
         .padding(.vertical, 13)
-        .opacity(walk.sent ? 1 : 0.55)
+        // No dimming. A walk with no document is a normal, complete walk —
+        // fading it implied "lesser" or "dead" and made a saved walk look lost.
         .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
+    }
+}
+
+/// Honest disposition label. "DISCARDED" is deliberately gone: nothing in
+/// WalkSummary records a discard, so it was always a guess — and the guess was
+/// wrong for the common case of finishing a walk without building a document.
+private func walkTag(_ walk: AppModel.WalkRecord) -> TagFixture {
+    switch walk.disposition {
+    case .saving:     return TagFixture(kind: .yellow, label: "SAVING")
+    case .saved:      return TagFixture(kind: .plain, label: "NOTES SAVED")
+    case .documented: return TagFixture(kind: .green, label: "SENT")
     }
 }
 


### PR DESCRIPTION
## Thinking

Fallout from #268 that would have been the **first thing seen after every walk**.

The board label was a two-state guess derived from `hasDocument`: document → "SENT", otherwise → **"DISCARDED" at 55% opacity**. Nothing in `WalkSummary` records a discard, so that was always wrong — it was just nearly invisible, because a walk only entered the log via `completeSend()` and therefore almost always had a document.

#268 made a *finished* walk appear immediately, which is correct and what Isaac asked for. It also meant the common new case — finish a walk, file it, don't build a document — rendered as a greyed-out **"DISCARDED"**.

For someone who had just reported *"the walks don't seem to be saving,"* that label would have confirmed the fear about a walk that was, in fact, saved. Worth fixing before it's seen.

## Three honest states instead of two guessed ones

| Disposition | Label | Meaning |
|---|---|---|
| `saving` | SAVING | Queued; notes not readable yet |
| `saved` | NOTES SAVED | No document — an ordinary end state |
| `documented` | SENT | A document exists |

Dimming is gone too. Fading a walk with no document implied lesser-or-dead; a walk whose notes are saved is complete.

## Verification

9 Swift tests pass, `BUILD SUCCEEDED`.

## Unrelated snag worth recording

`xcodegen` globs `Sources/Resources`, so a previously-generated project can hold a dangling reference to the **gitignored** whisper model and fail the build with `ggml-small.en-q5_1.bin couldn't be opened`. Re-running `xcodegen generate` clears it — the app already degrades to text-only when no model is bundled. Noting it because it looks like a broken checkout and isn't.