### PR TITLE
fix(ios): never block a walk when there is no way to subscribe

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -421,7 +421,14 @@ final class AppModel {
         // dev-only (`demo=1`), and metering it would break the multi-round
         // autoflow QA runs at walk six.
         if !isPracticeWalk && walkMode != .demo {
-            switch WalkAllowance.decide(isPro: entitlement.isPro, record: WalkMeter.load(), now: Date()) {
+            switch WalkAllowance.decide(
+                isPro: entitlement.isPro,
+                record: WalkMeter.load(),
+                now: Date(),
+                // No purchasable product means no way out of the limit — so the
+                // limit does not apply. See WalkAllowance.decide.
+                canSubscribe: entitlement.canSubscribe
+            ) {
             case .blocked(let used, let limit):
                 blockedUsage = (used: used, limit: limit)
                 showPaywall = true

--- a/apps/ios/Sources/App/Entitlement.swift
+++ b/apps/ios/Sources/App/Entitlement.swift
@@ -39,6 +39,15 @@ final class Entitlement {
     /// lookup failed — the paywall must handle both without claiming a price.
     private(set) var proProduct: Product?
 
+    /// Whether a subscription can actually be bought right now.
+    ///
+    /// False while the product is loading, if the App Store Connect product
+    /// doesn't exist or its id doesn't match, if agreements aren't signed, or if
+    /// StoreKit is simply unreachable. The free-tier gate reads this and
+    /// declines to block when it's false — we do not refuse someone's money and
+    /// their work at the same time. See `WalkAllowance.decide`.
+    var canSubscribe: Bool { proProduct != nil }
+
     /// Set when a load or purchase failed in a way worth telling the operator
     /// about. `nil` for user-cancelled: cancelling is not an error.
     var purchaseError: String?

--- a/apps/ios/Sources/App/WalkAllowance.swift
+++ b/apps/ios/Sources/App/WalkAllowance.swift
@@ -67,14 +67,30 @@ enum WalkAllowance {
     }
 
     /// The gate. Pro is unmetered and short-circuits before any date handling.
+    ///
+    /// `canSubscribe` is whether a purchasable product actually loaded. **If we
+    /// cannot sell someone a way out, we do not block them.** Refusing to take
+    /// somebody's money and refusing to let them work is indefensible — and it
+    /// is not hypothetical: until the App Store Connect product exists, no
+    /// install can subscribe at all, so a hard gate would brick every TestFlight
+    /// tester at walk six with no recourse until the 1st of the month.
+    ///
+    /// It also covers the ordinary failures — StoreKit unreachable, a network
+    /// blip on a job site with no signal, agreements lapsing. The cost of
+    /// failing open is a handful of unmetered walks, bounded by the proxy's
+    /// per-install and global daily spend caps. The cost of failing closed is a
+    /// contractor standing in front of a client unable to record. Those are not
+    /// close.
     static func decide(
         isPro: Bool,
         record: Record,
         now: Date,
         calendar: Calendar = .current,
-        limit: Int = freeMonthlyLimit
+        limit: Int = freeMonthlyLimit,
+        canSubscribe: Bool = true
     ) -> Decision {
         if isPro { return .allowed(remaining: nil) }
+        if !canSubscribe { return .allowed(remaining: nil) }
         let used = usage(in: record, now: now, calendar: calendar)
         // `>=`, not `==`: a limit that drops (or a record written by a build
         // with a higher limit) must still block rather than wrap into an

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -434,7 +434,11 @@ extension BoardView {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-        } else {
+        } else if model.entitlement.canSubscribe {
+            // Only shown when the limit is actually being enforced. With no
+            // purchasable product the gate declines to block (see
+            // `WalkAllowance.decide`), so "2 LEFT" would be a lie — and a
+            // discouraging one, since nothing runs out.
             let used = WalkAllowance.usage(in: WalkMeter.load(), now: Date())
             let left = max(0, WalkAllowance.freeMonthlyLimit - used)
             Button {

--- a/apps/ios/Tests/WalkAllowanceTests.swift
+++ b/apps/ios/Tests/WalkAllowanceTests.swift
@@ -137,6 +137,45 @@ final class WalkAllowanceTests: XCTestCase {
         XCTAssertEqual(decision, .allowed(remaining: 4))
     }
 
+    // MARK: Never block someone we can't sell to
+
+    func testExhaustedButNoProductAvailableIsAllowed() {
+        // The defect this exists to prevent: until the App Store Connect
+        // product exists, NO install can subscribe. A hard gate would brick
+        // every TestFlight tester at walk six with no way to pay and no
+        // recourse until the 1st. Refusing someone's money and their work at
+        // the same time is indefensible.
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-07", 5),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5,
+            canSubscribe: false
+        )
+        XCTAssertEqual(decision, .allowed(remaining: nil))
+    }
+
+    func testTheLimitStillAppliesOnceAProductExists() {
+        // The other half — failing open must be conditional, not a hole. The
+        // same exhausted record blocks the moment a product is purchasable.
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-07", 5),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5,
+            canSubscribe: true
+        )
+        XCTAssertEqual(decision, .blocked(used: 5, limit: 5))
+    }
+
+    func testNoProductDoesNotDisturbSomeoneUnderTheLimit() {
+        // Failing open must not change what an under-limit user sees; it is a
+        // release valve at the boundary, not a separate mode.
+        let decision = WalkAllowance.decide(
+            isPro: false, record: record("2026-07", 1),
+            now: date("2026-07-28T12:00:00Z"), calendar: calendar, limit: 5,
+            canSubscribe: false
+        )
+        // `nil` remaining, same as Pro: nothing is being counted down toward.
+        XCTAssertEqual(decision, .allowed(remaining: nil))
+    }
+
     // MARK: Recording a finish
 
     func testFinishIncrementsWithinTheSameMonth() {


### PR DESCRIPTION
A defect I shipped in #277, caught while working out how Isaac would test it.

## The bug

**Until the App Store Connect product exists, no install can subscribe.** `Product.products(for:)` returns empty, the paywall shows no price, and GET JEFE PRO is disabled — correctly, since there is nothing to buy.

But the free-tier gate blocked at five walks regardless. So the first TestFlight tester to finish five walks would have been **locked out of the product with no way to pay and no recourse until the 1st of the month.** On a job site, in front of a client.

That is worse than any amount of unmetered usage, and I built it.

## The fix

The gate declines to block whenever no purchasable product loaded.

**Refusing someone's money and their work at the same time is indefensible.** That's the whole principle; the ASC-product case is just the most obvious instance. It also covers the ordinary failures — StoreKit unreachable, a job site with no signal, agreements lapsing between renewals.

The asymmetry isn't close. Failing open costs a handful of unmetered walks, bounded by the proxy's per-install ($2/day) and global ($25/day) caps. Failing closed costs a contractor standing in front of a client unable to record the walk.

The board's plan chip is hidden in the same condition — "2 LEFT" would be a lie when nothing is being counted down toward, and a discouraging one.

## Verification

Three new tests, 38 total, all passing:

- exhausted + no product → **allowed**
- the same exhausted record + a product available → **still blocked** (failing open is conditional, not a hole)
- under the limit + no product → unchanged, so this is a release valve at the boundary rather than a separate mode

## Note for whoever turns the product on

The moment `com.damsac.jefe.pro.monthly` exists in ASC and agreements are signed, the limit starts being enforced for everyone — including testers who have already been walking freely. That's correct, but it will be a visible change in behaviour, so it's worth doing deliberately rather than discovering it.