### PR TITLE
fix(ios): scope the auto-file message to its own walk

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -692,12 +692,20 @@ final class AppModel {
             return
         }
         try? setWalkJob(sessionId: sessionId, jobId: match.id)
-        autoFiledJobName = match.name
+        autoFiled = (sessionId: sessionId, jobName: match.name)
     }
 
-    /// Set when the last finish auto-filed, so the notes screen can say so
-    /// rather than silently changing state under the operator.
-    var autoFiledJobName: String?
+    /// Set when a finish auto-filed, so the notes screen can say so rather
+    /// than silently changing state under the operator.
+    ///
+    /// SESSION-SCOPED, not a bare name. A bare name never went stale on its
+    /// own and the view's "does it match the current filing?" check let a
+    /// false positive through: auto-file walk A to a job, then MANUALLY file
+    /// walk B to that same job, and the notes screen would claim it heard the
+    /// name in walk B. Claiming to have heard something we didn't is exactly
+    /// the failure this message exists to prevent, so the id is carried and
+    /// compared instead of hoping a reset fires everywhere.
+    var autoFiled: (sessionId: String, jobName: String)?
 
     private func activeJobsForMatching() -> [JobModel] {
         ((try? engine.listJobs()) ?? []).filter { $0.status == .active }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -443,12 +443,14 @@ struct NotesView: View {
             if let fileError {
                 Text(fileError)
                     .font(Theme.F.mono(8.5)).foregroundStyle(Theme.C.redTag)
-            } else if let auto = model.autoFiledJobName, filedJob?.name == auto {
+            } else if let auto = model.autoFiled,
+                      auto.sessionId == model.currentSessionId,
+                      filedJob?.name == auto.jobName {
                 // Say it out loud. Auto-filing that happens silently is
                 // indistinguishable from a bug the first time it guesses
                 // wrong — and the operator needs to know a choice was made
                 // on their behalf so they can correct it.
-                Text("HEARD “\(auto.uppercased())” IN THE WALK — FILED THERE. TAP TO CHANGE.")
+                Text("HEARD “\(auto.jobName.uppercased())” IN THE WALK — FILED THERE. TAP TO CHANGE.")
                     .font(Theme.F.mono(8)).tracking(0.4)
                     .foregroundStyle(Theme.C.orangeDeep)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Thinking

Self-review catch on #268 — **same class as the two bugs real use found**: state that only misbehaves on a *second* action.

`autoFiledJobName` was a bare `String`, set once and never cleared. The view guarded it with "does it match the current filing?", which let a false positive through:

1. Finish walk A → auto-files to "117 Lexington", name is stored
2. Finish walk B → nothing heard, no auto-file
3. **Manually** file walk B to 117 Lexington
4. Notes screen: **HEARD "117 LEXINGTON" IN THE WALK — FILED THERE**

It didn't hear it. The operator chose it.

A message whose entire purpose is being **honest about automatic behavior** would be lying — and precisely where trust in the feature gets decided, the first time someone checks whether it really heard them. Reopening an old walk had the same hole.

## Fix

Carry the `sessionId` alongside the name and compare it, rather than relying on a reset firing on every path that starts or reopens a walk. Resets are the kind of thing that gets forgotten when a new entry path is added; a scoped value can't go stale on its own.

## Verification

9 Swift tests pass, `BUILD SUCCEEDED`.