### PR TITLE
fix(ios): never offer a document core will refuse to build

### DIFF
--- a/apps/ios/Sources/Engine/DocumentSchemaModel.swift
+++ b/apps/ios/Sources/Engine/DocumentSchemaModel.swift
@@ -91,7 +91,16 @@ struct DocumentSchemaModel: Identifiable, Hashable {
     var label: String
     /// Core mints `<prefix>-NNNN`; the app never invents document numbers.
     var numberPrefix: String
-    /// Which trade this belongs to; nil = all.
+    /// Which trade this belongs to.
+    ///
+    /// **`nil` does NOT mean "works for every trade."** It means "resolves only
+    /// for a session with no template" — core's `resolve_active_schema` matches
+    /// `trade_key = ?template OR (trade_key IS NULL AND ?template IS NULL)`.
+    /// The listing query is looser and *does* return nil-trade rows for any
+    /// trade, which is what made the shipped universal `report` schema appear
+    /// in a landscape operator's picker and then fail to build (Isaac,
+    /// TestFlight 2026-07-28). Filter with `buildable(from:tradeKey:)` before
+    /// offering anything.
     var tradeKey: String?
     var totalKind: String
     var totalLabelKey: String
@@ -107,6 +116,35 @@ struct DocumentSchemaModel: Identifiable, Hashable {
     /// Surfaced so the editor can steer toward "duplicate" rather than
     /// in-place edits of a shared default.
     var isBuiltin: Bool
+
+    /// The schemas a walk on `tradeKey` can ACTUALLY build — a mirror of core's
+    /// `resolve_active_schema`, so a button never offers a document that will
+    /// then be refused.
+    ///
+    /// Two rules, both copied from the resolver rather than invented here:
+    ///
+    /// 1. **Trade must match exactly**, including nil-to-nil. `listDocumentSchemas`
+    ///    is deliberately looser — it returns nil-trade rows for every trade —
+    ///    so the shipped universal `report` schema showed up in a landscape
+    ///    operator's picker and then failed with *"'report' is not a legal
+    ///    document kind for template Some(\"landscape\")"*. Duplicating Report in
+    ///    the Document Builder stamps it with the operator's trade, which is how
+    ///    a landscaper gets a working Report.
+    /// 2. **One winner per kind**, the newest. Core resolves with
+    ///    `ORDER BY updated_at DESC LIMIT 1`, so when two schemas share a kind
+    ///    exactly one is ever built; showing both would put a dead button on
+    ///    screen and collide as `ForEach` ids, which is undefined in SwiftUI and
+    ///    can swallow taps.
+    ///
+    /// Sorted by label for a stable order.
+    static func buildable(
+        from schemas: [DocumentSchemaModel], tradeKey: String?
+    ) -> [DocumentSchemaModel] {
+        let matching = schemas.filter { $0.tradeKey == tradeKey }
+        return Dictionary(grouping: matching, by: \.kind)
+            .compactMap { _, group in group.max(by: { $0.updatedAt < $1.updatedAt }) }
+            .sorted { $0.label < $1.label }
+    }
 
     init(
         id: String = "",

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -42,6 +42,7 @@ struct DocumentBuilderView: View {
             if let editing {
                 SchemaEditor(
                     schema: editing,
+                    tradeKey: model.trade.key,
                     onCancel: { self.editing = nil },
                     onSave: { save($0) },
                     onDelete: editing.isBuiltin || editing.id.isEmpty
@@ -244,14 +245,18 @@ private struct SchemaEditor: View {
     let onSave: (DocumentSchemaModel) -> Void
     /// nil for built-ins and unsaved drafts — neither can be deleted.
     let onDelete: (() -> Void)?
+    /// The operator's trade, stamped onto a copy of a built-in. See `saveShape`.
+    private let tradeKey: String?
 
     init(
         schema: DocumentSchemaModel,
+        tradeKey: String?,
         onCancel: @escaping () -> Void,
         onSave: @escaping (DocumentSchemaModel) -> Void,
         onDelete: (() -> Void)?
     ) {
         self.original = schema
+        self.tradeKey = tradeKey
         _draft = State(initialValue: schema)
         self.onCancel = onCancel
         self.onSave = onSave
@@ -277,6 +282,18 @@ private struct SchemaEditor: View {
         var copy = draft
         copy.id = ""            // create, don't overwrite the shipped default
         copy.isBuiltin = false
+        // Stamp the operator's trade. The shipped `report` built-in carries
+        // `trade_key: nil`, and core only resolves a nil-trade schema for a
+        // nil-template session — so copying the nil through produced a document
+        // type that appeared in every picker and built under none of them
+        // (Isaac, TestFlight 2026-07-28: "'prf' is not a legal document kind
+        // for template Some(\"landscape\")").
+        //
+        // A copy belongs to the operator who made it, so their trade is the
+        // right answer regardless. For an already trade-scoped built-in this is
+        // a no-op; for the universal one it's what makes duplicating Report the
+        // way a landscaper gets a working Report.
+        copy.tradeKey = tradeKey
         if draft.label != original.label {
             copy.kind = Self.slug(draft.label)
         }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -71,22 +71,28 @@ struct NotesView: View {
                 DocChoice(kind: $0, label: DocKinds.label(for: $0), stamp: DocKinds.stamp(for: $0))
             }
         } else {
-            // ONE button per KIND, choosing the same schema core will.
+            // Only what core will actually build. `buildable(from:tradeKey:)`
+            // mirrors `resolve_active_schema` — exact trade match, one winner
+            // per kind — so a button's label always describes a document that
+            // really comes out.
             //
-            // `buildDocument(kind:)` resolves with ORDER BY updated_at DESC
-            // LIMIT 1, so when two schemas share a kind — which happens the
-            // moment someone customizes a built-in — exactly one of them gets
-            // built. Showing both would put two buttons on screen where one is
-            // dead, and (before this) they collided as ForEach ids, which is
-            // undefined behaviour in SwiftUI and can swallow taps outright.
-            //
-            // Mirroring the resolver here means the button's label always
-            // describes the document that will actually come out.
-            let winners = Dictionary(grouping: schemas, by: \.kind)
-                .compactMap { _, group in group.max(by: { $0.updatedAt < $1.updatedAt }) }
-                .sorted { $0.label < $1.label }
+            // The trade filter is the field fix (Isaac, TestFlight 2026-07-28):
+            // `listDocumentSchemas` returns nil-trade rows for every trade, so
+            // the universal `report` built-in was offered to a landscape
+            // operator and then refused by the build. Same for any doc type
+            // duplicated from it.
+            let winners = DocumentSchemaModel.buildable(from: schemas, tradeKey: model.trade.key)
             docChoices = winners.map {
                 DocChoice(kind: $0.kind, label: $0.label, stamp: $0.numberPrefix.uppercased())
+            }
+            // Every schema filtered out — an operator with only nil-trade
+            // customs would face an action row with no buttons, which reads as
+            // a broken screen. Fall back to the built-in list for the trade,
+            // which core's `doc_kinds_for_template` accepts unconditionally.
+            if docChoices.isEmpty {
+                docChoices = DocKinds.legalKinds(for: model.trade.key).map {
+                    DocChoice(kind: $0, label: DocKinds.label(for: $0), stamp: DocKinds.stamp(for: $0))
+                }
             }
         }
     }

--- a/apps/ios/Tests/DocumentChoiceTests.swift
+++ b/apps/ios/Tests/DocumentChoiceTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `DocumentSchemaModel.buildable(from:tradeKey:)` — the picker's
+/// mirror of core's `resolve_active_schema`.
+///
+/// This exists because the two drifted in the field. `listDocumentSchemas`
+/// returns nil-trade rows for EVERY trade, but core resolves a nil-trade schema
+/// only for a nil-template session. So a landscape operator was shown REPORT and
+/// a custom PRF, tapped either, and got:
+///
+///     'report' is not a legal document kind for template Some("landscape")
+///
+/// A button that cannot build the document it names is worse than a missing
+/// button, so these pin the filter in both directions: nothing offered that core
+/// refuses, and nothing dropped that core accepts.
+final class DocumentChoiceTests: XCTestCase {
+    private func schema(
+        _ kind: String, label: String? = nil, trade: String?, updatedAt: UInt64 = 0,
+        id: String = ""
+    ) -> DocumentSchemaModel {
+        DocumentSchemaModel(
+            id: id.isEmpty ? kind : id,
+            kind: kind,
+            label: label ?? kind.capitalized,
+            numberPrefix: String(kind.prefix(3)).uppercased(),
+            tradeKey: trade,
+            updatedAt: updatedAt
+        )
+    }
+
+    // MARK: The field bug
+
+    func testUniversalSchemaIsNotOfferedToATradeSession() {
+        // The exact shape of Isaac's report: the shipped `report` built-in
+        // carries trade_key nil and was listed for a landscape walk.
+        let all = [
+            schema("estimate", trade: "landscape"),
+            schema("report", trade: nil)
+        ]
+        let kinds = DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").map(\.kind)
+        XCTAssertEqual(kinds, ["estimate"], "a nil-trade schema must not be offered to a trade walk")
+    }
+
+    func testCustomTypeCopiedFromReportIsNotOfferedUntilItHasATrade() {
+        // The PRF case. Duplicating Report used to carry its nil trade through,
+        // producing a doc type visible everywhere and buildable nowhere.
+        let all = [schema("prf", label: "PRF", trade: nil)]
+        XCTAssertTrue(DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").isEmpty)
+    }
+
+    func testTheSameCustomTypeIsOfferedOnceItCarriesTheTrade() {
+        // And the fix: `saveShape` now stamps the operator's trade, so their
+        // own document type works. This is also how a landscaper gets a
+        // working Report — duplicate it, and the copy is trade-scoped.
+        let all = [schema("prf", label: "PRF", trade: "landscape")]
+        XCTAssertEqual(
+            DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").map(\.kind), ["prf"]
+        )
+    }
+
+    // MARK: Trade matching in general
+
+    func testAnotherTradesSchemaIsNeverOffered() {
+        let all = [
+            schema("condition", trade: "property"),
+            schema("estimate", trade: "landscape")
+        ]
+        XCTAssertEqual(
+            DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").map(\.kind),
+            ["estimate"]
+        )
+    }
+
+    func testNilTradeSessionGetsExactlyTheUniversalSchemas() {
+        // The mirror image — nil-to-nil matches, and a trade-scoped schema
+        // must not leak into a session with no template.
+        let all = [
+            schema("report", trade: nil),
+            schema("estimate", trade: "landscape")
+        ]
+        XCTAssertEqual(
+            DocumentSchemaModel.buildable(from: all, tradeKey: nil).map(\.kind), ["report"]
+        )
+    }
+
+    // MARK: One winner per kind
+
+    func testTwoSchemasSharingAKindCollapseToTheNewest() {
+        // Core builds ORDER BY updated_at DESC LIMIT 1, so only one is ever
+        // built. Two buttons would mean one dead button — and duplicate
+        // ForEach ids, which is undefined in SwiftUI and can swallow taps.
+        let all = [
+            schema("estimate", label: "Estimate", trade: "landscape", updatedAt: 100, id: "builtin"),
+            schema("estimate", label: "My Estimate", trade: "landscape", updatedAt: 900, id: "custom")
+        ]
+        let winners = DocumentSchemaModel.buildable(from: all, tradeKey: "landscape")
+        XCTAssertEqual(winners.count, 1)
+        XCTAssertEqual(winners.first?.id, "custom", "newest updatedAt wins, matching core")
+        XCTAssertEqual(
+            winners.first?.label, "My Estimate",
+            "the label must describe the schema that actually builds"
+        )
+    }
+
+    func testDistinctKindsAreAllKeptAndSortedByLabel() {
+        let all = [
+            schema("work_order", label: "Work Order", trade: "landscape"),
+            schema("estimate", label: "Estimate", trade: "landscape"),
+            schema("invoice", label: "Invoice", trade: "landscape")
+        ]
+        XCTAssertEqual(
+            DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").map(\.label),
+            ["Estimate", "Invoice", "Work Order"]
+        )
+    }
+
+    func testEmptyInputIsEmptyNotACrash() {
+        XCTAssertTrue(DocumentSchemaModel.buildable(from: [], tradeKey: "landscape").isEmpty)
+    }
+}


### PR DESCRIPTION
Isaac's TestFlight report, 2026-07-28. Two buttons on the notes screen — **REPORT** and a custom **PRF** — both failed:

```
document build error: invalid state: 'report' is not a legal document kind
for template Some("landscape")
```

Worth noting: that message is legible only because #275 replaced the old "couldn't build the report" with the real error. It named the bug outright.

## Root cause — two queries that disagree

| | trade filter |
|---|---|
| `list_document_schemas(trade)` | `?1 IS NULL OR trade_key = ?1 OR **trade_key IS NULL**` |
| `resolve_active_schema(kind, template)` | `trade_key = ?2 OR (trade_key IS NULL **AND ?2 IS NULL**)` |

The listing treats a nil `trade_key` as *universal*. The resolver treats it as *only for a session with no template*. The picker read the listing.

The shipped `report` built-in is seeded `trade_key: None`, so a landscape operator was **offered a REPORT button that could never build**. And `saveShape` copied that nil straight through when duplicating it — which is exactly how the PRF was made, so it inherited the same defect.

## Why this is fixed app-side and not in core

My first instinct was to make the resolver treat nil as universal. **I backed that out.** There is a named parity test — `resolve_report_only_for_none_template_not_for_landscape` — that pins the current behaviour on purpose, and `doc_kinds_for_template` is an explicit per-trade allowlist. Flipping a deliberate core decision while dam is days from a month away, on my read of intent, is not a call I should make alone.

The app-side fix is also just correct on its own: **a picker must never offer a document that will be refused.**

## The fix

- `DocumentSchemaModel.buildable(from:tradeKey:)` — mirrors the resolver exactly: trade must match including nil-to-nil, one winner per kind by newest. The notes picker uses it.
- `saveShape` stamps the operator's trade on a copy of a built-in. A copy belongs to whoever made it, so their trade is right regardless — and it means **duplicating Report is how a landscaper gets a working Report** (their copy is trade-scoped, so core's `has_active_schema` clause accepts it).
- If filtering empties the row entirely, it falls back to the trade's built-in kinds — an action row with no buttons reads as a broken screen.

## Verification

**46 tests, 8 new**, pinning both directions — nothing offered that core refuses, nothing dropped that core accepts — plus the PRF case before and after the trade stamp.

## For dam

**Should a nil-trade schema be buildable under any trade?** Today it can be listed but never built, which makes "universal" a shape nothing can use. Either the resolver should treat nil as universal (then your parity test's premise needs revisiting), or `report` should stop being seeded nil and the listing query should stop returning nil-trade rows.

I've made the app agree with core rather than guess. Left as-is, a landscaper gets Report only by duplicating it — which works, but is not obvious.