### PR TITLE
fix(ios): date walks on the job card — "9:41" is useless months later

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -86,14 +86,22 @@ final class AppModel {
             return sent ? .documented : .saved
         }
 
+        /// Raw start time. Kept alongside the formatted `time` because the
+        /// TODAY list wants a clock ("9:41") while a job card spanning months
+        /// needs a date — and "9:41" on a walk from March is useless for the
+        /// case jobs exist to serve.
+        let startedAt: UInt64
+
         /// The job this walk is filed under; nil = unfiled. Set AFTER the walk
         /// (R4: no pre-labeling), and re-settable — a walk filed to the wrong
         /// job months ago has to be movable.
         var jobId: String?
 
         init(time: String, docNo: String, docKind: String, sent: Bool,
-             sessionId: String, queued: Bool, jobId: String? = nil) {
+             sessionId: String, queued: Bool, jobId: String? = nil,
+             startedAt: UInt64 = 0) {
             self.jobId = jobId
+            self.startedAt = startedAt
             self.time = time
             self.docNo = docNo
             self.docKind = docKind
@@ -116,6 +124,7 @@ final class AppModel {
             self.sessionId = summary.id
             self.queued = summary.queued
             self.jobId = summary.jobId
+            self.startedAt = summary.startedAt
         }
     }
     private(set) var sessionWalks: [WalkRecord] = []
@@ -1087,6 +1096,26 @@ final class AppModel {
     /// path's counterpart of `clockNow()` (Plan 20 F7 mapping). `nonisolated`:
     /// pure value formatting, callable from `WalkRecord.init` (a nonisolated
     /// struct initializer).
+    /// Date-aware label for a walk in a job card, where the list can span
+    /// months. Today collapses to a clock time (a date would be noise for
+    /// something that just happened); this year drops the year; anything older
+    /// carries it.
+    nonisolated static func walkDateLabel(epochSeconds: UInt64, now: Date = Date()) -> String {
+        guard epochSeconds > 0 else { return "" }
+        let date = Date(timeIntervalSince1970: TimeInterval(epochSeconds))
+        let cal = Calendar.current
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        if cal.isDate(date, inSameDayAs: now) {
+            formatter.dateFormat = "h:mm a"
+        } else if cal.component(.year, from: date) == cal.component(.year, from: now) {
+            formatter.dateFormat = "MMM d"
+        } else {
+            formatter.dateFormat = "MMM d yyyy"
+        }
+        return formatter.string(from: date).uppercased()
+    }
+
     fileprivate nonisolated static func clockTime(epochSeconds: UInt64) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -410,7 +410,7 @@ private struct OperatorJobCard: View {
                         Rectangle()
                             .fill(Theme.C.hairline)
                             .frame(width: 1, height: 13)
-                        Text(walk.time)
+                        Text(AppModel.walkDateLabel(epochSeconds: walk.startedAt))
                             .font(Theme.F.mono(9.5))
                             .foregroundStyle(Theme.C.ink60)
                         Text(walk.docKind)

--- a/apps/ios/Tests/JobMatchTests.swift
+++ b/apps/ios/Tests/JobMatchTests.swift
@@ -71,3 +71,74 @@ final class JobMatchTests: XCTestCase {
         XCTAssertNil(AppModel.jobMatching(transcript: transcript, jobs: jobs))
     }
 }
+
+/// Gates on `AppModel.walkDateLabel` — the job-card timestamp.
+///
+/// Jobs exist so an operator can answer "what happened here?" months later, so
+/// a walk from March showing a bare "9:41" defeats the feature. These pin the
+/// three branches and the boundaries between them.
+final class WalkDateLabelTests: XCTestCase {
+    private func epoch(_ iso: String) -> UInt64 {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return UInt64(f.date(from: iso)!.timeIntervalSince1970)
+    }
+    private func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: iso)!
+    }
+
+    func testTodayShowsAClockTime() {
+        // A date on something that happened an hour ago is noise.
+        let label = AppModel.walkDateLabel(
+            epochSeconds: epoch("2026-07-27T09:41:00Z"),
+            now: date("2026-07-27T18:00:00Z")
+        )
+        XCTAssertTrue(label.contains(":"), "expected a clock time, got \(label)")
+    }
+
+    func testEarlierThisYearShowsMonthAndDayWithoutYear() {
+        let label = AppModel.walkDateLabel(
+            epochSeconds: epoch("2026-03-14T09:41:00Z"),
+            now: date("2026-07-27T18:00:00Z")
+        )
+        XCTAssertTrue(label.contains("MAR"), "expected a month, got \(label)")
+        XCTAssertFalse(label.contains("2026"), "same year shouldn't repeat the year: \(label)")
+    }
+
+    func testPriorYearCarriesTheYear() {
+        // The "email months later" case — without a year this is ambiguous.
+        let label = AppModel.walkDateLabel(
+            epochSeconds: epoch("2025-11-02T09:41:00Z"),
+            now: date("2026-07-27T18:00:00Z")
+        )
+        XCTAssertTrue(label.contains("2025"), "expected the year, got \(label)")
+    }
+
+    func testYesterdayIsNotTreatedAsToday() {
+        // Guards the same-day check against being a naive 24-hour window.
+        //
+        // Built through Calendar rather than fixed UTC instants: the label uses
+        // `isDate(_:inSameDayAs:)`, which is LOCAL-time based, so a UTC pair
+        // straddling midnight-Z can still be the same local day. An earlier
+        // version of this test asserted exactly that and failed against
+        // correct code.
+        let cal = Calendar.current
+        let now = date("2026-07-27T18:00:00Z")
+        let yesterdayEvening = cal.date(byAdding: .hour, value: -6, to: cal.startOfDay(for: now))!
+        let label = AppModel.walkDateLabel(
+            epochSeconds: UInt64(yesterdayEvening.timeIntervalSince1970),
+            now: now
+        )
+        XCTAssertFalse(
+            label.contains(":"),
+            "yesterday must render as a date, not a clock time — got \(label)"
+        )
+    }
+
+    func testMissingTimestampRendersEmptyNotEpochZero() {
+        // Legacy/demo rows carry 0; "JAN 1 1970" would be worse than nothing.
+        XCTAssertEqual(AppModel.walkDateLabel(epochSeconds: 0), "")
+    }
+}


