### PR TITLE
feat(ios): Jefe Pro — StoreKit 2, the free-tier meter, and the privacy manifest

### DIFF
--- a/apps/ios/Jefe.storekit
+++ b/apps/ios/Jefe.storekit
@@ -1,0 +1,56 @@
+{
+  "identifier" : "A1F2C4E8",
+  "nonRenewingSubscriptions" : [
+  ],
+  "products" : [
+  ],
+  "settings" : {
+    "_applicationInternalID" : "jefe",
+    "_developerTeamID" : "98GXNZ6NKZ",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 0,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+    ]
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "21456789",
+      "localizations" : [
+      ],
+      "name" : "Jefe",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+          ],
+          "codeOffers" : [
+          ],
+          "displayPrice" : "12.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "31456789",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Unlimited walks. Talk through as many jobs as you want and Jefe writes up the paperwork.",
+              "displayName" : "Jefe Pro",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.damsac.jefe.pro.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Jefe Pro Monthly",
+          "subscriptionGroupID" : "21456789",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+          ]
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -134,6 +134,26 @@ final class AppModel {
     }
     private(set) var sessionWalks: [WalkRecord] = []
 
+    // MARK: Billing
+
+    /// Jefe Pro entitlement. Owned by the model so every gate reads one answer;
+    /// `GalleryApp` kicks off `start()` at launch.
+    let entitlement = Entitlement()
+
+    /// Drives the paywall sheet. Set only by `startWalk()` refusing, and by the
+    /// explicit "upgrade" affordances — never by a background event, so the
+    /// paywall can't appear over a walk in progress.
+    var showPaywall = false
+
+    /// Usage at the moment the gate refused, so the paywall can say "you've used
+    /// all 5 of this month's walks" instead of a generic upsell. Nil until a
+    /// refusal.
+    var blockedUsage: (used: Int, limit: Int)?
+
+    /// Free walks left AFTER the one just started; nil for Pro. Read by the
+    /// notes screen to nudge at the end of a walk rather than the start.
+    var walksRemainingAfterThis: Int?
+
     // Walk state
     var transcript = ""
     /// Volatile greyed preview tail from the Rust STT pump (Plan 08 D4) — the
