### PR TITLE
feat(ios): the control system — raised, recessed, or off

### DIFF
--- a/apps/ios/Sources/Components/Controls.swift
+++ b/apps/ios/Sources/Components/Controls.swift
@@ -1,135 +1,289 @@
 import SwiftUI
 
-// MARK: - Pressed-block button style (mechanical, no bounce)
+// MARK: - The control system: raised, recessed, or off
+//
+// ONE RULE, from the control-system review (2026-07-29): if it can be pressed,
+// it stands off the paper or is cut into it. Flat is reserved for DISABLED.
+// Then flatness carries meaning instead of just reading as print.
+//
+// Why this is a ButtonStyle and not a View: the old `BlockButton` hand-stacked
+// two rounded rectangles inside a `View`, which structurally cannot see
+// `configuration.isPressed`. Every button in the app also carried
+// `.buttonStyle(.plain)` — added to stop iOS tinting labels blue, which also
+// threw away all press feedback. Between them, NOTHING in the app responded to
+// touch, and that absence is most of the "feels flat" complaint. Moving the
+// same drawing into a ButtonStyle is what unlocks it.
 
-private struct BlockButton: View {
-    let title: String
-    let fill: Color
-    let textColor: Color
-    let shadow: Color
-    var leadingDot: Bool = false
+/// Tier 1 + 2: a cap sitting on a darker lip. On touch-down the cap travels the
+/// 3pt onto its lip and the lip vanishes — 90ms ease-out, no scale, no bounce,
+/// which is exactly how a machine button behaves.
+///
+/// Disabled removes the lip entirely: the control becomes physically flat, and
+/// flat is the one state that is never pressable.
+struct RaisedBlockStyle: ButtonStyle {
+    var face: Color = Theme.C.orange
+    var lip: Color = Theme.C.orangeDeep
+    var text: Color = Theme.C.onOrange
+    /// Tier 2 / destructive outline. `nil` = filled, no border.
+    var border: Color?
     var height: CGFloat = Theme.S.buttonHeight
+    var radius: CGFloat = Theme.S.radius
+    /// The live-state dot on START WALK / SEND.
+    var leadingDot: Bool = false
+    /// Full-width by default (bottom-anchored primaries). Header chips size to
+    /// their label instead — forcing `.infinity` on those made the label
+    /// overflow its own body.
+    var fillWidth: Bool = true
 
-    var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: Theme.S.radius)
-                .fill(shadow)
-                .offset(y: 3)
-            RoundedRectangle(cornerRadius: Theme.S.radius)
-                .fill(fill)
-            HStack(spacing: 12) {
-                if leadingDot {
-                    Circle().fill(textColor).frame(width: 10, height: 10)
-                }
-                Text(title)
-                    .font(Theme.F.ui(15, .bold))
-                    .tracking(1.4)
+    @Environment(\.isEnabled) private var isEnabled
+
+    private static let lipDepth: CGFloat = 3
+
+    func makeBody(configuration: Configuration) -> some View {
+        let down = configuration.isPressed
+        let lipHeight: CGFloat = isEnabled ? (down ? 0 : Self.lipDepth) : 0
+        return HStack(spacing: 12) {
+            if leadingDot, isEnabled {
+                Circle().fill(text).frame(width: 10, height: 10)
             }
-            .foregroundStyle(textColor)
+            configuration.label
         }
+        .foregroundStyle(isEnabled ? text : Theme.C.ink35)
+        .padding(.horizontal, fillWidth ? 0 : 14)
+        .frame(maxWidth: fillWidth ? .infinity : nil)
+        .frame(height: height - Self.lipDepth)
+        .background(isEnabled ? face : Theme.C.paperDeep)
+        .overlay(
+            RoundedRectangle(cornerRadius: radius)
+                .stroke(
+                    isEnabled ? (border ?? .clear) : Theme.C.hairline,
+                    lineWidth: border == nil ? 1 : 2
+                )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: radius))
+        // The travel: padding moves the cap down onto the lip rather than
+        // scaling it, so the label never distorts.
+        .padding(.top, down ? Self.lipDepth : 0)
+        .padding(.bottom, lipHeight)
+        .background(isEnabled ? lip : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: radius))
         .frame(height: height)
+        .animation(.easeOut(duration: 0.09), value: down)
+        // Gloves get almost no tactile confirmation off glass. Fires on
+        // touch-DOWN only — a second tick on release reads as a double-tap.
+        .sensoryFeedback(trigger: down) { _, isDown in
+            isDown ? .impact(flexibility: .rigid) : nil
+        }
     }
 }
 
