### PR TITLE
fix(ios): readable failures, and the demo builds the document you asked for (#222)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1023,7 +1023,7 @@ final class AppModel {
                 // and explained nothing. Isaac tapped a custom button and got
                 // no usable signal at all.
                 self.documentBuildError =
-                    "Couldn’t build it — \(error.localizedDescription)"
+                    "Couldn’t build it — \(EngineErrorText.readable(error))"
             }
         }
     }

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1028,7 +1028,19 @@ final class AppModel {
         }
     }
 
-    func buildPrimaryDocument() { buildDocument(kind: DocKinds.primaryKind(for: trade.key)) }
+    /// Builds the template's lead document kind.
+    ///
+    /// `doc=<kind>` overrides it — a QA hook (parallel to `autoflow`/`autopdf`)
+    /// so a headless run can reach any document type. Without it only the lead
+    /// kind was reachable unattended, which is why #222 — the demo engine
+    /// ignoring `kind` entirely — survived as long as it did: nothing that ran
+    /// without hands ever built a second kind. Store screenshots need this too.
+    func buildPrimaryDocument() {
+        let arg = ProcessInfo.processInfo.arguments.first { $0.hasPrefix("doc=") }
+        let kind = arg.map { String($0.dropFirst("doc=".count)) }
+            ?? DocKinds.primaryKind(for: trade.key)
+        buildDocument(kind: kind)
+    }
 
     // MARK: Item edits (Plan 16 CRUD) — the walk is a first draft; the operator
     // fixes it here. These go through the CORE (not app-side pixels), so a

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -357,14 +357,50 @@ final class DemoWalkEngine: WalkEngine {
     // per-kind rendering — it returns the trade's canned document rows
     // regardless of `kind` (Worked Ex B shape), so the button -> ReviewView
     // wiring is exercised end to end without a backend.
+    /// Issue #222: this used to take `kind` and never read it, so every button
+    /// on the notes screen produced the same document. Demo is the
+    /// no-credential fallback AND the path a fresh clone takes — including any
+    /// run used to produce App Store screenshots — so "every document looks like
+    /// an estimate" is a claim we'd be shipping to reviewers.
+    ///
+    /// It mirrors the two distinctions the real pipeline actually makes, rather
+    /// than inventing per-kind fixtures nobody maintains:
+    ///
+    /// - **Pricing** (`is_pricing_kind` in core): only estimates and invoices
+    ///   carry money. A work order handed to a crew with prices on it is the
+    ///   wrong document, and printing one is a real-world mistake.
+    /// - **Total shape** (`total_shape` in core): an inspection has no summable
+    ///   dollar total; it counts findings.
     func buildDocument(sessionId: String, kind: String) async throws -> DocumentModel {
         try? await Task.sleep(for: .seconds(0.8))
+        let priced = DocKinds.isPricingKind(kind)
+        // Strip everything that only means something on a priced document:
+        // the amount, the price-history hint ("LAST 3: $110 · $120"), the gap
+        // flag (a gap IS a missing price — it drives the "+1 GAP" badge), and
+        // the warning sub that explains the gap. A crew reading a work order
+        // should see the work, not a conversation about money.
+        let rows = priced ? trade.rows : trade.rows.map { row in
+            var stripped = row
+            stripped.amount = ""
+            stripped.hint = nil
+            stripped.isGap = false
+            // The edit affordance marks an EDITABLE AMOUNT; with no amount it
+            // is a mark pointing at nothing.
+            stripped.isEdit = false
+            if row.subWarn { stripped.sub = "" }
+            stripped.subWarn = false
+            return stripped
+        }
+        // Findings-counted rather than summed, matching core's ("static",
+        // "findings") shape for an inspection.
+        let counted = kind == "inspection"
         return DocumentModel(
-            rows: trade.rows,
-            totalKey: trade.totalKey,
-            staticTotal: trade.totalValue,
-            note: trade.note,
-            send: trade.send
+            rows: rows,
+            totalKey: priced ? trade.totalKey : (counted ? "FINDINGS" : "ITEMS"),
+            staticTotal: priced ? trade.totalValue : "\(rows.count)",
+            // The gap/price note only means anything on a priced document.
+            note: priced ? trade.note : "",
+            send: "SEND \(DocKinds.label(for: kind).uppercased())"
         )
     }
 

--- a/apps/ios/Sources/Engine/EngineErrorText.swift
+++ b/apps/ios/Sources/Engine/EngineErrorText.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Turns an engine error into something a contractor can read.
+///
+/// UniFFI conforms its generated error enums to `LocalizedError` with
+/// `errorDescription = String(reflecting: self)`, so `localizedDescription`
+/// hands back the Swift *reflection* of the case:
+///
+/// ```
+/// MurmurCoreFFI.EngineError.Document(message: "document build error: invalid
+/// state: 'prf' is not a legal document kind for template Some(\"landscape\")")
+/// ```
+///
+/// That shipped to TestFlight and Isaac photographed it (2026-07-28). The
+/// payload inside it was genuinely useful — it named a real bug — but the
+/// wrapper is Swift-module trivia, the `\"` escapes are an artifact of being
+/// printed twice, and none of it belongs on a job site. App Review would see
+/// the same thing.
+///
+/// So: keep the message, drop the packaging. This deliberately does NOT
+/// rewrite errors into friendly copy — a vague "something went wrong" is what
+/// made the previous version of this screen useless, and the specific text is
+/// what turns a field report into a fix. It only removes what carries no
+/// information.
+enum EngineErrorText {
+    /// Rust error-variant names that lead the payload. They name a `CoreError`
+    /// case, which is an implementation detail of the crate — the sentence
+    /// after them is the part with meaning.
+    private static let noisePrefixes = ["invalid state: ", "invalid input: "]
+
+    static func readable(_ error: Error) -> String {
+        let raw = error.localizedDescription
+        var text = payload(in: raw) ?? raw
+
+        // Strip variant names wherever they lead a clause. "document build
+        // error: invalid state: 'prf' is not…" keeps the useful "document build
+        // error:" context and loses the enum name in the middle.
+        for prefix in noisePrefixes {
+            text = text.replacingOccurrences(of: prefix, with: "")
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Extracts the `message: "…"` payload from UniFFI's reflected description,
+    /// or nil when the shape doesn't match — a StoreKit error, an `NSError`, or
+    /// a future UniFFI that formats differently all fall through to the raw
+    /// description rather than being mangled.
+    private static func payload(in raw: String) -> String? {
+        guard let start = raw.range(of: "(message: \""),
+              raw.hasSuffix("\")")
+        else { return nil }
+        let inner = raw[start.upperBound..<raw.index(raw.endIndex, offsetBy: -2)]
+        guard !inner.isEmpty else { return nil }
+        // Undo one level of escaping: the payload was rendered as a Swift
+        // string literal, so its own quotes arrived as \" and its backslashes
+        // as \\. Order matters — quotes first, then backslashes, or a literal
+        // \\" would collapse wrongly.
+        return String(inner)
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\\\", with: "\\")
+    }
+}

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -47,11 +47,13 @@ struct CapturedFixture: Identifiable {
 struct DocRowFixture: Identifiable {
     let id = UUID()
     let title: String
-    let sub: String
+    var sub: String
     var subWarn: Bool = false
     var hint: String? = nil
     let qty: String
-    let amount: String
+    /// `var` so a non-pricing document can blank it without rebuilding the row
+    /// field by field (#222) — a work order must not carry prices.
+    var amount: String
     var isEdit: Bool = false
     var isGap: Bool = false
     /// The core item this row was built from (Plan 12). `nil` for demo/

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -485,7 +485,7 @@ extension BoardView {
         } catch {
             // Leave whatever is on screen rather than blanking the list — the
             // vocabulary/schema editors' posture.
-            jobsError = "Couldn't load jobs: \(error.localizedDescription)"
+            jobsError = "Couldn't load jobs: \(EngineErrorText.readable(error))"
         }
     }
 
@@ -498,7 +498,7 @@ extension BoardView {
             try model.setWalkJob(sessionId: walk.sessionId, jobId: jobId)
             jobsError = nil
         } catch {
-            jobsError = "Couldn't file walk: \(error.localizedDescription)"
+            jobsError = "Couldn't file walk: \(EngineErrorText.readable(error))"
         }
     }
 
@@ -519,7 +519,7 @@ extension BoardView {
             operatorJobs.insert(created, at: 0)
             jobsError = nil
         } catch {
-            jobsError = "Couldn't add job: \(error.localizedDescription)"
+            jobsError = "Couldn't add job: \(EngineErrorText.readable(error))"
         }
     }
 }

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -152,7 +152,7 @@ struct DocumentBuilderView: View {
         } catch {
             // Leave whatever is on screen intact rather than blanking the list
             // (the vocabulary editor's posture).
-            loadError = "Couldn't load document types: \(error.localizedDescription)"
+            loadError = "Couldn't load document types: \(EngineErrorText.readable(error))"
         }
     }
 
