### PR TITLE
ci(release): pass the proxy settings to the archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,8 @@ jobs:
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           PPQ_API_KEY: ${{ secrets.PPQ_API_KEY }}
+          JEFE_PROXY_URL: ${{ vars.JEFE_PROXY_URL }}
+          JEFE_APP_SECRET: ${{ secrets.JEFE_APP_SECRET }}
           MARKETING_VERSION_OVERRIDE: ${{ steps.version.outputs.marketing_version }}
         run: |
           if [ -z "$APPLE_TEAM_ID" ]; then
@@ -273,6 +275,21 @@ jobs:
             "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
             "CURRENT_PROJECT_VERSION=${{ github.run_number }}"
             "PPQ_API_KEY=$PPQ_API_KEY"
+            # The proxy (services/proxy). When BOTH are non-empty the app
+            # routes through it and NO Anthropic key is present in the build —
+            # which is the point: a key in Info.plist is extractable from any
+            # downloaded IPA (EngineResolution.swift resolveCredential()).
+            #
+            # SAFE WHEN UNSET: absent secrets expand to empty strings, the app
+            # falls through to the direct-key path, and the build behaves
+            # exactly as it does today. So this can land before the secrets
+            # exist without changing a single shipped build.
+            #
+            # JEFE_PROXY_URL is a plain var (a URL is not a secret); the app
+            # secret is a repo secret. Both must be set together — a URL
+            # without the secret is rejected by the proxy on every call.
+            "JEFE_PROXY_URL=$JEFE_PROXY_URL"
+            "JEFE_APP_SECRET=$JEFE_APP_SECRET"
             # NO ANTHROPIC_BASE_URL override: the key in the PPQ_API_KEY secret
             # is a direct Anthropic key (sk-ant-…), verified live against
             # api.anthropic.com and REJECTED (401) by api.ppq.ai. Builds #24–#32


### PR DESCRIPTION
## Thinking

**The last mechanical step before the App Store blocker is actually closed.**

The proxy is deployed and verified. The app knows how to use it (#262). But **no shipped build has ever engaged it** — `release.yml` never passed the two settings, so every TestFlight build including 68 still falls back to the baked key. The blocker is closed in principle and open in practice.

## Safe to land before the secrets exist

Absent secrets expand to empty strings, `resolveCredential()` falls through to the direct-key path, and the build behaves **exactly as it does today**. Nothing changes until both values are set — so this can merge now without altering a single shipped build.

`JEFE_PROXY_URL` is a repo **variable** (a URL isn't a secret); `JEFE_APP_SECRET` is a repo **secret**. They must be set together — a URL without the secret is rejected by the proxy on every call, which is precisely why the app requires both before choosing the proxy path.

## To arm it

**Settings → Secrets and variables → Actions**

- **Variables:** `JEFE_PROXY_URL` = `https://jefe-proxy.damsac-app.workers.dev`
- **Secrets:** `JEFE_APP_SECRET` = the value in `services/proxy/.dev.vars`

The next build after that is **the first one with no Anthropic key inside it**.

## What this does and doesn't close

It closes key **custody**. It does **not** close caller **authentication** — the proxy is still guarded by a secret extractable from any downloaded IPA, and the $25/day global and $2/day per-install caps are what actually bound the loss.

**App Attest (Phase 2) is still required before the listing goes public.** See `services/proxy/README.md` and the v1 design doc §4.5.1.

## Verification

Indentation verified against sibling entries in both insertion points (the `env:` block and the `BUILD_SETTINGS` array) — a malformed workflow would break the release lane, and `pyyaml` isn't available locally to parse it outright.