-// MARK: - START WALK — the biggest thing on the home screen
+/// Tier 3: the inverse gesture — a control cut INTO the sheet, for things that
+/// live inside a row (FILE, SHOW ALL, CLOSE, the plan chip). A recessed well
+/// with a hairline shadow across its top edge, like a sunk key on a tool case.
+///
+/// Replaces every dashed box and every bare-text tap target. Dashed reads
+/// "empty placeholder" in app language, which is the opposite of "tap me" —
+/// and Isaac reported that three separate times.
+struct WellChipStyle: ButtonStyle {
+    var tint: Color = Theme.C.paperDeep
+    var text: Color = Theme.C.ink
+    var minHeight: CGFloat = 44
 
-struct WalkButton: View {
-    var title: String = "START WALK"
+    func makeBody(configuration: Configuration) -> some View {
+        let down = configuration.isPressed
+        return configuration.label
+            .foregroundStyle(text)
+            .frame(minHeight: minHeight)
+            .padding(.horizontal, 12)
+            .background(down ? tint.opacity(0.72) : tint)
+            // The "cut in" cue: a hairline across the TOP edge only, reading as
+            // the shadow the sheet casts into the well.
+            .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1.5) }
+            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Theme.C.hairline))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            // Invisible hit slop — the chip reads small but catches a glove.
+            .contentShape(Rectangle().inset(by: -8))
+            .animation(.easeOut(duration: 0.09), value: down)
+            .sensoryFeedback(trigger: down) { _, isDown in
+                isDown ? .impact(flexibility: .rigid) : nil
+            }
+    }
+}
 