@@ -385,7 +405,34 @@ final class AppModel {
     /// that can't hear must never begin (same posture as throwing begin()).
     /// Returns immediately when already authorized; first-ever tap shows the
     /// system prompt. Denied → `micDenied` surfaces on the board.
+    ///
+    /// The free-tier meter gates here too, and for the same reason: both are
+    /// conditions that must be settled BEFORE the operator starts talking.
+    /// Refusing at finish would destroy a recording they had already made.
     func startWalk() {
+        // Two exemptions, both principled rather than convenient.
+        //
+        // Practice walks: they run on a throwaway engine, are never saved, and
+        // are part of onboarding. Charging someone a walk to learn how the app
+        // works — or blocking the tutorial at the limit — would be indefensible.
+        //
+        // Demo mode: the scripted DemoWalkEngine makes no model calls at all, so
+        // it costs nothing, and the free tier exists to bound cost. It is also
+        // dev-only (`demo=1`), and metering it would break the multi-round
+        // autoflow QA runs at walk six.
+        if !isPracticeWalk && walkMode != .demo {
+            switch WalkAllowance.decide(isPro: entitlement.isPro, record: WalkMeter.load(), now: Date()) {
+            case .blocked(let used, let limit):
+                blockedUsage = (used: used, limit: limit)
+                showPaywall = true
+                return
+            case .allowed(let remaining):
+                // Surfaced on the notes screen after the walk, not now: a
+                // countdown on the START button would make every walk feel
+                // rationed. `nil` = Pro, never counted.
+                walksRemainingAfterThis = remaining
+            }
+        }
         if walkMode == .voice && !wavFixture && !isPracticeWalk {
             Task { [weak self] in
                 guard let self else { return }
@@ -647,6 +694,9 @@ final class AppModel {
     var notesLoading = false
 
     func finishWalk() {
+        // Captured BEFORE the async work: a practice walk must never be metered,
+        // and `isPracticeWalk` is cleared by the exit paths that may run first.
+        let metered = !isPracticeWalk && walkMode != .demo
         keepScreenAwake(false)   // recording's done — let the phone sleep normally
         source?.stop()
         audioSource?.stop()
@@ -668,6 +718,14 @@ final class AppModel {
             let notes = await engine.finish()
             self.notes = notes
             self.notesLoading = false
+            // Metered on OUTPUT, not on tapping START: the count moves only
+            // once a walk has actually produced notes. Someone who starts a
+            // walk, realizes they're at the wrong address, and discards it has
+            // received nothing and must not be charged for it. Pro is unmetered
+            // — no reason to keep a count nobody reads.
+            if metered && !self.entitlement.isPro {
+                WalkMeter.recordFinishedWalk()
+            }
             // A FINISHED walk is a walk, whether or not a document was ever
             // built from it. Previously a walk only entered the log via
             // `completeSend()` — so finishing and then just filing it left it

--- a/apps/ios/Sources/App/Entitlement.swift
+++ b/apps/ios/Sources/App/Entitlement.swift
@@ -1,0 +1,173 @@
+import Foundation
+import StoreKit
+import os
+
+/// Jefe Pro — the subscription, and whether this install has it.
+///
+/// StoreKit 2 throughout. Entitlement is read from `Transaction.currentEntitlements`,
+/// which StoreKit verifies cryptographically against Apple's signature on device;
+/// we never hand-parse a receipt and never ask a server whether someone paid.
+///
+/// **No accounts, on purpose.** The tiers design chose a minimal proxy with no
+/// user identity, so entitlement is per-Apple-ID via StoreKit and nothing else.
+/// That is also why `restore()` is not optional garnish: an operator who gets a
+/// new phone has no login to fall back on, and Apple requires a restore path in
+/// any case.
+///
+/// **Unverified transactions are ignored, never trusted.** `VerificationResult`
+/// carries a `.unverified` case; treating it as entitled would make the
+/// signature pointless.
+@MainActor
+@Observable
+final class Entitlement {
+    /// Must match the App Store Connect subscription product exactly. If this
+    /// string and ASC disagree, `Product.products(for:)` returns empty and the
+    /// paywall renders with no price — the failure is silent, so it is worth
+    /// checking first when the paywall looks wrong.
+    static let proMonthlyID = "com.damsac.jefe.pro.monthly"
+
+    /// Whether this install currently has Jefe Pro.
+    ///
+    /// Starts `false` and is corrected by `refresh()` on launch. Starting
+    /// false-then-correcting rather than true-then-correcting means a
+    /// subscriber briefly sees the free-tier count on a cold launch, which is
+    /// harmless, instead of a lapsed user briefly getting Pro — the error that
+    /// costs money.
+    private(set) var isPro = false
+
+    /// The subscription product, once loaded. `nil` while loading or if the
+    /// lookup failed — the paywall must handle both without claiming a price.
+    private(set) var proProduct: Product?
+
+    /// Set when a load or purchase failed in a way worth telling the operator
+    /// about. `nil` for user-cancelled: cancelling is not an error.
+    var purchaseError: String?
+
+    /// True while a purchase or restore is in flight, so the paywall can
+    /// disable its buttons rather than allow a double-purchase tap.
+    private(set) var isWorking = false
+
+    /// The `Transaction.updates` listener.
+    ///
+    /// `@ObservationIgnored` because it is plumbing, not UI state — and because
+    /// without it the `@Observable` macro synthesizes main-actor-isolated
+    /// accessors that `deinit` cannot call. `nonisolated(unsafe)` so `deinit`,
+    /// which is not main-actor isolated, can cancel it; safe in fact, since it
+    /// is written exactly once in `init` and read exactly once in `deinit` with
+    /// no concurrent access in between.
+    @ObservationIgnored
+    private nonisolated(unsafe) var updatesTask: Task<Void, Never>?
+    private let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "billing"
+    )
+
+    init() {
+        // Transaction.updates delivers renewals, refunds, revocations, Ask-to-Buy
+        // approvals, and purchases made on another device. Without this listener
+        // a refund or a lapsed renewal would leave `isPro` true until the next
+        // cold launch.
+        updatesTask = Task { [weak self] in
+            for await update in Transaction.updates {
+                guard let self else { return }
+                if case .verified(let transaction) = update {
+                    await transaction.finish()
+                }
+                await self.refresh()
+            }
+        }
+    }
+
+    deinit { updatesTask?.cancel() }
+
+    /// Loads the product and re-reads entitlement. Safe to call repeatedly.
+    func start() async {
+        await loadProducts()
+        await refresh()
+    }
+
+    func loadProducts() async {
+        do {
+            let products = try await Product.products(for: [Self.proMonthlyID])
+            proProduct = products.first
+            if proProduct == nil {
+                // Not fatal and not the operator's problem — but it means the
+                // paywall cannot show a price, so leave a breadcrumb.
+                log.error("no product returned for \(Self.proMonthlyID, privacy: .public) — check the ASC product id and that agreements are signed")
+            }
+        } catch {
+            log.error("product load failed: \(error, privacy: .public)")
+        }
+    }
+
+    /// Re-reads entitlement from StoreKit. This is the only thing that may set
+    /// `isPro`.
+    func refresh() async {
+        var entitled = false
+        for await result in Transaction.currentEntitlements {
+            // .unverified is deliberately NOT trusted — see the type doc.
+            guard case .verified(let transaction) = result else { continue }
+            guard transaction.productID == Self.proMonthlyID else { continue }
+            if transaction.revocationDate == nil { entitled = true }
+        }
+        isPro = entitled
+    }
+
+    /// Buys Jefe Pro. Returns true only on a verified, completed purchase.
+    @discardableResult
+    func purchase() async -> Bool {
+        guard let product = proProduct else {
+            purchaseError = "The subscription isn't available right now. Try again in a moment."
+            return false
+        }
+        isWorking = true
+        defer { isWorking = false }
+        do {
+            switch try await product.purchase() {
+            case .success(let verification):
+                guard case .verified(let transaction) = verification else {
+                    // Signature check failed. Do not entitle; this is the case
+                    // the verification exists for.
+                    purchaseError = "That purchase couldn't be verified."
+                    log.error("purchase returned an unverified transaction")
+                    return false
+                }
+                await transaction.finish()
+                await refresh()
+                purchaseError = nil
+                return isPro
+            case .userCancelled:
+                // Not an error. Saying nothing is the correct response.
+                purchaseError = nil
+                return false
+            case .pending:
+                // Ask-to-Buy / SCA. The transaction may complete later and will
+                // arrive through Transaction.updates.
+                purchaseError = "That purchase needs approval before it goes through."
+                return false
+            @unknown default:
+                purchaseError = "That purchase didn't complete."
+                return false
+            }
+        } catch {
+            purchaseError = "That purchase didn't complete: \(error.localizedDescription)"
+            log.error("purchase failed: \(error, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Restores a subscription bought on another device or before a reinstall.
+    /// Apple requires this path to exist; with no accounts it is also the only
+    /// way an operator recovers on a new phone.
+    func restore() async {
+        isWorking = true
+        defer { isWorking = false }
+        do {
+            try await AppStore.sync()
+            await refresh()
+            purchaseError = isPro ? nil : "No previous subscription found on this Apple ID."
+        } catch {
+            purchaseError = "Couldn't restore: \(error.localizedDescription)"
+            log.error("restore failed: \(error, privacy: .public)")
+        }
+    }
+}

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -72,6 +72,16 @@ struct AppRoot: View {
                 licenseNumber: "44-1234", tradeKey: "landscape"
             ))
         }
+        // meter=N seeds the free-tier walk meter for the CURRENT month (parallel
+        // to autoprofile). The blocked-at-the-limit paywall is otherwise
+        // reachable only by finishing five real walks, which no headless
+        // screenshot run and no quick manual check can do. `meter=0` clears it.
+        if let arg = args.first(where: { $0.hasPrefix("meter=") }),
+           let count = Int(arg.dropFirst("meter=".count)) {
+            WalkMeter.save(WalkAllowance.Record(
+                month: WalkAllowance.monthKey(for: Date()), count: max(0, count)
+            ))
+        }
         // QA hooks for the Letterhead Studio (parallel to autoprofile): stamp a
         // sample branding so headless screenshots exercise a customized letterhead.
         if args.contains("resetbrand=1") { Branding.save(.default); DocumentLayout.save(.default) }
@@ -169,6 +179,23 @@ struct AppRoot: View {
             // is never re-fired while a walk is live — one suspension point
             // ahead of it would Fail a live session. See runAppOpenSweeps().
             model.runAppOpenSweeps()
+            // Entitlement + product load, off the critical path. Detached from
+            // this .task on purpose: it awaits the network, and the INVARIANT
+            // above forbids a suspension point ahead of runAppOpenSweeps().
+            // `isPro` starts false and is corrected when this lands — the
+            // free-tier gate reads it, so the worst case is a subscriber
+            // briefly seeing the free count on a cold launch, never a lapsed
+            // user briefly getting Pro.
+            Task { await model.entitlement.start() }
+            // paywall=1 raises the paywall on launch. simctl can't tap, so this
+            // is the only way to verify the sheet headlessly; pair with meter=5
+            // for the refused-at-the-limit copy.
+            if ProcessInfo.processInfo.arguments.contains("paywall=1") {
+                model.blockedUsage = ProcessInfo.processInfo.arguments.contains("meter=5")
+                    ? (used: WalkAllowance.freeMonthlyLimit, limit: WalkAllowance.freeMonthlyLimit)
+                    : nil
+                model.showPaywall = true
+            }
             // (Removed: the legacy SpeechSource permission ask for live=1.
             // STT is Rust-side whisper — Apple Speech Recognition is never
             // used on the walk path, and its system dialog carries "sent to

--- a/apps/ios/Sources/App/InstallIdentity.swift
+++ b/apps/ios/Sources/App/InstallIdentity.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Security
 
 /// A stable, anonymous per-install id, used to meter and rate-limit this
 /// install at the proxy.
@@ -35,38 +34,13 @@ enum InstallIdentity {
     }
 
     private static func read() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-              let data = item as? Data,
-              let value = String(data: data, encoding: .utf8),
-              !value.isEmpty
+        guard let data = KeychainStore.read(service: service, account: account),
+              let value = String(data: data, encoding: .utf8), !value.isEmpty
         else { return nil }
         return value
     }
 
     private static func write(_ value: String) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-        ]
-        // Delete-then-add rather than update: simpler, and idempotent if a
-        // partial item somehow exists.
-        SecItemDelete(query as CFDictionary)
-
-        var attributes = query
-        attributes[kSecValueData as String] = Data(value.utf8)
-        // AfterFirstUnlock, not WhenUnlocked: a walk can finish and process
-        // with the screen locked in a pocket (the background-audio path), and
-        // the id has to be readable then.
-        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        SecItemAdd(attributes as CFDictionary, nil)
+        KeychainStore.write(Data(value.utf8), service: service, account: account)
     }
 }

--- a/apps/ios/Sources/App/KeychainStore.swift
+++ b/apps/ios/Sources/App/KeychainStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Security
+
+/// Minimal keychain read/write for the two things that must survive app
+/// deletion: the install id and the free-tier walk meter.
+///
+/// Keychain rather than `UserDefaults` on purpose — keychain items survive
+/// delete-and-reinstall, `UserDefaults` does not. Both callers key a usage
+/// allowance off their value, so a `UserDefaults` home would make "reinstall the
+/// app" a one-tap way to reset it.
+///
+/// Everything is `AfterFirstUnlock`: a walk can finish and process with the
+/// screen locked in a pocket (the background-audio path), and both values have
+/// to be readable then.
+enum KeychainStore {
+    static func read(service: String, account: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data, !data.isEmpty
+        else { return nil }
+        return data
+    }
+
+    /// Writes, replacing any existing value. Returns whether it stuck — callers
+    /// decide what a failure means; for both of ours it must never block a walk.
+    @discardableResult
+    static func write(_ value: Data, service: String, account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        // Delete-then-add rather than update: simpler, and idempotent if a
+        // partial item somehow exists.
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = value
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess
+    }
+}

--- a/apps/ios/Sources/App/WalkAllowance.swift
+++ b/apps/ios/Sources/App/WalkAllowance.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// The free-tier walk meter: 5 finished walks per calendar month, then Jefe Pro.
+///
+/// Split deliberately into pure decision logic (`WalkAllowance`) and keychain
+/// persistence (`WalkMeter`). Everything that decides anything is a static
+/// function over explicit inputs, so the rules — month rollover, what counts,
+/// what happens at exactly the limit — are unit-testable without StoreKit, a
+/// keychain, or a wall clock. Those are the parts that will be wrong.
+///
+/// ## What counts as a walk
+///
+/// A walk that FINISHED and produced notes. Not a walk that was started and
+/// discarded, and never a practice walk. You are metered on output, not on
+/// tapping a button — someone who starts a walk, realizes they are at the wrong
+/// address, and discards it has received nothing and must not be charged for it.
+///
+/// ## Where it is enforced
+///
+/// At `startWalk()`, never at finish. Refusing after the operator has already
+/// walked the site and talked for ten minutes would destroy the recording they
+/// just made, at the worst possible moment. R6 says reject rather than coerce —
+/// but the rejection has to arrive BEFORE the work, not after it.
+///
+/// ## What this is not
+///
+/// It is not a security boundary. The meter lives on the device and the
+/// entitlement check is StoreKit's local (cryptographically signed, but local)
+/// `currentEntitlements`. Someone who patches the binary can walk for free. What
+/// bounds that is the proxy's per-install and global daily spend caps, and — in
+/// Phase 2 — App Attest. Treating an honest customer well matters more here than
+/// making a determined one impossible.
+enum WalkAllowance {
+    /// Finished walks per calendar month on the free tier (Isaac, 2026-07-26).
+    static let freeMonthlyLimit = 5
+
+    /// One month's usage. `month` is a "YYYY-MM" key, not a date, so a rollover
+    /// is a string comparison rather than date arithmetic across time zones.
+    struct Record: Codable, Equatable {
+        var month: String
+        var count: Int
+
+        static let empty = Record(month: "", count: 0)
+    }
+
+    enum Decision: Equatable {
+        /// Start the walk. `remaining` is what will be left AFTER this one, for
+        /// the "1 walk left this month" nudge; nil for Pro (never counted).
+        case allowed(remaining: Int?)
+        /// Out of free walks this month — show the paywall instead of recording.
+        case blocked(used: Int, limit: Int)
+    }
+
+    /// The month key a date falls in. Local calendar on purpose: an operator's
+    /// month is the one on their wall, not UTC's.
+    static func monthKey(for date: Date, calendar: Calendar = .current) -> String {
+        let parts = calendar.dateComponents([.year, .month], from: date)
+        guard let year = parts.year, let month = parts.month else { return "" }
+        return String(format: "%04d-%02d", year, month)
+    }
+
+    /// Usage for `now`'s month, treating a record from any earlier month as
+    /// zero. Rollover is therefore implicit — nothing has to run at midnight on
+    /// the 1st, which is the kind of thing that silently never fires.
+    static func usage(in record: Record, now: Date, calendar: Calendar = .current) -> Int {
+        record.month == monthKey(for: now, calendar: calendar) ? record.count : 0
+    }
+
+    /// The gate. Pro is unmetered and short-circuits before any date handling.
+    static func decide(
+        isPro: Bool,
+        record: Record,
+        now: Date,
+        calendar: Calendar = .current,
+        limit: Int = freeMonthlyLimit
+    ) -> Decision {
+        if isPro { return .allowed(remaining: nil) }
+        let used = usage(in: record, now: now, calendar: calendar)
+        // `>=`, not `==`: a limit that drops (or a record written by a build
+        // with a higher limit) must still block rather than wrap into an
+        // unbounded free tier.
+        if used >= limit { return .blocked(used: used, limit: limit) }
+        return .allowed(remaining: limit - used - 1)
+    }
+
+    /// The record after a walk finishes. Rolls the month over on write as well
+    /// as on read, so a stale month never accumulates.
+    static func recordingFinish(
+        in record: Record, now: Date, calendar: Calendar = .current
+    ) -> Record {
+        let key = monthKey(for: now, calendar: calendar)
+        let base = record.month == key ? record.count : 0
+        return Record(month: key, count: base + 1)
+    }
+}
+
+/// Keychain-backed home for the meter. Keychain rather than `UserDefaults` so
+/// delete-and-reinstall is not a one-tap allowance reset (same reasoning as
+/// `InstallIdentity`, which shares the store).
+enum WalkMeter {
+    private static let service = "app.jefe.meter"
+    private static let account = "free-walks"
+
+    static func load() -> WalkAllowance.Record {
+        guard let data = KeychainStore.read(service: service, account: account),
+              let record = try? JSONDecoder().decode(WalkAllowance.Record.self, from: data)
+        else { return .empty }
+        return record
+    }
+
+    /// Persists the record. Deliberately returns nothing: a keychain failure
+    /// must not block or fail a walk that already happened — the same trade
+    /// `InstallIdentity` makes. The cost of a failed write is one uncounted
+    /// walk, which is a far better outcome for someone standing on a job site
+    /// than an error over bookkeeping.
+    static func save(_ record: WalkAllowance.Record) {
+        guard let data = try? JSONEncoder().encode(record) else { return }
+        KeychainStore.write(data, service: service, account: account)
+    }
+
+    static func recordFinishedWalk(now: Date = Date()) {
+        save(WalkAllowance.recordingFinish(in: load(), now: now))
+    }
+}

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -21,6 +21,8 @@ struct BoardView: View {
     @State private var newJobName = ""
     /// TODAY collapses so JOBS clears the fold. Expanding shows the rest.
     @State private var showAllWalks = false
+    /// Apple's own manage-subscriptions sheet, raised by the PRO chip.
+    @State private var showManageSubscription = false
     /// Enough to see today's work at a glance without pushing jobs off
     /// screen — the complaint that prompted this.
     private static let collapsedWalkCount = 3
@@ -57,6 +59,7 @@ struct BoardView: View {
                     // cryptic chips (VOCAB + PAPER). A raised amber block (same
                     // pressed-block grammar as START WALK) so it reads as a
                     // button; opens the two-tab PAPERWORK / WORDS sheet.
+                    planChip
                     Button { showCustomize = true } label: {
                         raisedChip(face: Theme.C.orange, edge: Theme.C.orangeDeep) {
                             Text("MY BUSINESS")
@@ -298,6 +301,16 @@ struct BoardView: View {
                 .presentationDragIndicator(.visible)
                 .presentationBackground(Theme.C.paper)
         }
+        // Raised by `startWalk()` refusing at the free-tier limit, and by the
+        // deliberate upgrade affordance in Customize. Never raised by a
+        // background event, so it can't appear over a walk in progress.
+        .sheet(isPresented: $model.showPaywall) {
+            PaywallView(model: model, blocked: model.blockedUsage)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+                .presentationBackground(Theme.C.paper)
+        }
+        .manageSubscriptionsSheet(isPresented: $showManageSubscription)
     }
 }
 
@@ -397,6 +410,50 @@ extension BoardView {
     }
 
     var activeJobs: [JobModel] { operatorJobs.filter { $0.status == .active } }
+
+    /// Plan status, and the only always-visible way in and out of billing.
+    ///
+    /// Free shows walks remaining rather than walks used — "2 LEFT" is what an
+    /// operator actually needs to decide whether to start a walk, and it stays
+    /// quiet (ink60, no fill) so it reads as a fact rather than a nag. Pro opens
+    /// Apple's manage-subscriptions sheet: Apple requires that a subscriber can
+    /// reach cancellation easily, and hiding it would be both a review risk and
+    /// the kind of thing that makes people distrust a subscription.
+    @ViewBuilder
+    private var planChip: some View {
+        if model.entitlement.isPro {
+            Button { showManageSubscription = true } label: {
+                Text("PRO")
+                    .font(Theme.F.mono(8, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(Theme.C.greenTag)
+                    .padding(.horizontal, 6)
+                    .padding(.top, 3)
+                    .padding(.bottom, 2)
+                    .background(Theme.C.greenTint)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        } else {
+            let used = WalkAllowance.usage(in: WalkMeter.load(), now: Date())
+            let left = max(0, WalkAllowance.freeMonthlyLimit - used)
+            Button {
+                model.blockedUsage = nil   // opened by choice, not refused
+                model.showPaywall = true
+            } label: {
+                Text(left == 0 ? "0 LEFT" : "\(left) LEFT")
+                    .font(Theme.F.mono(8, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(left == 0 ? Theme.C.redTag : Theme.C.ink60)
+                    .padding(.horizontal, 6)
+                    .padding(.top, 3)
+                    .padding(.bottom, 2)
+                    .background(left == 0 ? Theme.C.redTint : Theme.C.paperDeep)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
 
     /// The UNFILED walks, capped until expanded.
     ///

--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -1,0 +1,181 @@
+import StoreKit
+import SwiftUI
+
+/// The Jefe Pro paywall.
+///
+/// Shown when the free tier runs out at START WALK, and reachable deliberately
+/// from the board. Written to be read by someone standing on a job site who
+/// just wanted to record a walk: what happened, what it costs, one button.
+///
+/// Deliberately NOT a feature grid. Every paid feature is the same feature —
+/// more walks — so a checklist would be padding, and padding at the moment
+/// someone is blocked from working reads as a stall.
+struct PaywallView: View {
+    @Bindable var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// Usage that triggered this, when it was a refusal. Nil when the operator
+    /// opened the paywall themselves — the copy changes accordingly, because
+    /// "you've used all 5" is wrong and alarming if they came here by choice.
+    var blocked: (used: Int, limit: Int)?
+
+    private var entitlement: Entitlement { model.entitlement }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    headline
+                    priceBlock
+                    reassurance
+                    if let error = entitlement.purchaseError {
+                        Text(error)
+                            .font(Theme.F.mono(10))
+                            .foregroundStyle(Theme.C.redTag)
+                            .padding(.horizontal, Theme.S.screenPad)
+                            .padding(.top, 14)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+            actions
+        }
+        .background(Theme.C.paper.ignoresSafeArea())
+        .task { await entitlement.start() }
+        // The sheet's only job is to sell Pro; once Pro exists it has no reason
+        // to be on screen, and leaving it up would make a successful purchase
+        // feel like it failed.
+        .onChange(of: entitlement.isPro) { _, isPro in if isPro { dismiss() } }
+    }
+
+    private var header: some View {
+        HStack {
+            SectionLabel("JEFE PRO")
+            Spacer()
+            Button { dismiss() } label: {
+                Text("CLOSE")
+                    .font(Theme.F.mono(9, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 18)
+        .padding(.bottom, 12)
+        .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
+    }
+
+    private var headline: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let blocked {
+                Text("You've used all \(blocked.limit) free walks this month.")
+                    .font(Theme.F.serif(23, .bold))
+                    .foregroundStyle(Theme.C.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("They reset on the 1st. Jefe Pro removes the limit today.")
+                    .font(Theme.F.ui(14, .medium))
+                    .foregroundStyle(Theme.C.ink60)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("Walk as many jobs as you want.")
+                    .font(Theme.F.serif(23, .bold))
+                    .foregroundStyle(Theme.C.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("The free tier covers \(WalkAllowance.freeMonthlyLimit) walks a month. Pro removes the limit.")
+                    .font(Theme.F.ui(14, .medium))
+                    .foregroundStyle(Theme.C.ink60)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 22)
+    }
+
+    private var priceBlock: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let product = entitlement.proProduct {
+                // The price comes from StoreKit, never hardcoded — it is
+                // localized, and it is the number Apple will actually charge.
+                // A hardcoded "$12.99" would be wrong in every other currency
+                // and would silently lie after any price change.
+                Text(product.displayPrice)
+                    .font(Theme.F.serif(30, .bold))
+                    .foregroundStyle(Theme.C.ink)
+                Text("per month · cancel anytime")
+                    .font(Theme.F.mono(10))
+                    .tracking(0.6)
+                    .foregroundStyle(Theme.C.ink60)
+            } else {
+                // No product: either still loading, or the ASC product id
+                // doesn't match. Say nothing about price rather than invent one.
+                Text("Loading…")
+                    .font(Theme.F.mono(11))
+                    .foregroundStyle(Theme.C.ink35)
+            }
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 26)
+    }
+
+    private var reassurance: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            row("Your notes and jobs stay yours — nothing is deleted if you cancel.")
+            row("Audio never leaves your phone. Jefe transcribes it right here.")
+            row("No account. Nothing to log into on a job site.")
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 26)
+    }
+
+    private func row(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 9) {
+            Rectangle()
+                .fill(Theme.C.orangeDeep)
+                .frame(width: 4, height: 4)
+                .padding(.top, 6)
+            Text(text)
+                .font(Theme.F.ui(13, .medium))
+                .foregroundStyle(Theme.C.ink60)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var actions: some View {
+        VStack(spacing: 10) {
+            Button {
+                Task { await entitlement.purchase() }
+            } label: {
+                WalkButton(title: entitlement.isWorking ? "…" : "GET JEFE PRO")
+            }
+            .buttonStyle(.plain)
+            // No product means no purchase is possible; a live button would
+            // just fail silently.
+            .disabled(entitlement.isWorking || entitlement.proProduct == nil)
+            .opacity(entitlement.proProduct == nil ? 0.4 : 1)
+
+            // Restore is not optional garnish: Apple requires the path, and
+            // with no accounts it is the ONLY way an operator recovers a
+            // subscription on a new phone.
+            Button {
+                Task { await entitlement.restore() }
+            } label: {
+                Text("RESTORE PURCHASE")
+                    .font(Theme.F.mono(9.5, .semibold))
+                    .tracking(1.0)
+                    .foregroundStyle(Theme.C.ink60)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(entitlement.isWorking)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.bottom, 12)
+        .padding(.top, 12)
+        .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
+    }
+}

--- a/apps/ios/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/apps/ios/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Apple's privacy manifest. REQUIRED: an app that calls a "required reason API"
+  without declaring it here is rejected at submission, and we call two.
+
+  This file must also AGREE with the App Privacy answers in App Store Connect —
+  they are two separate surfaces describing the same thing, and Apple compares
+  them. If you change one, change the other.
+
+  The honest summary this encodes: audio never leaves the device (whisper runs
+  locally), the TRANSCRIPT does — it goes to Anthropic through our proxy,
+  because that is how extraction and summarization work. Nothing is linked to an
+  identity, because there are no accounts; the only identifier that exists is a
+  random per-install UUID minted on device. Nothing is used for tracking, and
+  there are no tracking domains.
+-->
+<plist version="1.0">
+<dict>
+    <!-- No cross-app/website tracking, no data brokers, no ad networks. -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <!--
+          The walk transcript and the items extracted from it.
+
+          Declared even though our proxy is forbidden to log, store, or forward
+          request bodies (see services/proxy/src/index.ts), because the model
+          provider is still a third party receiving operator content. Apple
+          rejects for under-declaration and never for over-declaration, and on a
+          product where contractors talk about client property all day the
+          conservative answer is also the right one.
+
+          NOT linked to identity: no accounts, no email, no name. NOT used for
+          tracking.
+        -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherUserContent</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!--
+          Photos taken during a walk. Persisted on device and rendered in the
+          app; they are NOT sent to the model — the harness has no image
+          ContentBlock variant (issue #263), so today this is enforced by the
+          plumbing not existing. If #263 lands and photos start being sent,
+          this entry and the ASC answers both have to be revisited.
+        -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+    </array>
+
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!--
+          UserDefaults: business profile, branding, document layout, walk mode,
+          and the one-shot coach-mark flags. Read and written only by this app.
+        -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+
+        <!--
+          File timestamps: AppModel+Photos.photoFileAge() reads the modification
+          date of files in <Documents>/photos/ so the orphan sweep can hold back
+          anything younger than the 24h grace window. Files inside our own
+          container only — reason C617.1.
+        -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/apps/ios/Tests/WalkAllowanceTests.swift
+++ b/apps/ios/Tests/WalkAllowanceTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `WalkAllowance` — the free-tier meter's decision logic.
+///
+/// Two failure directions, both bad in different ways. Blocking a paying
+/// subscriber, or blocking someone who has walks left, stops a contractor
+/// working mid-job — the worst thing this app can do. Failing open lets the
+/// free tier run unbounded, which costs real money at $-per-token. So these
+/// pin both edges of the limit and every path through the month rollover,
+/// which is the part that will rot silently: nothing runs at midnight on the
+/// 1st, so if rollover is wrong it stays wrong until someone complains.
+final class WalkAllowanceTests: XCTestCase {
+    /// Fixed calendar in UTC so month boundaries are unambiguous under test.
+    /// (Production uses `.current` on purpose — an operator's month is the one
+    /// on their wall, not UTC's.)
+    private let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    private func date(_ iso: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(identifier: "UTC")!
+        return formatter.date(from: iso)!
+    }
+
+    private func record(_ month: String, _ count: Int) -> WalkAllowance.Record {
+        WalkAllowance.Record(month: month, count: count)
+    }
+
+    // MARK: Month keys
+
+    func testMonthKeyIsZeroPadded() {
+        // "2026-7" would sort and compare wrong against "2026-11".
+        XCTAssertEqual(
+            WalkAllowance.monthKey(for: date("2026-07-28T12:00:00Z"), calendar: calendar),
+            "2026-07"
+        )
+    }
+
+    func testMonthKeyRollsAtTheYearBoundary() {
+        XCTAssertEqual(
+            WalkAllowance.monthKey(for: date("2026-12-31T23:59:00Z"), calendar: calendar),
+            "2026-12"
+        )
+        XCTAssertEqual(
+            WalkAllowance.monthKey(for: date("2027-01-01T00:01:00Z"), calendar: calendar),
+            "2027-01"
+        )
+    }
+
+    // MARK: Usage + rollover
+
+    func testUsageCountsOnlyTheCurrentMonth() {
+        let now = date("2026-07-28T12:00:00Z")
+        XCTAssertEqual(
+            WalkAllowance.usage(in: record("2026-07", 3), now: now, calendar: calendar), 3
+        )
+    }
+
+    func testUsageFromAnEarlierMonthIsZero() {
+        // The rollover. Nothing runs on the 1st — a stale record simply stops
+        // counting, so an operator who used all 5 in June starts July at zero
+        // without any scheduled work having to fire.
+        let now = date("2026-07-01T00:00:00Z")
+        XCTAssertEqual(
+            WalkAllowance.usage(in: record("2026-06", 5), now: now, calendar: calendar), 0
+        )
+    }
+
+    func testEmptyRecordIsZeroUsage() {
+        XCTAssertEqual(
+            WalkAllowance.usage(in: .empty, now: date("2026-07-28T12:00:00Z"), calendar: calendar),
+            0
+        )
+    }
+
+    // MARK: The gate
+
+    func testProIsAlwaysAllowedAndNeverCounted() {
+        // Even with a maxed-out record: Pro short-circuits before usage is read.
+        let decision = WalkAllowance.decide(
+            isPro: true, record: record("2026-07", 99),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar
+        )
+        XCTAssertEqual(decision, .allowed(remaining: nil))
+    }
+
+    func testFreshFreeUserIsAllowedWithFullRemainder() {
+        let decision = WalkAllowance.decide(
+            isPro: false, record: .empty,
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5
+        )
+        // 4, not 5: `remaining` is what's left AFTER the walk being started.
+        XCTAssertEqual(decision, .allowed(remaining: 4))
+    }
+
+    func testLastFreeWalkIsAllowedWithZeroRemaining() {
+        // The off-by-one that matters: 4 used against a limit of 5 must still
+        // let the 5th walk happen.
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-07", 4),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5
+        )
+        XCTAssertEqual(decision, .allowed(remaining: 0))
+    }
+
+    func testExactlyAtTheLimitIsBlocked() {
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-07", 5),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5
+        )
+        XCTAssertEqual(decision, .blocked(used: 5, limit: 5))
+    }
+
+    func testOverTheLimitIsBlockedRatherThanWrapping() {
+        // Guards the `>=`. A record written by a build with a higher limit (or
+        // a limit we later lower) must not read as "negative remaining, so
+        // allowed" and hand out an unbounded free tier.
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-07", 9),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5
+        )
+        XCTAssertEqual(decision, .blocked(used: 9, limit: 5))
+    }
+
+    func testAMaxedOutPriorMonthDoesNotBlockTheNewMonth() {
+        // The whole point of the rollover, stated as the gate sees it.
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-06", 5),
+            now: date("2026-07-01T08:00:00Z"), calendar: calendar, limit: 5
+        )
+        XCTAssertEqual(decision, .allowed(remaining: 4))
+    }
+
+    // MARK: Recording a finish
+
+    func testFinishIncrementsWithinTheSameMonth() {
+        let updated = WalkAllowance.recordingFinish(
+            in: record("2026-07", 2), now: date("2026-07-28T12:00:00Z"), calendar: calendar
+        )
+        XCTAssertEqual(updated, record("2026-07", 3))
+    }
+
+    func testFinishInANewMonthRestartsAtOne() {
+        // Rolls over on WRITE as well as on read — otherwise a stale month
+        // would keep accumulating and the next read would discard the lot.
+        let updated = WalkAllowance.recordingFinish(
+            in: record("2026-06", 5), now: date("2026-07-02T09:00:00Z"), calendar: calendar
+        )
+        XCTAssertEqual(updated, record("2026-07", 1))
+    }
+
+    func testFinishFromEmptyStartsAtOne() {
+        let updated = WalkAllowance.recordingFinish(
+            in: .empty, now: date("2026-07-28T12:00:00Z"), calendar: calendar
+        )
+        XCTAssertEqual(updated, record("2026-07", 1))
+    }
+
+    // MARK: The whole arc
+
+    func testFiveWalksThenBlockedThenFreeAgainNextMonth() {
+        // End-to-end on the pure logic: walk the free tier to exhaustion, prove
+        // it blocks, then prove the calendar alone reopens it.
+        let july = date("2026-07-15T10:00:00Z")
+        var current = WalkAllowance.Record.empty
+
+        for walk in 1...5 {
+            let decision = WalkAllowance.decide(
+                isPro: false, record: current, now: july, calendar: calendar, limit: 5
+            )
+            XCTAssertEqual(
+                decision, .allowed(remaining: 5 - walk),
+                "walk \(walk) of 5 should be allowed"
+            )
+            current = WalkAllowance.recordingFinish(in: current, now: july, calendar: calendar)
+        }
+
+        XCTAssertEqual(
+            WalkAllowance.decide(
+                isPro: false, record: current, now: july, calendar: calendar, limit: 5
+            ),
+            .blocked(used: 5, limit: 5),
+            "the 6th walk in the same month must be refused"
+        )
+
+        XCTAssertEqual(
+            WalkAllowance.decide(
+                isPro: false, record: current,
+                now: date("2026-08-01T00:00:00Z"), calendar: calendar, limit: 5
+            ),
+            .allowed(remaining: 4),
+            "August must start fresh with no rollover job having run"
+        )
+    }
+
+    func testSubscribingUnblocksImmediatelyWithoutTouchingTheRecord() {
+        // What happens the instant a purchase completes: the same exhausted
+        // record must stop blocking, and must NOT need to be reset — so that
+        // cancelling later returns the operator to their honest usage rather
+        // than to a laundered zero.
+        let now = date("2026-07-28T12:00:00Z")
+        let exhausted = record("2026-07", 5)
+
+        XCTAssertEqual(
+            WalkAllowance.decide(isPro: false, record: exhausted, now: now, calendar: calendar),
+            .blocked(used: 5, limit: 5)
+        )
+        XCTAssertEqual(
+            WalkAllowance.decide(isPro: true, record: exhausted, now: now, calendar: calendar),
+            .allowed(remaining: nil)
+        )
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -85,6 +85,16 @@ targets:
     scheme:
       testTargets:
         - SitewalkGalleryTests
+      # Local StoreKit testing (Jefe.storekit): lets the paywall load a real
+      # Product, show a real localized price, and complete a real purchase flow
+      # in the simulator without App Store Connect.
+      #
+      # This lives in the scheme's LAUNCH action only. `xcodebuild archive`
+      # doesn't read the launch action, so TestFlight and App Store builds
+      # transact against the real App Store — a local config can't leak into a
+      # shipped build. The file is deliberately OUTSIDE Sources/ so it is never
+      # copied into the app bundle.
+      storeKitConfiguration: Jefe.storekit
   # Plan 15: hosted unit tests for app-side contracts that need no simulator
   # UI — today just VocabPackTests (every bundled vocab pack decodes and obeys
   # the seeding schema: version >= 1, <= 60 terms, no ci-dupes, 1-6 words).


### PR DESCRIPTION
Tier 0 + Tier 1 of the readiness audit (#276). Before this the app could not take money and would have been rejected on submission.

## Thinking

**Metering is on OUTPUT, not on tapping START.** The count moves only once a walk has produced notes. Someone who starts a walk, realizes they're at the wrong address, and discards it has received nothing and must not be charged for it.

**The gate runs at `startWalk()`, never at finish.** R6 says reject rather than coerce — but the rejection has to arrive *before* the work. Refusing at DONE would destroy a recording the operator had already spent ten minutes making, at the worst possible moment. Everything else follows from that.

**Two exemptions, both principled.** Practice walks run on a throwaway engine, are never saved, and are the tutorial — charging someone a walk to learn the app, or blocking the tutorial at the limit, is indefensible. Demo mode makes no model calls at all, so it costs nothing (the free tier exists to bound cost), and it's dev-only; metering it would also break multi-round autoflow QA at walk six.

**Keychain, not UserDefaults.** Keychain items survive delete-and-reinstall. A `UserDefaults` meter would make "reinstall the app" a one-tap allowance reset. `InstallIdentity` already made this call for the same reason, so the keychain access is now shared (`KeychainStore`).

**Unverified transactions are ignored.** `VerificationResult` has an `.unverified` case; entitling on it would make the signature pointless. `isPro` starts false and is corrected on launch — a subscriber briefly seeing the free count is harmless, a lapsed user briefly getting Pro is the error that costs money.

**The price is never hardcoded.** It comes from StoreKit's `displayPrice`, so it is localized and it is what Apple will actually charge. A hardcoded "$12.99" would be wrong in every other currency and would silently lie after any price change.

**Restore is not garnish.** Apple requires the path, and with no accounts it is the *only* way an operator recovers a subscription on a new phone. The PRO chip opens Apple's manage-subscriptions sheet for the same reason — hiding cancellation is both a review risk and the thing that makes people distrust a subscription.

## What's here

- `WalkAllowance` — pure decision logic (limit, rollover, what counts), fully testable without StoreKit, a keychain, or a wall clock. `WalkMeter` is its keychain half.
- `Entitlement` — StoreKit 2: product load, purchase, restore, and a `Transaction.updates` listener so a refund or lapsed renewal doesn't leave `isPro` true until the next cold launch.
- `PaywallView` — deliberately not a feature grid. Every paid feature is the same feature (more walks), so a checklist would be padding, and padding at the moment someone is blocked from working reads as a stall.
- A plan chip on the board: `N LEFT` for free (walks *remaining* is what you need to decide whether to start one), `PRO` for subscribers.
- **`PrivacyInfo.xcprivacy`** — declares `UserDefaults` (CA92.1) and file timestamps (C617.1, the photo orphan sweep). Verified present at the built bundle's root, not just in the source tree.
- `Jefe.storekit` + scheme wiring, so the purchase flow is testable in the simulator with no App Store Connect.

## Verification

**35 tests pass**, 16 of them new. They pin both edges of the limit (4-used must be allowed, 5-used must be blocked, 9-used must block rather than wrap into an unbounded free tier) and every path through the rollover — the part that will rot silently, since nothing runs at midnight on the 1st. One test walks the whole arc: five walks, blocked on the sixth, free again in August with no rollover job having fired.

**Rendered on-sim** at the blocked state. The no-product path degrades honestly — "Loading…" instead of an invented price, and GET JEFE PRO disabled rather than live-and-silently-failing.

**The StoreKit config is in the scheme's LAUNCH action only** — verified by parsing the generated scheme: `ArchiveAction` has no reference, so TestFlight and App Store builds transact against the real App Store. The file also lives outside `Sources/` so it is never copied into the bundle.

## Gaps, stated plainly

- **The price path is unproven.** `simctl launch` doesn't pick up a scheme's StoreKit config, and xcodegen has no `test.storeKitConfiguration` key, so I could not assert `displayPrice` renders. It needs one manual Run from Xcode. Everything around it — product-nil handling, disabled button, purchase/restore plumbing — is verified.
- **No real purchase has been made.** That needs a sandbox Apple ID on a device.
- **The ASC product does not exist yet.** `com.damsac.jefe.pro.monthly` must be created as an auto-renewable subscription at $12.99/mo, and Paid Apps agreements signed, or `Product.products(for:)` returns empty and the paywall shows no price. That's Isaac's to do.
- **This is not a security boundary** and isn't meant to be. The meter is on-device and the entitlement check is local. A patched binary walks free; what bounds that is the proxy's spend caps and, later, App Attest. Treating an honest customer well matters more here than making a determined one impossible.