### PR TITLE
fix(ios): the design gallery renders again — I broke it in #277 (#289)

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -287,6 +287,21 @@ struct GalleryRoot: View {
 
     @State private var path: [Dest] = GalleryRoot.initialPath()
 
+    /// ONE model for the whole gallery, created once.
+    ///
+    /// The vocab and structure destinations used to construct `AppModel()`
+    /// inline in the `navigationDestination` builder. SwiftUI re-evaluates that
+    /// builder freely, so every evaluation minted a fresh model — which was
+    /// merely wasteful until `AppModel` gained an `Entitlement` (#277), and each
+    /// one spawned a `Transaction.updates` listener. From then on `screen=vocab`
+    /// and `screen=structure` rendered BLANK (#289): the whole design gallery,
+    /// the only headless route to any screen behind a tap, was dead.
+    ///
+    /// Hoisting to `@State` is the fix and is also just correct SwiftUI —
+    /// building an observable model inside a ViewBuilder was always wrong,
+    /// StoreKit only made it visible.
+    @State private var galleryModel = AppModel()
+
     var body: some View {
         NavigationStack(path: $path) {
             VStack(alignment: .leading, spacing: 0) {
@@ -334,11 +349,11 @@ struct GalleryRoot: View {
                 case .jobs: JobsBoardScreen(trade: Fixtures.landscape)
                 case .capture: CaptureScreen(trade: Fixtures.landscape)
                 case .document: DocumentReviewScreen(trade: Fixtures.landscape)
-                case .vocab: VocabularyView(model: AppModel())
+                case .vocab: VocabularyView(model: galleryModel)
             // The Document Builder is the surface most in need of design
             // iteration without a Rust build — the demo engine seeds it
             // with built-ins, so `screen=structure` is a full editor.
-            case .structure: DocumentBuilderView(model: AppModel())
+            case .structure: DocumentBuilderView(model: galleryModel)
                 }
             }
         }


### PR DESCRIPTION
## Correcting myself first

I filed #289 saying the blank gallery was **"pre-existing on main, not something I introduced."** That was wrong. I checked main — where my own change already was — and didn't check the commit before it.

Rebuilding clean at `c2a2040` (the commit before #277) renders the vocabulary screen perfectly. **This is my regression.** It matters because I'd written it up as someone else's problem, and because dam has enough on his list before he leaves.

## The cause

```swift
case .vocab: VocabularyView(model: AppModel())
case .structure: DocumentBuilderView(model: AppModel())
```

Constructing an observable model **inside the `navigationDestination` ViewBuilder**. SwiftUI re-evaluates that closure freely, so every evaluation minted a fresh `AppModel`.

That was merely wasteful — until #277 gave `AppModel` an `Entitlement`, whose `init` spawns a `Transaction.updates` listener. From then on each re-evaluation started another StoreKit listener, and both screens rendered blank.

Hoisted to a single `@State private var galleryModel = AppModel()`. **Building an observable model inside a ViewBuilder was always wrong; StoreKit only made it visible.**

## Verified, and it cleared a second gap

`screen=vocab` renders again — confirmed on-sim.

That screenshot **also visually verifies #290**, which I'd shipped explicitly unverified for exactly this reason: the strip now reads **`2 TERMS`** instead of `TERMS 2 / 100`.

`screen=structure` renders too, so the Document Builder is reachable headlessly again.

## Why this was worth stopping for

`screen=` is the only headless route to any screen behind a tap. While it was broken, #225 shipped unverified, and the store screenshot set (#288) was missing the Document Builder because I couldn't reach it.

**I did not add the Builder to the store set**, though — captured at 1320 × 2868 it's sparse (two document types, mostly white space) and carries the gallery's floating back-chevron, which would read as an artifact in a listing. Four strong screenshots beat five with a weak one. Worth revisiting with a seeded custom document type.

63 tests pass.