-    var body: some View {
-        BlockButton(
-            title: title,
-            fill: Theme.C.orange,
-            textColor: Theme.C.onOrange,
-            shadow: Theme.C.orangeDeep,
-            leadingDot: true
+/// Tier 4: a list row. The humblest control in the app, and until now not a
+/// button at all — a hairline underline with no fill under the finger and no
+/// chevron. `Theme.S.minTarget` was already declared 56 and simply not applied.
+struct FieldRowStyle: ButtonStyle {
+    var minHeight: CGFloat = Theme.S.minTarget
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(minHeight: minHeight)
+            .background(configuration.isPressed ? Theme.C.paperDeep : Color.clear)
+            .contentShape(Rectangle())
+            .animation(.easeOut(duration: 0.09), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Tier presets
+//
+// Named so a call site picks a TIER, never a colour. One amber fill per screen
+// is a rule the styles can enforce only if nobody hand-rolls a face colour.
+
+extension ButtonStyle where Self == RaisedBlockStyle {
+    /// Tier 1 — the one primary action on a screen. START WALK / SEND / SAVE.
+    static var primaryBlock: RaisedBlockStyle {
+        RaisedBlockStyle(leadingDot: true)
+    }
+
+    /// Tier 1, ink — DONE. Same physics, no amber, because the walk screen's
+    /// amber is already spent on the RECORDING banner.
+    static var inkBlock: RaisedBlockStyle {
+        RaisedBlockStyle(face: Theme.C.ink, lip: .black, text: Theme.C.paper, border: nil)
+    }
+
+    /// Tier 2 — secondary. Same body, no colour: PAUSE, PHOTO, ADJUST,
+    /// My business, Add job.
+    static var secondaryBlock: RaisedBlockStyle {
+        RaisedBlockStyle(
+            face: Theme.C.sheet, lip: Theme.C.ink.opacity(0.32),
+            text: Theme.C.ink, border: Theme.C.ink
+        )
+    }
+
+    /// Tier 2 at header-chip height.
+    static var secondaryChip: RaisedBlockStyle {
+        RaisedBlockStyle(
+            face: Theme.C.sheet, lip: Theme.C.ink.opacity(0.32),
+            text: Theme.C.ink, border: Theme.C.ink, height: 44, radius: 4,
+            fillWidth: false
+        )
+    }
+
+    /// Tier 4 — destructive. Tier 2's body in red, because flat red text
+    /// didn't read as tappable (Isaac, on DISCARD).
+    static var destructiveBlock: RaisedBlockStyle {
+        RaisedBlockStyle(
+            face: Theme.C.sheet, lip: Theme.C.redTag.opacity(0.32),
+            text: Theme.C.redTag, border: Theme.C.redTag, height: 52, radius: 4
         )
     }
 }
 
-// MARK: - Capture controls: PHOTO square + PAUSE outline + DONE block
+/// The Tier 3 well drawn as chrome rather than as a style.
+///
+/// `Menu` does not route its label through a `ButtonStyle`, so a menu that
+/// should look like a chip (FILE, the trade picker) needs the same recessed
+/// treatment applied directly. Press feedback comes from the menu's own
+/// highlight; everything else matches `WellChipStyle` exactly, and both must be
+/// changed together.
+struct WellChrome: ViewModifier {
+    var tint: Color = Theme.C.paperDeep
+    var minHeight: CGFloat = 44
 
-struct PhotoSquareButton: View {
+    func body(content: Content) -> some View {
+        content
+            .frame(minHeight: minHeight)
+            .padding(.horizontal, 12)
+            .background(tint)
+            .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1.5) }
+            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Theme.C.hairline))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .contentShape(Rectangle().inset(by: -8))
+    }
+}
+
+extension View {
+    /// Tier 3 chrome for controls that can't take a `ButtonStyle` (menus).
+    func wellChrome(tint: Color = Theme.C.paperDeep, minHeight: CGFloat = 44) -> some View {
+        modifier(WellChrome(tint: tint, minHeight: minHeight))
+    }
+}
+
+extension ButtonStyle where Self == WellChipStyle {
+    /// Tier 3 — recessed in-row chip.
+    static var wellChip: WellChipStyle { WellChipStyle() }
+}
+
+extension ButtonStyle where Self == FieldRowStyle {
+    /// Tier 4 — a list row with a fill under the finger.
+    static var fieldRow: FieldRowStyle { FieldRowStyle() }
+}
+
+// MARK: - Labels
+//
+// These are LABEL CONTENT ONLY — the body, lip and press behaviour all come
+// from the styles above. `BlockButton` (a View that hand-stacked two rounded
+// rectangles) is gone: it could not see press state, which is the structural
+// reason nothing in the app responded to touch.
+
+/// The text inside any raised block.
+struct BlockLabel: View {
+    let title: String
+    var size: CGFloat = 15
+
+    init(_ title: String, size: CGFloat = 15) {
+        self.title = title
+        self.size = size
+    }
+
+    var body: some View {
+        Text(title)
+            .font(Theme.F.ui(size, .bold))
+            .tracking(1.4)
+    }
+}
+
+/// PHOTO — icon over label, sized square by its call site.
+struct PhotoLabel: View {
     var body: some View {
         VStack(spacing: 3) {
             Image(systemName: "camera")
-                .font(.system(size: 17, weight: .medium))
+                .font(.system(size: 19, weight: .medium))
             Text("PHOTO")
-                .font(Theme.F.mono(7, .semibold))
+                .font(Theme.F.mono(9, .semibold))
                 .tracking(1.1)
         }
-        .foregroundStyle(Theme.C.ink)
-        .frame(width: Theme.S.buttonHeight, height: Theme.S.buttonHeight)
-        .overlay(
-            RoundedRectangle(cornerRadius: Theme.S.radius)
-                .stroke(Theme.C.ink, lineWidth: 2)
-        )
     }
 }
 
-struct PauseButton: View {
-    var body: some View {
-        Text("PAUSE")
-            .font(Theme.F.ui(13.5, .bold))
-            .tracking(1.1)
-            .foregroundStyle(Theme.C.ink)
-            .frame(maxWidth: .infinity)
-            .frame(height: Theme.S.buttonHeight)
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.S.radius)
-                    .stroke(Theme.C.ink, lineWidth: 2)
-            )
-    }
-}
-
-struct DoneButton: View {
-    var body: some View {
-        BlockButton(
-            title: "DONE",
-            fill: Theme.C.ink,
-            textColor: Theme.C.paper,
-            shadow: .black
-        )
-    }
-}
+// MARK: - Capture controls: PHOTO + PAUSE + DONE
+//
+// Static composition for the gallery/screens. The live walk screen builds its
+// own so each control gets a real action.
 
 struct CaptureControls: View {
     var body: some View {
         HStack(spacing: 9) {
-            PhotoSquareButton()
-            PauseButton()
+            Button {} label: { PhotoLabel() }
+                .buttonStyle(.secondaryBlock)
+                .frame(width: Theme.S.buttonHeight)
+            Button {} label: { BlockLabel("PAUSE", size: 13.5) }
+                .buttonStyle(.secondaryBlock)
                 .frame(width: 96)
-            DoneButton()
+            Button {} label: { BlockLabel("DONE") }
+                .buttonStyle(.inkBlock)
                 .frame(maxWidth: .infinity)
         }
     }
 }
 
