### PR TITLE
fix(ios): board rows say what the walk was (#221)

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -86,6 +86,30 @@ final class AppModel {
             return sent ? .documented : .saved
         }
 
+        /// The board row's headline. Pure so it can be tested without a store.
+        ///
+        /// Prefers the walk's own summary — the one thing that answers "what
+        /// was this?" months later. Falls back to a document number when there
+        /// genuinely is one (in-session records keep the real minted number),
+        /// then to a plain, honest label. Never blank: an untitled row is
+        /// unreadable and looks broken.
+        var title: String {
+            let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+            if !docNo.isEmpty { return docNo }
+            return queued ? "Walk still processing" : "Walk notes"
+        }
+
+        /// The quiet second line. Item count is a FACT about the walk; the doc
+        /// kind is advisory and would read as "an estimate exists" on a walk
+        /// that never produced one (#221). Kind is shown only once a document
+        /// really was built.
+        var subtitle: String {
+            let items = itemCount == 1 ? "1 item" : "\(itemCount) items"
+            guard disposition == .documented, !docKind.isEmpty else { return items }
+            return "\(items) · \(docKind.capitalized)"
+        }
+
         /// Raw start time, epoch SECONDS (core `started_at`). Kept alongside
         /// the formatted `time` for two reasons that arrived independently:
         /// the TODAY list wants a clock ("9:41") while a job card spanning
@@ -102,10 +126,27 @@ final class AppModel {
         /// job months ago has to be movable.
         var jobId: String?
 
+        /// The walk's narrative summary — what the board row actually says.
+        ///
+        /// The row used to lead with `docNo`, which is synthesized EMPTY for
+        /// every stored walk (the number is minted per-build and isn't in the
+        /// lightweight projection), so every hydrated row rendered with a blank
+        /// title (#221). The summary is the honest answer to "what was this
+        /// walk?" — and it is precisely the question an operator opening a
+        /// months-old walk has.
+        let summary: String
+
+        /// How many lines the walk captured. A quiet, TRUE subtitle — unlike
+        /// the doc kind, which is advisory and reads as a claim that an
+        /// estimate exists when none was ever built.
+        let itemCount: Int
+
         init(time: String, docNo: String, docKind: String, sent: Bool,
              sessionId: String, queued: Bool, jobId: String? = nil,
-             startedAt: UInt64 = 0) {
+             startedAt: UInt64 = 0, summary: String = "", itemCount: Int = 0) {
             self.jobId = jobId
+            self.summary = summary
+            self.itemCount = itemCount
             self.time = time
             self.docNo = docNo
             self.docKind = docKind
@@ -130,6 +171,8 @@ final class AppModel {
             self.queued = summary.queued
             self.jobId = summary.jobId
             self.startedAt = summary.startedAt
+            self.summary = summary.summary
+            self.itemCount = Int(summary.itemCount)
         }
     }
     private(set) var sessionWalks: [WalkRecord] = []
@@ -1352,7 +1395,8 @@ final class AppModel {
         }
         sessionWalks.append(WalkRecord(
             time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: true,
-            sessionId: currentSessionId ?? "", queued: notes?.queued ?? false
+            sessionId: currentSessionId ?? "", queued: notes?.queued ?? false,
+            summary: notes?.summary ?? "", itemCount: notes?.items.count ?? 0
         ))
         shareURL = nil
         document = nil
@@ -1369,7 +1413,8 @@ final class AppModel {
         if exitPracticeIfActive() { return }
         sessionWalks.append(WalkRecord(
             time: Self.clockNow(), docNo: trade.docNo, docKind: trade.docKind, sent: false,
-            sessionId: currentSessionId ?? "", queued: notes?.queued ?? false
+            sessionId: currentSessionId ?? "", queued: notes?.queued ?? false,
+            summary: notes?.summary ?? "", itemCount: notes?.items.count ?? 0
         ))
         shareURL = nil
         document = nil

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -767,11 +767,16 @@ private struct WalkLogRow<Trailing: View>: View {
                         .font(Theme.F.mono(11, .medium))
                         .foregroundStyle(Theme.C.ink)
                         .frame(width: 46, alignment: .leading)
+                    // What the walk WAS, not what document it might become
+                    // (#221). This led with `docNo`, which is synthesized empty
+                    // for every stored walk — so each hydrated row rendered
+                    // with a blank title — over a `docKind` subtitle that reads
+                    // as a claim an estimate exists when none was built.
                     VStack(alignment: .leading, spacing: 1) {
-                        Text(walk.docNo)
+                        Text(walk.title)
                             .font(Theme.F.ui(14.5, .semibold))
                             .lineLimit(1)
-                        Text(walk.docKind.capitalized)
+                        Text(walk.subtitle)
                             .font(Theme.F.cond(11.5, .medium))
                             .foregroundStyle(Theme.C.ink60)
                             .lineLimit(1)

--- a/apps/ios/Tests/WalkRowLabelTests.swift
+++ b/apps/ios/Tests/WalkRowLabelTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `WalkRecord.title` / `.subtitle` — what a board row says a walk was.
+///
+/// Issue #221. The row led with `docNo`, which `WalkRecord(_ summary:)`
+/// synthesizes EMPTY for every stored walk (the number is minted per-build and
+/// isn't in the lightweight projection), over a `docKind` subtitle. So a
+/// hydrated board rendered rows with blank titles under a label claiming an
+/// "Estimate" that had never been built.
+///
+/// The rule these pin: **say what the walk was, never claim a document that
+/// doesn't exist, and never render blank.**
+final class WalkRowLabelTests: XCTestCase {
+    private func walk(
+        summary: String = "", docNo: String = "", docKind: String = "",
+        itemCount: Int = 0, sent: Bool = false, queued: Bool = false
+    ) -> AppModel.WalkRecord {
+        AppModel.WalkRecord(
+            time: "9:41", docNo: docNo, docKind: docKind, sent: sent,
+            sessionId: "s1", queued: queued, summary: summary, itemCount: itemCount
+        )
+    }
+
+    // MARK: Title
+
+    func testSummaryIsTheHeadline() {
+        let record = walk(summary: "Walked 117 Lexington — front beds need mulch.", itemCount: 4)
+        XCTAssertEqual(record.title, "Walked 117 Lexington — front beds need mulch.")
+    }
+
+    func testFallsBackToTheDocumentNumberWhenThereIsARealOne() {
+        // In-session records keep the real minted number until the next hydrate.
+        XCTAssertEqual(walk(docNo: "EST-0047").title, "EST-0047")
+    }
+
+    func testNeverRendersBlank() {
+        // The actual #221 symptom: every stored walk had docNo == "" and, before
+        // summary was threaded through, nothing else to show.
+        XCTAssertFalse(walk().title.isEmpty)
+        XCTAssertEqual(walk().title, "Walk notes")
+    }
+
+    func testAStillProcessingWalkSaysSo() {
+        XCTAssertEqual(walk(queued: true).title, "Walk still processing")
+    }
+
+    func testWhitespaceOnlySummaryIsTreatedAsAbsent() {
+        XCTAssertEqual(walk(summary: "   \n ", docNo: "EST-0047").title, "EST-0047")
+    }
+
+    // MARK: Subtitle
+
+    func testSubtitleCountsItems() {
+        XCTAssertEqual(walk(itemCount: 5).subtitle, "5 items")
+    }
+
+    func testSubtitleSingularizesOneItem() {
+        XCTAssertEqual(walk(itemCount: 1).subtitle, "1 item")
+    }
+
+    func testDocKindIsHiddenUntilADocumentActuallyExists() {
+        // The other half of #221. A walk that was finished and never turned
+        // into a document must not advertise "Estimate" — `docKind` is
+        // advisory, and showing it reads as a claim.
+        let notDocumented = walk(docKind: "ESTIMATE", itemCount: 3, sent: false)
+        XCTAssertEqual(notDocumented.subtitle, "3 items")
+    }
+
+    func testDocKindAppearsOnceTheDocumentWasBuilt() {
+        let documented = walk(docKind: "ESTIMATE", itemCount: 3, sent: true)
+        XCTAssertEqual(documented.subtitle, "3 items · Estimate")
+    }
+
+    func testAQueuedWalkDoesNotClaimADocumentEvenIfSentIsSet() {
+        // `queued` wins in `disposition`, so processing never shows a kind.
+        let queued = walk(docKind: "ESTIMATE", itemCount: 2, sent: true, queued: true)
+        XCTAssertEqual(queued.subtitle, "2 items")
+    }
+}


### PR DESCRIPTION
Closes the rest of #221. The issue reported *"fixture doc numbers (EST-0047) and unexplained SENT/Estimate labels"*; the fixture numbers were fixed earlier, and looking at what replaced them turned up something worse.

## The bug

The row led with `docNo`. `WalkRecord(_ summary:)` synthesizes that **empty** for every stored walk — the document number is minted per-build and isn't in the lightweight projection (an accepted Plan 20 F7 fidelity loss).

So **every hydrated board row rendered with a blank title.** Under it sat `docKind`, which is advisory: a walk that was finished and never turned into a document still said "Estimate", which reads as a claim that an estimate exists.

A blank line above a false one.

## The fix

`WalkSummary` already carried `summary` and `itemCount` — nothing new from core.

- **Title** = the walk's own summary. That is the honest answer to "what was this walk?", and it's precisely the question someone opening a months-old walk has — Isaac's stated reason for jobs existing. Falls back to a real document number when there is one (in-session records keep the minted number), then to a plain label. **Never blank.**
- **Subtitle** = item count, a fact about the walk. The doc kind appears **only once a document was actually built**, so the row stops claiming paperwork that doesn't exist.

Both are pure computed properties on `WalkRecord`, so they're testable without a store.

## Verification

**63 tests, 10 new.** They pin the rule in both directions: the summary wins when present; a whitespace-only summary counts as absent; nothing ever renders blank; the doc kind is hidden when `sent` is false **and** when the walk is still queued (where `disposition` makes `queued` win over `sent`).

**Not visually verified, and worth being straight about why.** `DemoWalkEngine.listSessions()` returns `[]` by design — its log is in-memory — so a *hydrated* row is unreachable on the simulator; relaunching after a demo walk gives an empty board. The path this fixes is the real-core one. The pure computed properties are the gate, which is why they're separated out and covered this heavily.

Isaac will see it on the next TestFlight build.