### PR TITLE
feat(ios): shift the type ramp and adopt Dynamic Type

### DIFF
--- a/apps/ios/Sources/Components/Primitives.swift
+++ b/apps/ios/Sources/Components/Primitives.swift
@@ -69,9 +69,18 @@ struct MetaStrip: View {
                 .foregroundStyle(warn ? Theme.C.yellowTag : Theme.C.ink60)
         }
         .font(Theme.F.mono(8.5))
-        .tracking(0.8)
+        // Tracking eased from 0.8 as the type grew. Heavy tracking is a print
+        // device that helps at 8.5pt and actively hurts once the glyphs are big
+        // enough to hold their own shape.
+        .tracking(0.4)
         .foregroundStyle(Theme.C.ink60)
         .lineLimit(1)
+        // Dynamic Type is now honoured everywhere (Theme.F `relativeTo:`), but
+        // this strip is two labels sharing one line with `lineLimit(1)` — at
+        // accessibility sizes one of them would simply truncate away. Capping
+        // growth keeps both readable; the review calls this out as the pattern
+        // for any strip that must stay on one line.
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.vertical, 7)
         .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }

--- a/apps/ios/Sources/Theme/Theme.swift
+++ b/apps/ios/Sources/Theme/Theme.swift
@@ -62,21 +62,78 @@ enum Theme {
         enum MonoW: String { case regular = "Regular", medium = "Medium", semibold = "SemiBold" }
         enum SerifW: String { case semibold = "SemiBold", bold = "Bold" }
 
+        /// The type rescale (design review 2026-07-29, P0 #1 + #2).
+        ///
+        /// `mono` was being called at 7, 7.5, 8, 8.5, 9, 9.5 and 11pt. iOS body
+        /// is 17. A carbon-copy work order can set 8pt because paper has
+        /// infinite resolution and gets held at 14 inches in good light; a phone
+        /// at hip height in noon sun does not. The brief demands "glanceable at
+        /// arm's length" and the ramp quietly contradicted it.
+        ///
+        /// Who is holding the phone settles it: the median US construction
+        /// worker is 42, one in five is 55 or older, and the median trade
+        /// supervisor — the person paying $12.99/mo — is 46 and needs reading
+        /// glasses for 8pt mono. Type size is not a polish item for this
+        /// audience; it is the product working or not working.
+        ///
+        /// Applied HERE rather than at ~100 call sites, which is what makes the
+        /// ratios between levels survive exactly: one curve, no drift, and no
+        /// call site can opt out or invent its own. The forms and the ruling
+        /// carry the aesthetic, not the smallness — it survives at 1.3×.
+        ///
+        /// Growth tapers with size: small stamped type needs the most help,
+        /// headlines are already legible and would just eat the layout.
+        /// The multiplier tapers CONTINUOUSLY from 1.30 at 12pt to 1.08 at 20pt.
+        ///
+        /// It has to be continuous, not stepped. A first attempt used flat
+        /// bands (`<12 → ×1.30`, `<20 → ×1.20`, `else ×1.08`) and the ramp
+        /// INVERTED at every boundary: 11.5pt resolved to 14.95 while 12pt
+        /// resolved to 14.4, so a 12pt call site rendered smaller than an 11.5pt
+        /// one. On screen that is a subtitle set larger than the title above it.
+        /// `TypeRampTests.testTheCurveIsMonotonic` caught it and now guards it.
+        private static func scaled(_ size: CGFloat) -> CGFloat {
+            // 11pt floor — below this nothing is reliably legible in sun, so
+            // there is no smaller size worth preserving.
+            let floor: CGFloat = 11
+            let small: CGFloat = 1.30   // stamped type needs the most help
+            let large: CGFloat = 1.08   // headlines are already legible
+            let lower: CGFloat = 12
+            let upper: CGFloat = 20
+
+            if size <= lower { return max(floor, size * small) }
+            if size >= upper { return size * large }
+            // Linear taper between the anchors. Monotonic across the whole
+            // range: the derivative stays positive up to 20pt, and both ends
+            // meet the neighbouring branches exactly (12 → 15.6, 20 → 21.6).
+            let t = (size - lower) / (upper - lower)
+            return size * (small + t * (large - small))
+        }
+
+        /// What `scaled` returns — for tests, and for layout that must reserve
+        /// space for a glyph run.
+        static func resolvedSize(_ size: CGFloat) -> CGFloat { scaled(size) }
+
+        // `relativeTo:` is what adopts Dynamic Type (P0 #2). One in five
+        // operators is 55+ and many have already set a larger system size;
+        // until now every font was a fixed `.custom(size:)` and the app ignored
+        // that setting completely. Strips that must stay on one line cap growth
+        // with `.dynamicTypeSize(...)` at their own call site rather than here.
+
         /// UI type — Barlow (highway-signage DNA)
         static func ui(_ size: CGFloat, _ w: UIW = .semibold) -> Font {
-            .custom("Barlow-\(w.rawValue)", size: size)
+            .custom("Barlow-\(w.rawValue)", size: scaled(size), relativeTo: .body)
         }
         /// Dense data rows — Barlow Semi Condensed
         static func cond(_ size: CGFloat, _ w: CondW = .semibold) -> Font {
-            .custom("BarlowSemiCondensed-\(w.rawValue)", size: size)
+            .custom("BarlowSemiCondensed-\(w.rawValue)", size: scaled(size), relativeTo: .body)
         }
         /// Stamped metadata, prices, timestamps — IBM Plex Mono
         static func mono(_ size: CGFloat, _ w: MonoW = .regular) -> Font {
-            .custom("IBMPlexMono-\(w.rawValue)", size: size)
+            .custom("IBMPlexMono-\(w.rawValue)", size: scaled(size), relativeTo: .body)
         }
         /// Document letterhead only — Source Serif 4
         static func serif(_ size: CGFloat, _ w: SerifW = .bold) -> Font {
-            .custom("SourceSerif4-\(w.rawValue)", size: size)
+            .custom("SourceSerif4-\(w.rawValue)", size: scaled(size), relativeTo: .body)
         }
     }
 }