-// MARK: - Review bar: ADJUST outline + SEND block
+// MARK: - Review bar: ADJUST + SEND
 
 struct ReviewBar: View {
     let sendTitle: String
 
     var body: some View {
         HStack(spacing: 10) {
-            Text("ADJUST")
-                .font(Theme.F.ui(14, .bold))
-                .tracking(1.1)
-                .foregroundStyle(Theme.C.ink)
+            Button {} label: { BlockLabel("ADJUST", size: 14) }
+                .buttonStyle(RaisedBlockStyle(
+                    face: Theme.C.sheet, lip: Theme.C.ink.opacity(0.32),
+                    text: Theme.C.ink, border: Theme.C.ink, height: 58
+                ))
                 .frame(width: 124)
-                .frame(height: 58)
-                .overlay(
-                    RoundedRectangle(cornerRadius: Theme.S.radius)
-                        .stroke(Theme.C.ink, lineWidth: 2)
-                )
-            BlockButton(
-                title: sendTitle,
-                fill: Theme.C.orange,
-                textColor: Theme.C.onOrange,
-                shadow: Theme.C.orangeDeep,
-                height: 58
-            )
-            .frame(maxWidth: .infinity)
+            Button {} label: { BlockLabel(sendTitle) }
+                .buttonStyle(RaisedBlockStyle(height: 58, leadingDot: false))
+                .frame(maxWidth: .infinity)
         }
     }
 }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -60,16 +60,16 @@ struct BoardView: View {
                     // pressed-block grammar as START WALK) so it reads as a
                     // button; opens the two-tab PAPERWORK / WORDS sheet.
                     planChip
+                    // Demoted from a raised GOLD chip to Tier 2 ink. The brief
+                    // reserves amber for the live state and the primary action;
+                    // a gold "MY BUSINESS" read as important as START WALK.
+                    // Still obviously a button — which was the real complaint —
+                    // and now 44pt instead of ~29.
                     Button { showCustomize = true } label: {
-                        raisedChip(face: Theme.C.orange, edge: Theme.C.orangeDeep) {
-                            Text("MY BUSINESS")
-                                .font(Theme.F.ui(11, .bold))
-                                .tracking(0.5)
-                                .foregroundStyle(Theme.C.onOrange)
-                        }
-                        .contentShape(Rectangle())
+                        Text("My business")
+                            .font(Theme.F.ui(13, .semibold))
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.secondaryChip)
                 }
                 if let profile = model.profile {
                     // Operator mode: the board carries THEIR business. Trade
@@ -216,19 +216,19 @@ struct BoardView: View {
                         }
                     }
                     if model.looseWalks.count > Self.collapsedWalkCount {
+                        // Tier 3: was 8.5pt amber text with no bounds at all
+                        // (~27pt tall). Amber also goes — a disclosure toggle
+                        // is not the screen's primary action.
                         Button { showAllWalks.toggle() } label: {
                             Text(showAllWalks
-                                 ? "SHOW LESS"
-                                 : "SHOW ALL \(model.looseWalks.count) WALKS")
-                                .font(Theme.F.mono(8.5, .semibold))
-                                .tracking(1.0)
-                                .foregroundStyle(Theme.C.orangeDeep)
-                                .padding(.horizontal, Theme.S.screenPad)
-                                .padding(.vertical, 9)
+                                 ? "Show less"
+                                 : "Show all \(model.looseWalks.count) walks")
+                                .font(Theme.F.ui(13, .semibold))
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.wellChip)
+                        .padding(.horizontal, Theme.S.screenPad)
+                        .padding(.vertical, 6)
                         .overlay(alignment: .bottom) {
                             Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
                         }
@@ -286,9 +286,9 @@ struct BoardView: View {
                 coachStartShown = true
                 model.startWalk()
             } label: {
-                WalkButton()
+                BlockLabel("START WALK")
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.primaryBlock)
             .padding(.horizontal, Theme.S.screenPad)
             .padding(.bottom, 10)
         }