@@ -162,7 +162,7 @@ struct DocumentBuilderView: View {
             editing = nil
             load()
         } catch {
-            loadError = "Couldn't save: \(error.localizedDescription)"
+            loadError = "Couldn't save: \(EngineErrorText.readable(error))"
             editing = nil
         }
     }
@@ -173,7 +173,7 @@ struct DocumentBuilderView: View {
             editing = nil
             load()
         } catch {
-            loadError = "Couldn't delete: \(error.localizedDescription)"
+            loadError = "Couldn't delete: \(EngineErrorText.readable(error))"
             editing = nil
         }
     }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -116,7 +116,7 @@ struct NotesView: View {
             try model.setWalkJob(sessionId: sessionId, jobId: jobId)
             fileError = nil
         } catch {
-            fileError = error.localizedDescription
+            fileError = EngineErrorText.readable(error)
         }
     }
 
@@ -128,7 +128,7 @@ struct NotesView: View {
             loadJobs()
             file(under: job.id)
         } catch {
-            fileError = error.localizedDescription
+            fileError = EngineErrorText.readable(error)
         }
     }
 

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -46,8 +46,18 @@ struct ReviewView: View {
                         Letterhead(
                             biz: model.letterheadBiz,
                             bizSub: model.letterheadSub,
-                            docKind: model.trade.docKind,
-                            docNo: model.trade.docNo,
+                            // The kind actually being built, not the trade's
+                            // lead kind — a Work Order titled ESTIMATE with an
+                            // EST- number is the document equivalent of a typo
+                            // on company letterhead (#222). `docNo` is blank
+                            // outside the fixture estimate rather than invented:
+                            // core mints real numbers, and a fake one on a real
+                            // document would be worse than none.
+                            docKind: model.reviewKind.map { DocKinds.label(for: $0).uppercased() }
+                                ?? model.trade.docKind,
+                            docNo: model.reviewKind == nil
+                                || model.reviewKind == DocKinds.primaryKind(for: model.trade.key)
+                                ? model.trade.docNo : "",
                             docDate: model.letterheadDate,
                             branding: model.branding
                         )
@@ -58,8 +68,13 @@ struct ReviewView: View {
                         }
                         TotalRow(key: doc.totalKey, value: doc.totalValue, gaps: doc.gapCount)
                             .padding(.top, 2)
-                        RevNote(text: doc.note)
-                            .padding(.top, 10)
+                        // Empty note = no bar. An empty amber block reads as a
+                        // rendering failure, and a non-priced document has no
+                        // pricing gap to talk about (#222).
+                        if !doc.note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            RevNote(text: doc.note)
+                                .padding(.top, 10)
+                        }
 
                         // Document structure basics (DocumentLayout): operator
                         // terms + a client signature line, set in the PAPER tab.

