### PR TITLE
fix: declare what we actually collect — drop Photos, add the install ID

### DIFF
--- a/apps/ios/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/apps/ios/Sources/Resources/PrivacyInfo.xcprivacy
@@ -52,15 +52,27 @@
         </dict>
 
         <!--
-          Photos taken during a walk. Persisted on device and rendered in the
-          app; they are NOT sent to the model — the harness has no image
-          ContentBlock variant (issue #263), so today this is enforced by the
-          plumbing not existing. If #263 lands and photos start being sent,
-          this entry and the ASC answers both have to be revisited.
+          The per-install identifier (InstallIdentity): a random UUID minted on
+          device, sent to our proxy so usage can be metered and rate-limited.
+
+          Declared because it genuinely IS collected under Apple's definition —
+          it leaves the device and the proxy stores it in daily spend counters
+          (`spend:install:<id>:<day>`), which outlives the request it served.
+
+          NOT linked to identity: it is random, it is never tied to a name,
+          email or account, and there is no way to resolve it to a person. NOT
+          used for tracking.
+
+          Photos are deliberately NOT declared. Apple defines "collect" as
+          transmitting off the device, and photos never leave: `ContentBlock`
+          has no image variant (issue #263), so the harness cannot send one, and
+          nothing else uploads them. Declaring them would be inaccurate. If #263
+          lands and photos start being sent, this file AND the App Store Connect
+          answers both have to change.
         -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
-            <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+            <string>NSPrivacyCollectedDataTypeDeviceID</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
             <false/>
             <key>NSPrivacyCollectedDataTypeTracking</key>

--- a/docs/store/SUBMISSION-KIT.md
+++ b/docs/store/SUBMISSION-KIT.md
@@ -140,34 +140,50 @@ There is no sign-up and no login. Nothing to provide credentials for.
 
 ## 4. App Privacy answers — MUST match `PrivacyInfo.xcprivacy`
 
-Apple compares these against the bundled manifest. Answer exactly:
+Apple compares these against the bundled manifest. Answer exactly.
 
-**Does this app collect data?** → **Yes**
+**"Do you or your third-party partners collect data from this app?"** → **Yes**
 
-| Data type | Collected | Linked to identity | Used for tracking | Purpose |
-|---|---|---|---|---|
-| **Other User Content** (walk transcripts) | Yes | **No** | **No** | App Functionality |
-| **Photos or Videos** | Yes | **No** | **No** | App Functionality |
+Then check exactly **two** data types and nothing else:
 
-Everything else: **not collected.** No contact info, no identifiers, no usage
-data, no diagnostics, no location, no purchases.
+| Data type | Used for | Linked to identity | Used for tracking |
+|---|---|---|---|
+| **User Content → Other User Content** (walk transcripts) | App Functionality | **No** | **No** |
+| **Identifiers → Device ID** (the per-install UUID) | App Functionality | **No** | **No** |
 
-**Why "not linked to identity":** there are no accounts. The only identifier that
-exists is a random UUID minted on the device to meter usage, with nothing
-attached to it.
+Everything else: **not collected.** No contact info, no financial info, no
+location, no contacts, no browsing or search history, no purchases, no usage
+data, no diagnostics.
 
-**Why transcripts are declared at all**, given our proxy is forbidden to log,
-store or forward request bodies: the model provider is still a third party
-receiving operator content. Apple rejects for under-declaration and never for
-over-declaration, and on a product where contractors discuss client property all
-day, the conservative answer is also the honest one.
+### Why each answer is what it is
 
-**Photos are declared but never sent to the model** — the harness has no image
-content block (#263), so today that's enforced by the plumbing not existing. **If
-#263 lands and photos start being sent, this table and the manifest both have to
-be revisited.**
+**Transcripts are collected.** They leave the device for the model provider.
+Our proxy is forbidden to log, store or forward request bodies — but the
+provider is still a third party receiving operator content, so it's declared.
 
----
+**The install ID is collected.** It leaves the device on every request and the
+proxy stores it in daily spend counters (`spend:install:<id>:<day>`), which
+outlives the request it served. That's collection under Apple's definition.
+
+**Photos are NOT collected — this corrects an earlier over-declaration.** Apple
+defines "collect" as *transmitting off the device*. Photos never leave:
+`ContentBlock` has no image variant (#263), so the harness cannot send one, and
+nothing else uploads them. Declaring them would be inaccurate and would make the
+privacy story look worse than it truthfully is. **If #263 lands and photos start
+being sent, this table and the manifest both have to change.**
+
+**Audio is NOT collected.** Whisper runs on device; that claim holds literally.
+
+### The one genuine judgement call
+
+**"Linked to identity" on Other User Content.** Apple sometimes treats data
+collected alongside a persistent identifier as linked. **No** is the
+recommendation here: the install ID is randomly generated on device, never tied
+to a name, email or account, and cannot be resolved to a person — Apple's
+description of not-linked.
+
+Answering **Yes / Linked** to both is also defensible and costs only a
+worse-looking label. Prefer **No**; it's the accurate one.
 
 ## 5. Age rating
 


### PR DESCRIPTION
Isaac asked what to click in App Store Connect's App Privacy section. Writing out the actual answers turned up two errors in what I shipped in #277/#288.

## Photos should never have been declared

Apple defines **"collect"** as *transmitting data off the device*. Photos never leave:

- `ContentBlock` is `Text | ToolUse | ToolResult | Unknown` — the harness **cannot** send an image (#263)
- nothing else uploads them; `grep` across the harness for any image/upload/base64 path over photos returns nothing

So declaring them was **factually wrong**, and it made the privacy story look worse than it truthfully is. I over-declared out of caution in #277 and shouldn't have — "conservative" is only the right instinct when the conservative answer is also true.

## The install ID was missed and does qualify

`InstallIdentity`'s UUID leaves the device on every request, and the proxy stores it in daily spend counters (`spend:install:<id>:<day>`) — which outlives the request it served. That's collection.

Declared as **Identifiers → Device ID**, App Functionality, not linked, not tracking.

## Net effect

| | before | after |
|---|---|---|
| Other User Content | declared | declared (unchanged) |
| Photos or Videos | declared | **removed** — never leaves the device |
| Device ID | **missing** | declared |

Audio stays undeclared and that's correct — whisper runs on device, so the claim holds literally.

## The judgement call, recorded

**"Linked to identity" on the transcript.** Apple sometimes treats data collected alongside a persistent identifier as linked. Answering **No** because the install ID is random, minted on device, never tied to a name/email/account, and cannot be resolved to a person — Apple's own description of not-linked. Answering Yes is defensible too and costs only a worse label; the doc records both so whoever clicks it knows it was a decision, not an oversight.

## Verification

- `plutil -lint` passes; `plutil -p` on the **built app bundle** shows exactly the two declarations, not just the source file
- `docs/store/SUBMISSION-KIT.md` §4 rewritten to match, with the reasoning for each answer so the manifest and ASC can't drift silently
- Build succeeds

**Standing trap worth noting:** if #263 lands and photos start being sent to the model, the manifest **and** the ASC answers both have to change. That's called out in both files.