@@ -340,12 +340,11 @@ extension BoardView {
                 // read as a control — the same grammar the Document Builder's
                 // "NEW DOCUMENT TYPE" already uses.
                 Button { showNewJob = true } label: {
-                    HStack(spacing: 4) {
+                    HStack(spacing: 5) {
                         Image(systemName: "plus")
-                            .font(.system(size: 10, weight: .bold))
-                        Text("ADD JOB")
-                            .font(Theme.F.mono(9, .semibold))
-                            .tracking(0.8)
+                            .font(.system(size: 12, weight: .bold))
+                        Text("Add job")
+                            .font(Theme.F.ui(13, .semibold))
                     }
                     .foregroundStyle(Theme.C.orangeDeep)
                     .padding(.horizontal, 8)
@@ -422,18 +421,14 @@ extension BoardView {
     @ViewBuilder
     private var planChip: some View {
         if model.entitlement.isPro {
+            // Tier 3. These OPEN BILLING but read as stamps at ~16pt — the
+            // exact "looks like a label, is actually a button" failure.
             Button { showManageSubscription = true } label: {
-                Text("PRO")
-                    .font(Theme.F.mono(8, .semibold))
-                    .tracking(1.0)
+                Text("Pro")
+                    .font(Theme.F.ui(12, .semibold))
                     .foregroundStyle(Theme.C.greenTag)
-                    .padding(.horizontal, 6)
-                    .padding(.top, 3)
-                    .padding(.bottom, 2)
-                    .background(Theme.C.greenTint)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(WellChipStyle(tint: Theme.C.greenTint, text: Theme.C.greenTag, minHeight: 36))
         } else if model.entitlement.canSubscribe {
             // Only shown when the limit is actually being enforced. With no
             // purchasable product the gate declines to block (see
@@ -445,17 +440,15 @@ extension BoardView {
                 model.blockedUsage = nil   // opened by choice, not refused
                 model.showPaywall = true
             } label: {
-                Text(left == 0 ? "0 LEFT" : "\(left) LEFT")
-                    .font(Theme.F.mono(8, .semibold))
-                    .tracking(1.0)
+                Text(left == 0 ? "0 left" : "\(left) left")
+                    .font(Theme.F.ui(12, .semibold))
                     .foregroundStyle(left == 0 ? Theme.C.redTag : Theme.C.ink60)
-                    .padding(.horizontal, 6)
-                    .padding(.top, 3)
-                    .padding(.bottom, 2)
-                    .background(left == 0 ? Theme.C.redTint : Theme.C.paperDeep)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(WellChipStyle(
+                tint: left == 0 ? Theme.C.redTint : Theme.C.paperDeep,
+                text: left == 0 ? Theme.C.redTag : Theme.C.ink60,
+                minHeight: 36
+            ))
         }
     }
 
@@ -575,8 +568,8 @@ private struct OperatorJobCard: View {
                     .padding(.leading, Theme.S.screenPad + 2)
                     .padding(.trailing, Theme.S.screenPad)
                     .padding(.vertical, 7)
-                    .contentShape(Rectangle())
                 }
+                .buttonStyle(FieldRowStyle(minHeight: 56))
                 .buttonStyle(.plain)
             }
             .padding(.bottom, walks.isEmpty ? 0 : 8)
@@ -761,6 +754,9 @@ private struct WalkLogRow<Trailing: View>: View {
 
     var body: some View {
         HStack(spacing: 8) {
+            // Tier 4. This row NAVIGATES (it reopens the walk) and until now
+            // said so with nothing at all: no chevron, no fill under the
+            // finger, and ~44pt against a declared `minTarget` of 56.
             Button(action: onOpen) {
                 HStack(spacing: 12) {
                     Text(walk.time)
@@ -783,10 +779,14 @@ private struct WalkLogRow<Trailing: View>: View {
                     }
                     Spacer(minLength: 8)
                     FieldTag(tag: walkTag(walk))
+                    // This row navigates — it reopens the walk — and said so
+                    // with nothing at all until now.
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Theme.C.ink35)
                 }
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(FieldRowStyle(minHeight: 62))
 
             trailing
         }
@@ -845,35 +845,27 @@ private struct FileChip: View {
                 }
             }
         } label: {
+            // Tier 3 recessed well, both states. The unfiled state used to be
+            // a 1px DASHED box at ~30pt — dashed reads "empty placeholder" in
+            // app language, which is the exact opposite of "tap me", and Isaac
+            // reported it as not obviously tappable. A well says "press here"
+            // and catches a glove at 44pt.
             if let filedJob {
-                Text(filedJob.name.uppercased())
-                    .font(Theme.F.mono(8, .semibold))
-                    .tracking(0.8)
+                Text(filedJob.name)
+                    .font(Theme.F.ui(12, .semibold))
                     .foregroundStyle(Theme.C.orangeDeep)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .frame(maxWidth: 88, alignment: .trailing)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 8)
-                    .background(Theme.C.orangeTint)
-                    .contentShape(Rectangle())
+                    .frame(maxWidth: 96, alignment: .trailing)
             } else {
                 // Unfiled reads as an invitation, not an error — most walks
                 // will sit unfiled for a while and that's fine.
-                Text("FILE")
-                    .font(Theme.F.mono(8, .semibold))
-                    .tracking(0.8)
-                    .foregroundStyle(Theme.C.ink35)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 8)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
-                            .foregroundStyle(Theme.C.ink35)
-                    )
-                    .contentShape(Rectangle())
+                Text("File")
+                    .font(Theme.F.ui(12, .semibold))
+                    .foregroundStyle(Theme.C.ink60)
             }
         }
+        .wellChrome(tint: filedJob == nil ? Theme.C.paperDeep : Theme.C.orangeTint)
         .accessibilityLabel(filedJob.map { "Filed under \($0.name). Change." } ?? "File this walk")
     }
 }

