### PR TITLE
fix(ios): the subscription disclosure App Review requires on the paywall

### DIFF
--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -29,6 +29,7 @@ struct PaywallView: View {
                     headline
                     priceBlock
                     reassurance
+                    legalBlock
                     if let error = entitlement.purchaseError {
                         Text(error)
                             .font(Theme.F.mono(10))
@@ -129,6 +130,45 @@ struct PaywallView: View {
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 26)
     }
+
+    /// Apple's required subscription disclosure (App Review 3.1.2).
+    ///
+    /// An auto-renewable subscription must state, IN THE BINARY and on the
+    /// purchase screen: the title, the length of the period, the price per
+    /// period, and functional links to the Terms of Use (EULA) and Privacy
+    /// Policy. Missing any of it is a hard rejection, not a note. Title,
+    /// length, and price are above; this carries the renewal terms and the two
+    /// links.
+    ///
+    /// The renewal sentence is Apple's own required substance, in plain words:
+    /// billing is on the Apple ID, it renews unless cancelled, and cancellation
+    /// is 24 hours before the period ends. Anyone paying $12.99 a month deserves
+    /// to read that before paying rather than discover it after.
+    private var legalBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Payment is charged to your Apple ID at confirmation. It renews monthly unless you cancel at least 24 hours before the period ends. Manage or cancel it any time in your Apple ID settings.")
+                .font(Theme.F.mono(9))
+                .lineSpacing(2)
+                .foregroundStyle(Theme.C.ink35)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 14) {
+                Link("TERMS OF USE", destination: Self.termsURL)
+                Link("PRIVACY POLICY", destination: Self.privacyURL)
+            }
+            .font(Theme.F.mono(9, .semibold))
+            .tracking(0.8)
+            .foregroundStyle(Theme.C.orangeDeep)
+        }
+        .padding(.horizontal, Theme.S.screenPad)
+        .padding(.top, 24)
+    }
+
+    // swiftlint:disable force_unwrapping
+    // Both are literals verified to parse; a nil here would silently drop a
+    // link Apple requires to be present and functional.
+    static let termsURL = URL(string: "https://getjefe.netlify.app/terms.html")!
+    static let privacyURL = URL(string: "https://getjefe.netlify.app/privacy.html")!
+    // swiftlint:enable force_unwrapping
 
     private func row(_ text: String) -> some View {
         HStack(alignment: .top, spacing: 9) {


### PR DESCRIPTION
A rejection I'd missed in #277, caught while auditing the beta site's legal pages.

## The requirement

App Review guideline **3.1.2** requires that an auto-renewable subscription state, **in the binary** and on the purchase screen:

- subscription title — was already there
- length of the period — already there
- price per period — already there (from StoreKit's `displayPrice`)
- **the renewal terms** — missing
- **functional Terms of Use (EULA) and Privacy Policy links** — missing

Missing any of these is a rejection, not a note. Three of five were present, which is exactly the kind of near-miss that reads as done.

## What's added

The renewal sentence in plain words — billing is on the Apple ID, it renews unless cancelled, cancellation is 24 hours before the period ends. That's Apple's required substance, but it's also just fair: someone about to pay $12.99 a month should read it *before* paying rather than discover it after.

Plus both links.

## Verification

- **Rendered on-sim** at the blocked paywall — the disclosure and both links sit under the reassurance block.
- **`curl -sI` on both URLs returns `HTTP/2 200`.** Apple checks that these resolve, and a dead legal link is its own rejection. `privacy.html` and `terms.html` already existed on getjefe.netlify.app.

## Worth recording: the privacy policy is already honest

While checking the links I read the policy. It already says audio never leaves the device *and* that transcript text goes to a third-party AI processing provider, and that we don't retain it beyond generating the document. That matches `PrivacyInfo.xcprivacy` from #277 and matches what the proxy actually does.

So §4.2 of #276 was half wrong: the *site copy* was never the gap. What remains is the App Privacy answers in App Store Connect, which need Isaac's login.