--- a/apps/ios/Tests/EngineErrorTextTests.swift
+++ b/apps/ios/Tests/EngineErrorTextTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `EngineErrorText.readable` — what an operator actually reads when
+/// something fails.
+///
+/// The anchor case is real: Isaac photographed this on TestFlight 2026-07-28,
+/// rendered verbatim in a red bar on the notes screen. The payload inside it
+/// named a genuine bug, so the goal is to keep every word of that and throw
+/// away only the packaging.
+///
+/// The failure mode to guard against is over-cleaning. A helper that mangles a
+/// StoreKit error, or swallows an unfamiliar shape into "something went wrong",
+/// would cost us the next field diagnosis — which is the whole reason this text
+/// is on screen.
+final class EngineErrorTextTests: XCTestCase {
+    /// Stands in for a UniFFI-generated error: `LocalizedError` whose
+    /// description is `String(reflecting:)` of the case.
+    private struct Reflected: LocalizedError {
+        let text: String
+        var errorDescription: String? { text }
+    }
+
+    // MARK: The case from the field
+
+    func testUnwrapsTheRealTestFlightError() {
+        let error = Reflected(text:
+            #"MurmurCoreFFI.EngineError.Document(message: "document build error: invalid state: 'prf' is not a legal document kind for template Some(\"landscape\")")"#
+        )
+        XCTAssertEqual(
+            EngineErrorText.readable(error),
+            #"document build error: 'prf' is not a legal document kind for template Some("landscape")"#
+        )
+    }
+
+    func testKeepsTheLeadingContextAndDropsOnlyTheVariantName() {
+        // "document build error:" is context worth keeping. "invalid state:"
+        // names a CoreError case — an implementation detail of the crate.
+        let error = Reflected(text:
+            #"MurmurCoreFFI.EngineError.Item(message: "invalid state: item is not editable")"#
+        )
+        XCTAssertEqual(EngineErrorText.readable(error), "item is not editable")
+    }
+
+    func testUnescapesEmbeddedQuotesAndBackslashes() {
+        let error = Reflected(text:
+            #"MurmurCoreFFI.EngineError.Store(message: "bad path \"C:\\jobs\" rejected")"#
+        )
+        XCTAssertEqual(EngineErrorText.readable(error), #"bad path "C:\jobs" rejected"#)
+    }
+
+    // MARK: Must not mangle anything else
+
+    func testAPlainErrorPassesThroughUntouched() {
+        // StoreKit and Foundation errors already have good descriptions; this
+        // helper must leave them exactly alone.
+        struct Plain: LocalizedError {
+            var errorDescription: String? { "The network connection was lost." }
+        }
+        XCTAssertEqual(EngineErrorText.readable(Plain()), "The network connection was lost.")
+    }
+
+    func testAnUnfamiliarShapeFallsBackToTheFullDescription() {
+        // A future UniFFI that formats differently must degrade to showing
+        // everything, never to showing nothing.
+        let error = Reflected(text: "SomeModule.Weird.case(code: 42)")
+        XCTAssertEqual(EngineErrorText.readable(error), "SomeModule.Weird.case(code: 42)")
+    }
+
+    func testAnEmptyPayloadFallsBackRatherThanRenderingBlank() {
+        // An empty red bar tells the operator nothing at all — worse than the
+        // ugly version, because there is nothing to report back.
+        let error = Reflected(text: #"MurmurCoreFFI.EngineError.Store(message: "")"#)
+        XCTAssertFalse(EngineErrorText.readable(error).isEmpty)
+    }
+
+    func testTrimsSurroundingWhitespace() {
+        let error = Reflected(text:
+            #"MurmurCoreFFI.EngineError.Store(message: "  invalid state: locked  ")"#
+        )
+        XCTAssertEqual(EngineErrorText.readable(error), "locked")
+    }
+}


### PR DESCRIPTION
Two fixes off Isaac's TestFlight screenshots. They landed on one branch; keeping them together because they're the same lesson — *the app was telling operators things that weren't true.*

## 1. Operators were shown the Swift enum wrapper

The red bar on the notes screen read, verbatim:

```
Couldn't build it — MurmurCoreFFI.EngineError.Document(message: "document
build error: invalid state: 'prf' is not a legal document kind for template
Some(\"landscape\")")
```

UniFFI conforms its error enums to `LocalizedError` with `errorDescription = String(reflecting: self)`, so `localizedDescription` returns the reflected *case* — module path, case name, `message:` label, quotes escaped from being printed twice. App Review sees the same thing.

**Keep the message, drop the packaging.** I did not rewrite these into friendly copy, deliberately: a vague "something went wrong" is what made this screen useless before #275, and the specific text is what turned a screenshot into a same-day root cause. Only Swift module trivia and `CoreError` variant names (`invalid state:`) are removed.

Applied at all **nine** engine-error sites. The two StoreKit sites in `Entitlement` are untouched — Foundation errors already have good descriptions, and running them through this would be the mangling it exists to avoid.

## 2. The demo built the same document for every button (#222)

`DemoWalkEngine.buildDocument` took `kind` and never read it. Worse, the letterhead came from the trade's *lead* kind — so a **Work Order was titled ESTIMATE and stamped EST-0047**, which is the document equivalent of a typo on company letterhead.

Demo is the no-credential fallback and the path a fresh clone takes — **including any run used to produce App Store screenshots.**

It now mirrors the two distinctions the real pipeline makes, rather than inventing per-kind fixtures nobody maintains:

- **Pricing** (`is_pricing_kind`): only estimates and invoices carry money. Amounts, the price-history hint, the gap flag, and the edit affordance are all stripped otherwise — a crew reading a work order should see the work, not a conversation about money. A work order handed over *with* prices on it is a real-world mistake.
- **Total shape** (`total_shape`): an inspection counts findings; it has no summable dollar total.

Also: the letterhead follows the kind being built, an empty note renders **no bar** (an empty amber block reads as a rendering failure), and `doc=<kind>` lets a headless run reach a non-lead kind at all. **That last gap is why this survived so long — nothing that ran without hands ever built a second kind.**

## Verification

**53 tests pass.** The error helper has 7 new ones: the anchor uses the exact string off Isaac's screenshot; four more guard *over*-cleaning, which is the real risk — a plain error passes through untouched, an unfamiliar shape falls back to the **full** description, and an empty payload falls back rather than rendering a blank red bar.

Three document kinds rendered on-sim and inspected:

| kind | result |
|---|---|
| estimate | unchanged — prices, $1,210 total, +1 GAP, SEND ESTIMATE |
| invoice | priced, letterhead INVOICE, SEND INVOICE |
| work_order | no prices, ITEMS 6, no gap badge, no empty bar, SEND WORK ORDER |

## Known remaining wart

`Some("landscape")` is Rust's `{:?}` on an `Option<String>` and survives — that's core's prose, not packaging, and rewriting another crate's error text on a guess loses meaning.