--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -188,29 +188,28 @@ struct PaywallView: View {
             Button {
                 Task { await entitlement.purchase() }
             } label: {
-                WalkButton(title: entitlement.isWorking ? "…" : "GET JEFE PRO")
+                BlockLabel(entitlement.isWorking ? "…" : "GET JEFE PRO")
             }
-            .buttonStyle(.plain)
             // No product means no purchase is possible; a live button would
-            // just fail silently.
+            // just fail silently. `.disabled` now carries the whole visual —
+            // the style drops the lip and goes flat, so the control reads as
+            // physically unpressable instead of merely faded.
+            .buttonStyle(.primaryBlock)
             .disabled(entitlement.isWorking || entitlement.proProduct == nil)
-            .opacity(entitlement.proProduct == nil ? 0.4 : 1)
 
             // Restore is not optional garnish: Apple requires the path, and
             // with no accounts it is the ONLY way an operator recovers a
             // subscription on a new phone.
+            // Tier 3: a real 44pt target. Apple requires this path to exist,
+            // so it must not be 9pt text with no bounds.
             Button {
                 Task { await entitlement.restore() }
             } label: {
-                Text("RESTORE PURCHASE")
-                    .font(Theme.F.mono(9.5, .semibold))
-                    .tracking(1.0)
-                    .foregroundStyle(Theme.C.ink60)
+                Text("Restore purchase")
+                    .font(Theme.F.ui(13, .semibold))
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 10)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.wellChip)
             .disabled(entitlement.isWorking)
         }
         .padding(.horizontal, Theme.S.screenPad)

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -103,34 +103,25 @@ struct ReviewView: View {
             .background(Theme.C.paperDeep)
 
             HStack(spacing: 10) {
+                // Tier 2. DISCARD stays ink rather than going red: it abandons
+                // an unsent draft and the walk's notes survive untouched, so
+                // dressing it as destructive would overstate what it does.
                 Button { model.discardDocument() } label: {
-                    Text("DISCARD")
-                        .font(Theme.F.ui(14, .bold))
-                        .tracking(1.1)
-                        .foregroundStyle(Theme.C.ink)
-                        .frame(width: 124)
-                        .frame(height: 58)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: Theme.S.radius)
-                                .stroke(Theme.C.ink, lineWidth: 2)
-                        )
+                    BlockLabel("DISCARD", size: 14)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(RaisedBlockStyle(
+                    face: Theme.C.sheet, lip: Theme.C.ink.opacity(0.32),
+                    text: Theme.C.ink, border: Theme.C.ink, height: 58
+                ))
+                .frame(width: 124)
+                // Tier 1. Was a hand-stacked ZStack of two rounded rectangles —
+                // the same drawing, but as a View it could never see press
+                // state. This is the screen where money gets confirmed, so it's
+                // also the press that most needs to be felt.
                 Button { model.makePDF() } label: {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: Theme.S.radius)
-                            .fill(Theme.C.orangeDeep)
-                            .offset(y: 3)
-                        RoundedRectangle(cornerRadius: Theme.S.radius)
-                            .fill(Theme.C.orange)
-                        Text(model.document?.send ?? "SEND")
-                            .font(Theme.F.ui(15, .bold))
-                            .tracking(1.4)
-                            .foregroundStyle(Theme.C.onOrange)
-                    }
-                    .frame(height: 58)
+                    BlockLabel(model.document?.send ?? "SEND")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(RaisedBlockStyle(height: 58))
                 .frame(maxWidth: .infinity)
             }
             .padding(.horizontal, Theme.S.screenPad)

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -99,27 +99,21 @@ struct WalkView: View {
                     // One tap, zero confirm: camera on device, picker on sim.
                     // The shot pins to the item being spoken (see addPhoto).
                     if CameraCapture.isAvailable {
-                        Button { showCamera = true } label: { PhotoSquareButton() }
-                            .buttonStyle(.plain)
+                        Button { showCamera = true } label: { PhotoLabel() }
+                            .buttonStyle(.secondaryBlock)
+                            .frame(width: Theme.S.buttonHeight)
                     } else {
                         PhotosPicker(selection: $pickerItem, matching: .images) {
-                            PhotoSquareButton()
+                            PhotoLabel()
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.secondaryBlock)
+                        .frame(width: Theme.S.buttonHeight)
                     }
                     Button { model.togglePause() } label: {
-                        Text(model.isPaused ? "RESUME" : "PAUSE")
-                            .font(Theme.F.ui(13.5, .bold))
-                            .tracking(1.1)
-                            .foregroundStyle(Theme.C.ink)
-                            .frame(width: 96)
-                            .frame(height: Theme.S.buttonHeight)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: Theme.S.radius)
-                                    .stroke(Theme.C.ink, lineWidth: 2)
-                            )
+                        BlockLabel(model.isPaused ? "RESUME" : "PAUSE", size: 13.5)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.secondaryBlock)
+                    .frame(width: 96)
                     // DONE is finishable once ANYTHING has been captured —
                     // transcript OR extracted items (issue #168). On a voice
                     // walk the live board lags the speech (batched extraction),