--- a/apps/ios/Tests/TypeRampTests.swift
+++ b/apps/ios/Tests/TypeRampTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `Theme.F.resolvedSize` — the one curve every font in the app now
+/// passes through.
+///
+/// It exists because the ramp was the single highest-impact change in the design
+/// review: `mono` was called at 7–9.5pt against an iOS body of 17, for an
+/// audience whose median trade supervisor is 46 and needs reading glasses for
+/// 8pt. Putting the shift in one function is what keeps the ratios between
+/// levels intact — but it also means one wrong branch silently resizes the whole
+/// app, so the branches are pinned here.
+final class TypeRampTests: XCTestCase {
+    /// Nothing may resolve below 11pt. This is the floor the whole review turns
+    /// on: below it, type is not reliably legible in sun at arm's length, so
+    /// there is no smaller size worth preserving.
+    func testNothingResolvesBelowElevenPoints() {
+        for size in stride(from: CGFloat(6), through: 11, by: 0.5) {
+            XCTAssertGreaterThanOrEqual(
+                Theme.F.resolvedSize(size), 11,
+                "\(size)pt resolved below the 11pt floor"
+            )
+        }
+    }
+
+    func testTheSmallestStampedSizesLandOnTheFloor() {
+        // 7 and 8pt were the worst offenders — tags and doc subtitles.
+        XCTAssertEqual(Theme.F.resolvedSize(7), 11, accuracy: 0.01)
+        XCTAssertEqual(Theme.F.resolvedSize(8), 11, accuracy: 0.01)
+    }
+
+    func testSmallTypeGetsTheMostHelp() {
+        // 8.5 → ~11, 9 → ~11.7: the review's targets for MetaStrip and section
+        // labels.
+        XCTAssertEqual(Theme.F.resolvedSize(8.5), 11.05, accuracy: 0.05)
+        XCTAssertEqual(Theme.F.resolvedSize(9), 11.7, accuracy: 0.05)
+    }
+
+    func testMidRangeMatchesTheReviewsTargets() {
+        // The live transcript (review target 11.5 → 15) is read while walking
+        // with the phone at hip height; the captured row (13 → ~16) is the
+        // walk's output; the job row title (14.5 → ~17) is the board.
+        XCTAssertEqual(Theme.F.resolvedSize(11.5), 14.95, accuracy: 0.05)
+        XCTAssertEqual(Theme.F.resolvedSize(13), 16.54, accuracy: 0.05)
+        XCTAssertEqual(Theme.F.resolvedSize(14.5), 17.85, accuracy: 0.05)
+    }
+
+    /// The two sizes where the flat-band version inverted. Pinned by value, not
+    /// just by the monotonic sweep, so a regression names itself.
+    func testTheOldBranchBoundariesAreContinuous() {
+        XCTAssertEqual(Theme.F.resolvedSize(12), 15.6, accuracy: 0.01)
+        XCTAssertEqual(Theme.F.resolvedSize(20), 21.6, accuracy: 0.01)
+        XCTAssertGreaterThan(Theme.F.resolvedSize(12), Theme.F.resolvedSize(11.5))
+        XCTAssertGreaterThan(Theme.F.resolvedSize(20), Theme.F.resolvedSize(19.5))
+    }
+
+    func testHeadlinesBarelyMove() {
+        // Already legible; scaling them 30% would eat the layout rather than
+        // help anyone.
+        XCTAssertEqual(Theme.F.resolvedSize(26), 28.08, accuracy: 0.05)
+        XCTAssertEqual(Theme.F.resolvedSize(30), 32.4, accuracy: 0.05)
+    }
+
+    /// The ramp has to stay a ramp. If a branch boundary is ever mis-set, two
+    /// levels can cross and the hierarchy inverts — a subtitle rendering larger
+    /// than the title it sits under.
+    func testTheCurveIsMonotonic() {
+        var previous = Theme.F.resolvedSize(6)
+        for size in stride(from: CGFloat(6.5), through: 40, by: 0.5) {
+            let current = Theme.F.resolvedSize(size)
+            XCTAssertGreaterThanOrEqual(
+                current, previous,
+                "\(size)pt resolved smaller than the size below it — the ramp inverted"
+            )
+            previous = current
+        }
+    }
+
+    func testGrowthNeverExceedsThirtyPercent() {
+        // An upper bound as well as a lower one: unbounded growth would break
+        // fixed-width frames (the time column, PAUSE, DISCARD) rather than
+        // simply reflow.
+        for size in stride(from: CGFloat(12), through: 40, by: 0.5) {
+            XCTAssertLessThanOrEqual(
+                Theme.F.resolvedSize(size), size * 1.30,
+                "\(size)pt grew more than 30%"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Second of the design-review series, and the review's own "highest impact of anything here." Lands on top of #293 so the type grows into controls that already have bodies — the sequencing both docs asked for.

## Why

`Theme.F.mono` was being called at **7, 7.5, 8, 8.5, 9, 9.5 and 11pt**. iOS body is 17.

A carbon-copy work order can set 8pt because paper has infinite resolution and gets held at 14 inches in good light. A phone at hip height in noon sun cannot. The brief demands "glanceable at arm's length" and AAA contrast; the ramp quietly contradicted both.

And who is holding the phone settles it: median US construction worker is 42, **one in five is 55 or older**, and the median trade supervisor — the person paying $12.99/mo — is **46 and needs reading glasses for 8pt mono**. This is not a polish item for that audience; it is the product working or not.

## How — one curve, not 100 call sites

The review suggested editing call sites. I put it in the four `Theme.F` helpers instead, which is what makes **the ratios between levels survive exactly**: one curve, no drift, and no call site can opt out or invent its own scale.

Growth tapers with size — small stamped type needs the most help, headlines are already legible and would just eat the layout:

| call site | resolves to |
|---|---|
| 7, 8 | **11** (the floor) |
| 8.5 | 11.05 |
| 11.5 (live transcript) | 14.95 |
| 13 (captured row) | 16.5 |
| 14.5 (row title) | 17.9 |
| 26 (board headline) | 28.1 |

**Dynamic Type** comes from adding `relativeTo: .body`. The app ignored the system text-size setting entirely until now, which matters most for exactly the users who have already turned it up.

## The tests caught a real bug — the ramp inverted

My first curve used flat bands (`<12 → ×1.30`, `<20 → ×1.20`, else `×1.08`). At every boundary it went **backwards**:

- 11.5pt → 14.95
- **12pt → 14.4**

A 12pt call site rendering smaller than an 11.5pt one is, on screen, a subtitle set larger than the title above it. `testTheCurveIsMonotonic` failed immediately and named the size.

The curve is now a **continuous linear taper** between anchors — the derivative stays positive to 20pt, and both ends meet their neighbouring branches exactly (12 → 15.6, 20 → 21.6). Both former boundaries are also pinned by value, so a regression names itself rather than showing up as a vague "looks off."

## Verification

**71 tests, 10 new.** The floor is swept from 6pt up, the review's targets are pinned, monotonicity is swept across 6–40pt, and growth is bounded at 30% in both directions — unbounded growth would break fixed-width frames (the time column, PAUSE, DISCARD) rather than simply reflow.

**Board, walk and document rendered on-sim at 1320 × 2868 and inspected.** The layout absorbed it, as the review predicted — most screens were under-filled. The live transcript is the clearest win, and it is the thing you read while walking.

Also: `MetaStrip` eased its tracking 0.8 → 0.4 (heavy tracking helps at 8.5pt and hurts once glyphs hold their own shape) and caps at `accessibility1`, because it is two labels sharing one line under `lineLimit(1)` — without a cap one would truncate away. That is the pattern for any one-line strip.

## Still queued

Full sentence-case sweep, three-radii cleanup, SF Symbols for the typed chevron glyph, new-job sheet instead of `.alert`, real job **cards**, and the P2 chrome/dark-mode items. Plus the non-visual three: `orangeDeep` is ~4.4:1 (AA, not the AAA the brief claims), `Sources/Screens/*` are drifting duplicates that make the gallery lie, and BRIEF.md still specifies safety orange and the old Sitewalk name.