### PR DESCRIPTION
## Thinking

Jobs exist so an operator can answer *"what happened here?"* long after the fact — Isaac's framing was **an email arriving months later**. But a job card listing a walk from March and one from June showed **both as bare clock times**: `WalkRecord` only carried `time`, formatted `"h:mm"`, and the epoch was discarded.

Two walks on one card were literally indistinguishable by date. That defeats the feature's stated purpose, and it's the kind of thing that only shows up once a job actually accumulates history — which no test account has yet.

## Fix

`WalkRecord` keeps `startedAt`, and the job card renders a date-aware label:

| When | Renders |
|---|---|
| Today | `9:41 AM` — a date on something an hour old is noise |
| Earlier this year | `MAR 14` |
| Prior year | `NOV 2 2025` |

The TODAY list still shows clock times, which is correct — everything in it is from today.

Epoch `0` renders **empty** rather than `JAN 1 1970`: legacy and demo rows carry 0, and a wrong date is worse than none.

## A test that was wrong, not the code

One of the 5 new tests initially **failed against correct code**. It asserted that `2026-07-26T23:00Z` and `2026-07-27T01:00Z` are different days — but the label uses `isDate(_:inSameDayAs:)`, which is **local-time** based, so that UTC pair is the *same local day* in most timezones.

The test now builds its dates through `Calendar` so it means what it says anywhere, and the reasoning is in a comment so nobody later "fixes" the code to satisfy a bad test.

## Verification

14 Swift tests pass, `BUILD SUCCEEDED`.