@@ -127,11 +121,15 @@ struct WalkView: View {
                     // gating on items alone stranded the user on a stuck screen
                     // whenever items hadn't landed yet. Transcript-or-items.
                     let nothingCaptured = model.transcript.isEmpty && model.items.isEmpty
-                    Button { coachDoneShown = true; model.finishWalk() } label: { DoneButton() }
-                        .buttonStyle(.plain)
-                        .frame(maxWidth: .infinity)
-                        .disabled(nothingCaptured)
-                        .opacity(nothingCaptured ? 0.4 : 1)
+                    // No manual `.opacity` any more: the style drops the lip and
+                    // goes flat when disabled, so DONE reads as physically
+                    // unpressable rather than as a faded live button.
+                    Button { coachDoneShown = true; model.finishWalk() } label: {
+                        BlockLabel("DONE")
+                    }
+                    .buttonStyle(.inkBlock)
+                    .frame(maxWidth: .infinity)
+                    .disabled(nothingCaptured)
                 }
             }
             .padding(.horizontal, Theme.S.screenPad)

--- a/apps/ios/Sources/Gallery/ComponentsPage.swift
+++ b/apps/ios/Sources/Gallery/ComponentsPage.swift
@@ -64,7 +64,8 @@ struct ComponentsPage: View {
 
                 section("CONTROLS — 62PT GLOVE TARGETS")
                 VStack(spacing: 10) {
-                    WalkButton()
+                    Button {} label: { BlockLabel("START WALK") }
+                        .buttonStyle(.primaryBlock)
                     CaptureControls()
                     ReviewBar(sendTitle: land.send)
                 }

--- a/apps/ios/Sources/Screens/JobsBoardScreen.swift
+++ b/apps/ios/Sources/Screens/JobsBoardScreen.swift
@@ -38,7 +38,8 @@ struct JobsBoardScreen: View {
 
             Spacer(minLength: 0)
 
-            WalkButton()
+            Button {} label: { BlockLabel("START WALK") }
+                .buttonStyle(.primaryBlock)
                 .padding(.horizontal, Theme.S.screenPad)
                 .padding(.bottom, 10)
         }


### PR DESCRIPTION
First of the design-review series. Implements the **Control System** doc, which is explicit that it should land **before** the type rescale: it touches one file plus call sites, carries no layout risk, and it's the change Isaac will feel — all three of his "that isn't obviously a button" reports were this.

## The root cause was structural, not cosmetic

`BlockButton` hand-stacked two rounded rectangles inside a **`View`**, which cannot see `configuration.isPressed`. And every button in the app carried **`.buttonStyle(.plain)`** — added to stop iOS tinting labels blue, which also threw away all press feedback.

Between them, **nothing in this app responded to touch.** That absence is most of the "feels flat" complaint, and no amount of restyling would have fixed it while the drawing lived in a View.

## One rule

**If it can be pressed, it stands off the paper or is cut into it. Flat is reserved for disabled.** Then flatness carries meaning instead of just reading as print.

Three styles in `Controls.swift`:

- **`RaisedBlockStyle`** — the cap travels 3pt onto its lip and the lip vanishes; 90ms ease-out, no scale, no bounce. Disabled removes the lip entirely, so a dead control is *physically* flat rather than 40%-faded. Rigid haptic on touch-down only (a second tick on release reads as a double-tap) — gloves get almost nothing off glass.
- **`WellChipStyle`** — the inverse gesture, for controls living inside a row. Replaces every dashed box: dashed reads "empty placeholder" in app language, the exact opposite of "tap me." 8pt invisible hit slop.
- **`FieldRowStyle`** — a fill under the finger and the 56pt floor `Theme.S.minTarget` already declared and never applied.

Presets are named by **tier**, not colour, so no call site can hand-roll an amber face — that's the only way "one amber fill per screen" stays true.

## What changed on screen

| Control | Was | Now |
|---|---|---|
| START WALK / SEND | raised, no press state | Tier 1 + press |
| DONE | raised ink; disabled = 0.4 opacity over the lip | Tier 1, **flat** when off |
| PAUSE / PHOTO / ADJUST / DISCARD | flat 2pt outline, no body | Tier 2 |
| MY BUSINESS | raised **gold** chip, ~29pt | Tier 2 ink, 44pt |
| ADD JOB | 9pt mono, amber @45% border, flat | Tier 2, 44pt |
| FILE chip | 1px **dashed** box, ~30pt | Tier 3 well, 44pt |
| Walk rows | hairline underline, no chevron, ~44pt | Tier 4: 62pt, press fill, chevron |
| SHOW ALL | 8.5pt amber text, no bounds (~27pt) | Tier 3 well |
| PRO / N LEFT | 8pt tinted label — **opens billing**, looked like a stamp | Tier 3 well, 36pt |
| RESTORE PURCHASE | 9.5pt text, no bounds | Tier 3 well, 44pt |

**MY BUSINESS losing its gold is the one judgement call worth flagging.** The brief reserves amber for the live state and the primary action; a gold chip next to START WALK read as equally important. It's still obviously a button — which was Isaac's actual complaint — and it's now 44pt instead of 29.

`BlockButton` is deleted. `WalkButton`/`DoneButton`/`PauseButton`/`PhotoSquareButton` collapse into labels; `raisedChip` is gone.

Also added **`WellChrome`**, because `Menu` doesn't route its label through a `ButtonStyle` — the FILE chip is a Menu. Same drawing as `WellChipStyle`; the two must be changed together, and that's noted in both.

## Verification

63 tests pass. Board, walk and review rendered on-sim at 1320 × 2868 and inspected.

Two bugs caught by actually looking rather than by building: "My business" **overflowed its own body** (the style forced `maxWidth: .infinity`, so an intrinsically-sized header chip clipped — `fillWidth` is now opt-out), and my first chevron patch **silently didn't match** and had to be applied directly.

## Deliberately NOT in this PR

Scope is the operator-facing hot path: board, walk, review, paywall. `.buttonStyle(.plain)` still stands in NotesView, LetterheadStudio, Onboarding, DocumentBuilder, VocabSeedCard and Vocabulary — settings-ish surfaces that deserve the same pass but not in the same diff.

Queued from the design review: **type ramp +30% with an 11pt floor** and **Dynamic Type** (the two highest-impact P0 items, now landing on controls with bodies to grow into), full sentence-case sweep, three-radii cleanup, SF Symbols for the typed `⌄` glyph, new-job sheet instead of an `.alert`, real job **cards**, and the P2 chrome/dark-mode work.

Also recorded there and not touched: `orangeDeep` is ~4.4:1 on paper (AA, not the AAA the brief claims), `Sources/Screens/*` are drifting duplicates that make the gallery lie, and BRIEF.md still specifies safety orange and the Sitewalk name.