### PR TITLE
fix(ios): custom document types build, and the board scrolls

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -891,7 +891,14 @@ final class AppModel {
             } catch {
                 Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "document")
                     .error("buildDocument(\(kind, privacy: .public)) failed: \(error, privacy: .public)")
-                self.documentBuildError = "Couldn’t build the \(DocKinds.label(for: kind).lowercased()) — tap to try again."
+                // Carry the REAL reason. The old message said "couldn't build
+                // the report" for ANY custom kind (DocKinds.label falls through
+                // to "Report" for anything it doesn't hardcode), so a failure on
+                // a custom document type named itself after the wrong document
+                // and explained nothing. Isaac tapped a custom button and got
+                // no usable signal at all.
+                self.documentBuildError =
+                    "Couldn’t build it — \(error.localizedDescription)"
             }
         }
     }

--- a/apps/ios/Sources/Engine/DocumentSchemaModel.swift
+++ b/apps/ios/Sources/Engine/DocumentSchemaModel.swift
@@ -97,6 +97,11 @@ struct DocumentSchemaModel: Identifiable, Hashable {
     var totalLabelKey: String
     var sections: [SchemaSectionModel]
     var schemaVersion: UInt32
+    /// Core stamps this on every save. Needed app-side because core resolves
+    /// `buildDocument(kind:)` with `ORDER BY updated_at DESC LIMIT 1` — so when
+    /// two schemas share a kind, this is what decides which one actually gets
+    /// built, and the UI has to agree or it lies about what a button will do.
+    var updatedAt: UInt64
 
     /// Built-ins ship seeded from core and carry the sentinel device id.
     /// Surfaced so the editor can steer toward "duplicate" rather than
@@ -113,8 +118,10 @@ struct DocumentSchemaModel: Identifiable, Hashable {
         totalLabelKey: String = "total",
         sections: [SchemaSectionModel] = [],
         schemaVersion: UInt32 = 1,
+        updatedAt: UInt64 = 0,
         isBuiltin: Bool = false
     ) {
+        self.updatedAt = updatedAt
         self.id = id
         self.kind = kind
         self.label = label

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -450,6 +450,7 @@ final class MurmurEngine: WalkEngine {
                 )
             },
             schemaVersion: s.schemaVersion,
+            updatedAt: s.updatedAt,
             isBuiltin: s.deviceId == builtinDeviceId
         )
     }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -19,6 +19,11 @@ struct BoardView: View {
     @State private var jobsError: String?
     @State private var showNewJob = false
     @State private var newJobName = ""
+    /// TODAY collapses so JOBS clears the fold. Expanding shows the rest.
+    @State private var showAllWalks = false
+    /// Enough to see today's work at a glance without pushing jobs off
+    /// screen — the complaint that prompted this.
+    private static let collapsedWalkCount = 3
 
     var body: some View {
         VStack(spacing: 0) {
@@ -125,7 +130,14 @@ struct BoardView: View {
                 .padding(.bottom, 10)
             }
 
-            if model.profile != nil {
+            // The board had NO ScrollView: a plain VStack that simply ran out
+            // of room, which is why jobs ended up crammed against the bottom
+            // (Isaac). Header and START WALK stay pinned — the button is the
+            // one control that must never require scrolling to reach — and
+            // everything between them scrolls.
+            ScrollView {
+              VStack(spacing: 0) {
+                if model.profile != nil {
                 // Operator mode: no fixture crew/sync strip, no fixture jobs.
                 // The board logs the walks actually finished this session.
                 SectionHead(
@@ -155,7 +167,7 @@ struct BoardView: View {
                     // Plan 20 D5: rows are tappable — reopen the walk's notes.
                     // // sac: the reopen affordance visuals (chevron? row
                     // // sac: press state?) + the reopened banner are yours.
-                    ForEach(model.sessionWalks) { walk in
+                    ForEach(visibleWalks) { walk in
                         WalkLogRow(walk: walk) {
                             model.reopenWalk(sessionId: walk.sessionId)
                         } trailing: {
@@ -164,6 +176,25 @@ struct BoardView: View {
                             }
                         }
                     }
+                    if model.sessionWalks.count > Self.collapsedWalkCount {
+                        Button { showAllWalks.toggle() } label: {
+                            Text(showAllWalks
+                                 ? "SHOW LESS"
+                                 : "SHOW ALL \(model.sessionWalks.count) WALKS")
+                                .font(Theme.F.mono(8.5, .semibold))
+                                .tracking(1.0)
+                                .foregroundStyle(Theme.C.orangeDeep)
+                                .padding(.horizontal, Theme.S.screenPad)
+                                .padding(.vertical, 9)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .overlay(alignment: .bottom) {
+                            Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
+                        }
+                    }
+
                     if let reopenError = model.reopenError {
                         // F4 floor: the breadcrumb surfaces; chrome is sac's.
                         Text(reopenError.uppercased())
@@ -194,7 +225,9 @@ struct BoardView: View {
                 }
             }
 
-            Spacer(minLength: 0)
+              }
+            }
+            .scrollBounceBehavior(.basedOnSize)
 
             // First-run coach mark: point a brand-new operator at the one thing
             // to do. Only on a fresh board (profile set, no walks yet); the
@@ -328,6 +361,13 @@ extension BoardView {
     }
 
     var activeJobs: [JobModel] { operatorJobs.filter { $0.status == .active } }
+
+    /// Today's walks, capped until expanded.
+    var visibleWalks: [AppModel.WalkRecord] {
+        showAllWalks
+            ? model.sessionWalks
+            : Array(model.sessionWalks.prefix(Self.collapsedWalkCount))
+    }
 
     func loadJobs() {
         do {

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -260,6 +260,29 @@ private struct SchemaEditor: View {
 
     private var problem: String? { SchemaValidation.firstProblem(in: draft) }
 
+    /// What actually gets sent to `save_document_schema`.
+    ///
+    /// `save` upserts BY ID, so sending a built-in's id back overwrites the
+    /// built-in in place — while this screen promised "saving creates your own
+    /// copy, the default stays available." That was simply false, and it took
+    /// the shipped default with it.
+    ///
+    /// Clearing the id makes core mint a new one, so the copy is real. If the
+    /// operator also renamed it, the kind is re-derived: a built-in keeps its
+    /// kind frozen (that is what `buildDocument` resolves against), but a
+    /// RENAMED copy is a different document type and must not keep answering
+    /// to "estimate" — otherwise a button labelled RFP builds an estimate.
+    private func saveShape(of draft: DocumentSchemaModel) -> DocumentSchemaModel {
+        guard draft.isBuiltin else { return draft }
+        var copy = draft
+        copy.id = ""            // create, don't overwrite the shipped default
+        copy.isBuiltin = false
+        if draft.label != original.label {
+            copy.kind = Self.slug(draft.label)
+        }
+        return copy
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             editorBar
@@ -283,7 +306,7 @@ private struct SchemaEditor: View {
                 .font(Theme.F.mono(11, .semibold))
                 .foregroundStyle(Theme.C.ink60)
             Spacer()
-            Button("SAVE") { onSave(draft) }
+            Button("SAVE") { onSave(saveShape(of: draft)) }
                 .font(Theme.F.mono(11, .semibold))
                 .foregroundStyle(problem == nil ? Theme.C.orangeDeep : Theme.C.ink35)
                 .disabled(problem != nil)
@@ -310,8 +333,8 @@ private struct SchemaEditor: View {
 
     private var builtinNote: some View {
         Text(
-            "This is a default document type. Saving changes creates your own copy — "
-                + "the default stays available."
+            "This is a default document type. Saving makes your own copy — the "
+                + "original stays. Rename it and it becomes a new kind of document."
         )
         .font(Theme.F.ui(13, .regular))
         .foregroundStyle(Theme.C.ink60)

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -69,9 +69,21 @@ struct NotesView: View {
                 DocChoice(kind: $0, label: DocKinds.label(for: $0), stamp: DocKinds.stamp(for: $0))
             }
         } else {
-            // The schema's own label/prefix, so a custom type reads as the
-            // operator named it rather than falling through to "Report".
-            docChoices = schemas.map {
+            // ONE button per KIND, choosing the same schema core will.
+            //
+            // `buildDocument(kind:)` resolves with ORDER BY updated_at DESC
+            // LIMIT 1, so when two schemas share a kind — which happens the
+            // moment someone customizes a built-in — exactly one of them gets
+            // built. Showing both would put two buttons on screen where one is
+            // dead, and (before this) they collided as ForEach ids, which is
+            // undefined behaviour in SwiftUI and can swallow taps outright.
+            //
+            // Mirroring the resolver here means the button's label always
+            // describes the document that will actually come out.
+            let winners = Dictionary(grouping: schemas, by: \.kind)
+                .compactMap { _, group in group.max(by: { $0.updatedAt < $1.updatedAt }) }
+                .sorted { $0.label < $1.label }
+            docChoices = winners.map {
                 DocChoice(kind: $0.kind, label: $0.label, stamp: $0.numberPrefix.uppercased())
             }
         }


### PR DESCRIPTION
## 1. "I tried to click the RFP button which is a custom document, and it didn't do anything"

**Three defects behind that, all mine.**

**a) Saving a built-in *overwrote* it.** `save_document_schema` upserts by id, and the editor sent the built-in's id straight back — while the screen promised *"saving creates your own copy, the default stays available."* That was **false**, and it took the shipped default with it. The id is now cleared on save so core mints a new row: the copy is real.

**b) A renamed copy kept the original's `kind`.** `kind` freezes after first save on purpose — it's what `buildDocument` resolves against, so renaming mustn't orphan existing documents. But a *renamed copy of a built-in* is a different document type. Estimate renamed to "RFP" stayed `kind="estimate"`, so **a button labelled RFP built an estimate**. A renamed copy now re-derives its kind.

**c) Two schemas sharing a kind produced two buttons and duplicate `ForEach` ids** — undefined behaviour in SwiftUI, and it can swallow taps outright. Core resolves with `ORDER BY updated_at DESC LIMIT 1`, so only one was ever going to build anyway. The notes screen now **mirrors that resolver**: one button per kind, the same schema core would pick, so a button's label always describes the document that actually comes out. Required threading `updatedAt` onto the app-side model.

**Plus: the failure message was useless.** It said *"couldn't build the report"* for **any** custom kind, because `DocKinds.label` falls through to "Report" for anything it doesn't hardcode. It now carries the real error. Isaac got no usable signal at all — whatever fails next should say why.

## 2. "The jobs are crammed all the way at the bottom"

**The board had no `ScrollView`** — a plain `VStack` that simply ran out of room. With ten live jobs it would have been unusable, and no amount of collapsing would have fixed the underlying structure.

Header and START WALK are now **pinned** (the button must never require scrolling to reach); everything between them scrolls.

TODAY also **collapses to 3 walks** with SHOW ALL, so jobs clear the fold without scrolling in the common case. Isaac suggested 5 — 3 is what actually keeps jobs visible on a small phone, and the constant is one line if that's wrong.

## Verification

14 Swift tests pass, `BUILD SUCCEEDED`, board rendered on-sim.

The custom-document path itself still wants a real tap-through — it needs a saved custom schema and a finished walk, which `simctl` can't stage. That's the same gap that let all three of these ship.