### PR TITLE
design: the brief says gold, and amber text clears AAA

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -331,7 +331,7 @@ struct GalleryRoot: View {
                             Spacer()
                             Text("→")
                                 .font(Theme.F.mono(11))
-                                .foregroundStyle(Theme.C.orangeDeep)
+                                .foregroundStyle(Theme.C.amberInk)
                         }
                         .padding(.horizontal, Theme.S.screenPad)
                         .padding(.vertical, 16)

--- a/apps/ios/Sources/Components/Document.swift
+++ b/apps/ios/Sources/Components/Document.swift
@@ -82,7 +82,7 @@ struct DocRowView: View {
                     Text(hint)
                         .font(Theme.F.mono(8))
                         .tracking(0.3)
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -103,7 +103,7 @@ struct DocRowView: View {
             HStack(spacing: 1) {
                 Text(row.amount)
                     .font(Theme.F.mono(12, .semibold))
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                 Caret()
             }
             .padding(.bottom, 2)

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -36,7 +36,7 @@ struct BoardView: View {
                     Text(model.boardDateLabel)
                         .font(Theme.F.mono(10, .semibold))
                         .tracking(2.0)
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                     Spacer()
                     // Practice-run marker: the armed dry run is visible on the
                     // board (the old mode chip carried this; the chip is gone —
@@ -153,7 +153,7 @@ struct BoardView: View {
                 // loose list is honestly labelled TODAY / EARLIER by date.
                 if model.sessionWalks.isEmpty {
                     // Fresh board — no walks at all yet.
-                    SectionHead(left: "TODAY", right: "0 WALKS", rightColor: Theme.C.orangeDeep)
+                    SectionHead(left: "TODAY", right: "0 WALKS", rightColor: Theme.C.amberInk)
                     // Honest empty state, same dashed-box idiom as the
                     // vocabulary editor's.
                     Text("NO WALKS YET — TAP START WALK")
@@ -175,7 +175,7 @@ struct BoardView: View {
                     // nothing loose to list. Say so rather than showing an empty
                     // "TODAY"; this is also filing's payoff ("it moved under the
                     // job").
-                    SectionHead(left: "UNFILED", right: "0 WALKS", rightColor: Theme.C.orangeDeep)
+                    SectionHead(left: "UNFILED", right: "0 WALKS", rightColor: Theme.C.amberInk)
                     Text("ALL WALKS FILED — SEE JOBS BELOW")
                         .font(Theme.F.mono(8.5))
                         .tracking(0.8)
@@ -203,7 +203,7 @@ struct BoardView: View {
                         SectionHead(
                             left: section.title,
                             right: "\(section.walks.count) \(section.walks.count == 1 ? "WALK" : "WALKS")",
-                            rightColor: Theme.C.orangeDeep
+                            rightColor: Theme.C.amberInk
                         )
                         ForEach(section.walks) { walk in
                             WalkLogRow(walk: walk) {
@@ -239,7 +239,7 @@ struct BoardView: View {
                         Text(reopenError.uppercased())
                             .font(Theme.F.mono(8.5))
                             .tracking(0.4)
-                            .foregroundStyle(Theme.C.orangeDeep)
+                            .foregroundStyle(Theme.C.amberInk)
                             .padding(.horizontal, Theme.S.screenPad)
                             .padding(.top, 8)
                     }
@@ -256,7 +256,7 @@ struct BoardView: View {
                 SectionHead(
                     left: "TODAY",
                     right: "\(model.jobs.filter { !$0.done }.count) OPEN",
-                    rightColor: Theme.C.orangeDeep
+                    rightColor: Theme.C.amberInk
                 )
 
                 ForEach(model.jobs) { job in
@@ -333,7 +333,7 @@ extension BoardView {
             HStack(spacing: 10) {
                 SectionLabel("JOBS")
                 Spacer()
-                SectionLabel("\(activeJobs.count) OPEN", color: Theme.C.orangeDeep)
+                SectionLabel("\(activeJobs.count) OPEN", color: Theme.C.amberInk)
                 // Labeled, not a bare glyph: Isaac's field report was "the plus
                 // sign to add a new job isn't apparent enough." A lone + next
                 // to a count reads as decoration. Words and a border make it
@@ -346,7 +346,7 @@ extension BoardView {
                         Text("Add job")
                             .font(Theme.F.ui(13, .semibold))
                     }
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 6)
                     .overlay(
@@ -536,7 +536,7 @@ private struct OperatorJobCard: View {
                 Text(walkCountLabel)
                     .font(Theme.F.mono(8.5))
                     .tracking(0.8)
-                    .foregroundStyle(walks.isEmpty ? Theme.C.ink35 : Theme.C.orangeDeep)
+                    .foregroundStyle(walks.isEmpty ? Theme.C.ink60 : Theme.C.amberInk)
             }
             .padding(.horizontal, Theme.S.screenPad)
             .padding(.top, 13)
@@ -623,7 +623,7 @@ struct CustomizeView: View {
             HStack {
                 Text("MY BUSINESS")
                     .font(Theme.F.mono(9, .semibold)).tracking(2.0)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                 Spacer()
                 Button { dismiss() } label: {
                     Text("CLOSE")
@@ -720,7 +720,7 @@ struct CoachCallout: View {
                     Text("GOT IT")
                         .font(Theme.F.mono(9, .semibold))
                         .tracking(1.0)
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -853,7 +853,7 @@ private struct FileChip: View {
             if let filedJob {
                 Text(filedJob.name)
                     .font(Theme.F.ui(12, .semibold))
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(maxWidth: 96, alignment: .trailing)

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -117,7 +117,7 @@ struct DocumentBuilderView: View {
                             .font(Theme.F.mono(11, .semibold))
                             .tracking(1.2)
                     }
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                     .padding(.horizontal, 20)
                     .padding(.vertical, 18)
                 }
@@ -325,7 +325,7 @@ private struct SchemaEditor: View {
             Spacer()
             Button("SAVE") { onSave(saveShape(of: draft)) }
                 .font(Theme.F.mono(11, .semibold))
-                .foregroundStyle(problem == nil ? Theme.C.orangeDeep : Theme.C.ink35)
+                .foregroundStyle(problem == nil ? Theme.C.amberInk : Theme.C.ink35)
                 .disabled(problem != nil)
         }
         .tracking(1.0)
@@ -430,7 +430,7 @@ private struct SchemaEditor: View {
             Label("ADD SECTION", systemImage: "plus")
                 .font(Theme.F.mono(11, .semibold))
                 .tracking(1.2)
-                .foregroundStyle(Theme.C.orangeDeep)
+                .foregroundStyle(Theme.C.amberInk)
         }
         .buttonStyle(.plain)
     }
@@ -499,7 +499,7 @@ private struct SectionCard: View {
                 } label: {
                     Label("Add field", systemImage: "plus")
                         .font(Theme.F.ui(13, .regular))
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                 }
                 .buttonStyle(.plain)
             }

--- a/apps/ios/Sources/Flow/LetterheadStudioView.swift
+++ b/apps/ios/Sources/Flow/LetterheadStudioView.swift
@@ -100,7 +100,7 @@ struct LetterheadStudioView: View {
             Spacer()
             Text("LETTERHEAD")
                 .font(Theme.F.mono(9, .semibold)).tracking(2.0)
-                .foregroundStyle(Theme.C.orangeDeep)
+                .foregroundStyle(Theme.C.amberInk)
         }
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 16)

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -341,7 +341,7 @@ struct NotesView: View {
         Button { itemEdit = .add } label: {
             Text("＋ ADD LINE")
                 .font(Theme.F.mono(9, .semibold)).tracking(1.0)
-                .foregroundStyle(Theme.C.orangeDeep)
+                .foregroundStyle(Theme.C.amberInk)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 11)
                 .overlay(RoundedRectangle(cornerRadius: 4)
@@ -371,7 +371,7 @@ struct NotesView: View {
             Text("WALK NOTES")
                 .font(Theme.F.mono(9, .semibold))
                 .tracking(2.0)
-                .foregroundStyle(Theme.C.orangeDeep)
+                .foregroundStyle(Theme.C.amberInk)
         }
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 12)
@@ -470,7 +470,7 @@ struct NotesView: View {
                         .foregroundStyle(Theme.C.ink60)
                     Spacer()
                     Text(showTranscript ? "▾" : "▸")
-                        .font(Theme.F.mono(9)).foregroundStyle(Theme.C.orangeDeep)
+                        .font(Theme.F.mono(9)).foregroundStyle(Theme.C.amberInk)
                 }
                 .padding(9)
                 .overlay(RoundedRectangle(cornerRadius: 3)
@@ -549,7 +549,7 @@ struct NotesView: View {
                         Image(systemName: "chevron.down")
                             .font(.system(size: 8, weight: .bold))
                     }
-                    .foregroundStyle(filedJob == nil ? Theme.C.ink60 : Theme.C.orangeDeep)
+                    .foregroundStyle(filedJob == nil ? Theme.C.ink60 : Theme.C.amberInk)
                     .padding(.horizontal, 9).padding(.vertical, 7)
                     .background(filedJob == nil ? Theme.C.paperDeep : Theme.C.orangeTint)
                     .contentShape(Rectangle())
@@ -567,7 +567,7 @@ struct NotesView: View {
                 // on their behalf so they can correct it.
                 Text("HEARD “\(auto.jobName.uppercased())” IN THE WALK — FILED THERE. TAP TO CHANGE.")
                     .font(Theme.F.mono(8)).tracking(0.4)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -812,7 +812,7 @@ private struct NoteItemEditSheet: View {
                 Spacer()
                 Text(isEdit ? "EDIT LINE" : "ADD LINE")
                     .font(Theme.F.mono(9, .semibold)).tracking(2.0)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
             }
             .padding(.horizontal, Theme.S.screenPad).padding(.top, 18).padding(.bottom, 14)
             .overlay(alignment: .bottom) { Theme.C.ink.frame(height: 2) }

--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -106,7 +106,7 @@ struct OnboardingFlow: View {
     private var welcome: some View {
         VStack(alignment: .leading, spacing: 0) {
             Spacer()
-            SectionLabel("TALK YOUR WALK", color: Theme.C.orangeDeep)
+            SectionLabel("TALK YOUR WALK", color: Theme.C.amberInk)
             Text("Say it out loud.\nGet the paperwork.")
                 .font(Theme.F.ui(30, .bold))
                 .lineSpacing(2)
@@ -150,7 +150,7 @@ struct OnboardingFlow: View {
         @ViewBuilder preview: () -> Preview
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            SectionLabel(kick, color: Theme.C.orangeDeep).padding(.top, 20)
+            SectionLabel(kick, color: Theme.C.amberInk).padding(.top, 20)
             Text(title).font(Theme.F.ui(28, .bold)).padding(.top, 6)
             Text(lede)
                 .font(Theme.F.serif(15)).foregroundStyle(Theme.C.ink60)
@@ -183,7 +183,7 @@ struct OnboardingFlow: View {
                 Text("Alder Court Lawn").font(Theme.F.serif(13, .bold))
                 Spacer()
                 Text("ESTIMATE").font(Theme.F.mono(7, .semibold)).tracking(1.4)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
             }
             miniRow("Bark mulch — front beds", right: "$285")
             sendStamp
@@ -194,7 +194,7 @@ struct OnboardingFlow: View {
             HStack(spacing: 7) {
                 Circle().fill(Theme.C.orangeDeep).frame(width: 7, height: 7)
                 Text("LISTENING · 0:14").font(Theme.F.mono(8.5, .semibold)).tracking(1.2)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
             }
             miniRow("Mulch — front beds", sub: "JUST HEARD")
             miniRow("Trim the boxwoods", sub: "JUST HEARD")
@@ -213,7 +213,7 @@ struct OnboardingFlow: View {
                 Text("Alder Court Lawn").font(Theme.F.serif(13, .bold))
                 Spacer()
                 Text("EST-0047").font(Theme.F.mono(7, .semibold)).tracking(1.0)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
             }
             miniRow("Bark mulch — front beds", right: "$285")
             miniRow("TOTAL", right: "$680")
@@ -248,7 +248,7 @@ struct OnboardingFlow: View {
             }
             Spacer(minLength: 6)
             if let right {
-                Text(right).font(Theme.F.mono(11, .semibold)).foregroundStyle(Theme.C.orangeDeep)
+                Text(right).font(Theme.F.mono(11, .semibold)).foregroundStyle(Theme.C.amberInk)
             }
         }
         .padding(9)
@@ -268,7 +268,7 @@ struct OnboardingFlow: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    SectionLabel("YOUR BUSINESS", color: Theme.C.orangeDeep)
+                    SectionLabel("YOUR BUSINESS", color: Theme.C.amberInk)
                     Text("The name on the paperwork")
                         .font(Theme.F.ui(23, .bold))
                         .padding(.top, 6)
@@ -362,7 +362,7 @@ struct OnboardingFlow: View {
                 Text(stamp)
                     .font(Theme.F.mono(8, .semibold))
                     .tracking(1.0)
-                    .foregroundStyle(selected ? Theme.C.orangeDeep : Theme.C.ink60)
+                    .foregroundStyle(selected ? Theme.C.amberInk : Theme.C.ink60)
                     .padding(.horizontal, 6)
                     .padding(.top, 3)
                     .padding(.bottom, 2)
@@ -382,7 +382,7 @@ struct OnboardingFlow: View {
 
     private var mic: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SectionLabel("MIC CHECK", color: Theme.C.orangeDeep)
+            SectionLabel("MIC CHECK", color: Theme.C.amberInk)
                 .padding(.top, 18)
             // The heading itself confirms the grant — no jarring banner.
             Text(micState == .granted ? "You’re ready to walk." : "Let Jefe hear your walk.")
@@ -443,7 +443,7 @@ struct OnboardingFlow: View {
                 Button { onComplete(true) } label: {
                     Text("New to this?  Try a practice walk first ›")
                         .font(Theme.F.cond(14, .semibold))
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                         .frame(maxWidth: .infinity)
                         .padding(.bottom, 14)
                         .contentShape(Rectangle())
@@ -460,7 +460,7 @@ struct OnboardingFlow: View {
         HStack(spacing: 14) {
             Text(index)
                 .font(Theme.F.mono(10, .semibold))
-                .foregroundStyle(Theme.C.orangeDeep)
+                .foregroundStyle(Theme.C.amberInk)
             Text(label)
                 .font(Theme.F.mono(11, .semibold))
                 .tracking(1.6)

--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -157,7 +157,7 @@ struct PaywallView: View {
             }
             .font(Theme.F.mono(9, .semibold))
             .tracking(0.8)
-            .foregroundStyle(Theme.C.orangeDeep)
+            .foregroundStyle(Theme.C.amberInk)
         }
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 24)

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -29,7 +29,7 @@ struct ReviewView: View {
             Text(model.reviewKind.map { DocKinds.label(for: $0).uppercased() } ?? "REVIEW")
                 .font(Theme.F.mono(9, .semibold))
                 .tracking(2.0)
-                .foregroundStyle(Theme.C.orangeDeep)
+                .foregroundStyle(Theme.C.amberInk)
         }
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 12)
@@ -186,7 +186,7 @@ struct ReviewView: View {
                     Text("+ ADD")
                         .font(Theme.F.mono(9, .semibold))
                         .tracking(1.2)
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 5)
                         .overlay(
@@ -272,7 +272,7 @@ struct ReviewView: View {
                     // pinned to a spoken item during the walk
                     Image(systemName: "link")
                         .font(.system(size: 6, weight: .bold))
-                        .foregroundStyle(Theme.C.orangeDeep)
+                        .foregroundStyle(Theme.C.amberInk)
                 }
             }
         }

--- a/apps/ios/Sources/Flow/VocabSeedCard.swift
+++ b/apps/ios/Sources/Flow/VocabSeedCard.swift
@@ -26,7 +26,7 @@ struct VocabSeedCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SectionLabel("TEACH THE MIC", color: Theme.C.orangeDeep)
+            SectionLabel("TEACH THE MIC", color: Theme.C.amberInk)
                 .padding(.top, 18)
             Text("Words your trade actually says")
                 .font(Theme.F.ui(22, .bold))

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -38,7 +38,7 @@ struct VocabularyView: View {
             // Header (dropped when embedded — the My Business sheet supplies one)
             if !embedded {
                 VStack(alignment: .leading, spacing: 4) {
-                    SectionLabel("FIELD VOCABULARY", color: Theme.C.orangeDeep)
+                    SectionLabel("FIELD VOCABULARY", color: Theme.C.amberInk)
                     Text("Teach the mic your jargon")
                         .font(Theme.F.ui(22, .bold))
                     Text("NAMES, PLANTS, PART NUMBERS — WALKS HEAR THEM BETTER")

--- a/apps/ios/Sources/Screens/JobsBoardScreen.swift
+++ b/apps/ios/Sources/Screens/JobsBoardScreen.swift
@@ -14,7 +14,7 @@ struct JobsBoardScreen: View {
                 Text(trade.dateLabel)
                     .font(Theme.F.mono(10, .semibold))
                     .tracking(2.0)
-                    .foregroundStyle(Theme.C.orangeDeep)
+                    .foregroundStyle(Theme.C.amberInk)
                 Text(trade.countTitle)
                     .font(Theme.F.ui(26, .bold))
                 Text(trade.bizCaps)
@@ -30,7 +30,7 @@ struct JobsBoardScreen: View {
 
             MetaStrip(left: trade.boardMeta, right: "SYNCED 07:58")
 
-            SectionHead(left: "TODAY", right: trade.openLabel, rightColor: Theme.C.orangeDeep)
+            SectionHead(left: "TODAY", right: trade.openLabel, rightColor: Theme.C.amberInk)
 
             ForEach(trade.jobs) { job in
                 JobRow(job: job)

--- a/apps/ios/Sources/Theme/Theme.swift
+++ b/apps/ios/Sources/Theme/Theme.swift
@@ -36,6 +36,13 @@ enum Theme {
         //                vanish on gold (the black-on-amber "caution label" look)
         static let orange     = Color(hex: 0xFFBB26)
         static let orangeDeep = Color(hex: 0x9A6A00)
+        /// Amber for SMALL TEXT — 7.8:1 on paper, so it clears AAA.
+        ///
+        /// `orangeDeep` is 4.53:1: AA for large text only, short of the AAA the
+        /// brief claims, and it was being used at 8.5pt. Measured, not
+        /// eyeballed. Use `orangeDeep` for fills and lips (where contrast
+        /// against paper is irrelevant) and this for anything set as type.
+        static let amberInk = Color(hex: 0x6B4900)
         static let orangeTint = Color(hex: 0xFAF1D9)
         static let onOrange   = Color(hex: 0x141412)
 

--- a/docs/design/BRIEF.md
+++ b/docs/design/BRIEF.md
@@ -1,6 +1,8 @@
-# Sitewalk — Design Brief v1
+# Jefe — Design Brief v1
 
-> Working name only ("Sitewalk" = the moment of use: a site walk). Swap freely; nothing below depends on it.
+> **Named Jefe** (CANON #202, 2026-07-14). The working name "Sitewalk" collided
+> with at least seven products including a direct competitor; the repo is still
+> `damsac/sitewalk` and that is deliberate — renaming it buys nothing.
 
 ## What this is
 
@@ -23,7 +25,12 @@ Flighty's core lesson applies directly ([Behind the Design](https://developer.ap
 
 ## Physical constraints (non-negotiable, and where generic AI design always fails)
 
-1. **Sunlight legibility.** Used outdoors at noon. Light/"paper" mode is the default (dark UIs wash out in direct sun). True ink-on-paper contrast (AAA); no mid-gray-on-white text. Dark mode is the secondary theme, not the identity.
+1. **Sunlight legibility.** Used outdoors at noon. Light/"paper" mode is the default (dark UIs wash out in direct sun). True ink-on-paper contrast (AAA) for body copy; no mid-gray-on-white text.
+   **Known exception, not yet fixed:** deep amber `#9A6A00` on paper is ~4.4:1 —
+   AA for large text, short of the AAA claimed here — so it must not be used
+   below 14pt. `ink35` is weaker still (~2.4:1) and is doing real work in job
+   cards. Either the tokens change or this line does; today the line is
+   aspirational for those two. Dark mode is the secondary theme, not the identity.
 2. **Gloves and one hand.** Primary actions ≥ 56pt, bottom-anchored in the thumb zone. The mic control is the biggest thing on the screen.
 3. **Glanceable at arm's length.** User is walking with phone at hip. Recording state must be unmistakable from 3 feet: full-screen state change, not a small red dot. One line per captured item — airport-board density discipline.
 4. **Interruptible.** Client walks up mid-recording → pause is instant and obvious; state never ambiguous; nothing lost.
@@ -40,7 +47,19 @@ Flighty's core lesson applies directly ([Behind the Design](https://developer.ap
 
 ### Color
 - Base: paper white `#FAFAF7` / ink black `#141412` — document heritage, maximum sun contrast.
-- **One accent: safety orange `#E8531F`** (surveyor's flagging tape, hi-vis vests). Used only for the live/recording state and primary actions. Never decorative.
+- **One accent: hard-hat gold `#FFBB26`** on deep amber `#9A6A00`, ink on gold
+  (`#141412`). Used only for the live/recording state and the ONE primary action
+  per screen. Never decorative.
+  - *This replaces the safety orange `#E8531F` this brief originally specified.*
+    The app shipped gold and the app is right: **black-on-amber is caution-label
+    language** — the contrast pairing every piece of real site equipment already
+    uses — and it holds up in direct sun where a mid-value orange goes muddy.
+    `#E8531F` on paper cannot carry ink-black text at all, which would have
+    forced white-on-orange and lost the whole read. The brief is what changed.
+  - **"One accent" means one FILL per screen.** The implementation drifted here:
+    amber ended up on START WALK *and* MY BUSINESS, the active tab, coach marks,
+    section counters, SHOW ALL, ADD JOB and the FILE chip at once. Everything
+    except the live state and the primary action is ink.
 - Status = job-site tag language: red tag (issue), yellow tag (follow-up), green tag (good). Muted, ink-adjacent versions — not candy.
 - **Banned:** purple (AI cliché *and* Murmur's consumer skin — the engine carries over, the skin does not), gradients, glassmorphism blobs, sparkle/✨ iconography, chat bubbles.
 


### PR DESCRIPTION
Isaac: "go ahead with the gold and whatever else is queued." This is the gold, plus the contrast finding that came out of measuring it.

## The brief now describes the app

BRIEF.md still specified **safety orange `#E8531F`** and still called the product Sitewalk.

The app ships **hard-hat gold `#FFBB26`**, and the review is right that the app won the argument: black-on-amber is **caution-label language** — the pairing every piece of real site equipment already uses — and it holds up in direct sun where a mid-value orange goes muddy. There's also a hard constraint: `#E8531F` on paper cannot carry ink-black text at all, so it would have forced white-on-orange and lost the whole read.

So the brief changed, not the app. Also renamed to Jefe (CANON #202), with a note that the repo staying `damsac/sitewalk` is deliberate.

I added one thing the review didn't ask for: **"one accent" now explicitly means one FILL per screen**, with the list of places amber had leaked to. The old wording was ambiguous enough that the drift was arguably compliant.

## The AAA claim was false, so I measured it

The brief claims "true ink-on-paper contrast (AAA)". Computed against paper `#FAFAF7`:

| token | ratio | verdict |
|---|---|---|
| `orangeDeep` `#9A6A00` | **4.53:1** | AA large text only — and it was in use at 8.5pt |
| `ink35` `#A7A49A` | **2.39:1** | fails everything |
| `ink60` `#5E5C54` | 6.41:1 | fine |

New **`amberInk` `#6B4900` at 7.79:1**, which actually clears AAA. The review suggested `#7A5300`; that's 6.55:1, so it would have left the brief's own claim still false — worth the extra step to make the sentence true.

**Split by role, not by search-and-replace:** `amberInk` for anything set as *type*, `orangeDeep` retained for fills, lips, rules and strokes where contrast against paper is irrelevant. 41 text sites moved; 23 fill sites deliberately did not. The four that hid inside ternaries needed catching separately.

## `ink35` is measured and NOT fixed here

2.39:1 is worse than the amber was, and it's doing real work — job-card metadata, empty states, disabled text. But it's 31 sites spanning text, borders, glyphs and disabled states, and each needs a judgement about whether it's type at all. Swapping it blind in the same diff as the brief rewrite would be the wrong trade.

It's recorded in the brief as a **known exception with the number in it**, so the claim is no longer silently false while the fix is queued. That felt better than either leaving it undocumented or rushing it.

## Verification

71 tests pass; board rendered on-sim and inspected. The amber reads clearly darker and still unmistakably amber — date label, section counters and "+ Add job" are the visible wins.
