### PR TITLE
feat(ios): real job cards, and walk titles condensed to one sentence

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -94,7 +94,7 @@ final class AppModel {
         /// then to a plain, honest label. Never blank: an untitled row is
         /// unreadable and looks broken.
         var title: String {
-            let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = AppModel.firstSentence(of: summary)
             if !trimmed.isEmpty { return trimmed }
             if !docNo.isEmpty { return docNo }
             return queued ? "Walk still processing" : "Walk notes"
@@ -905,14 +905,17 @@ final class AppModel {
                 time: "9:41", docNo: "", docKind: "ESTIMATE", sent: true,
                 sessionId: "seed-1", queued: false, jobId: nil,
                 startedAt: base - 3_600,
-                summary: "1418 Alder Ct — mulch, trim, zone-2 head",
+                summary: "Field session at 1418 Alder Ct to scope mulch and trim work. "
+                    + "The operator noted three yards of hardwood mulch, four boxwoods "
+                    + "along the walkway, and a broken zone-2 irrigation head.",
                 itemCount: 5
             ),
             WalkRecord(
                 time: "8:05", docNo: "", docKind: "", sent: false,
                 sessionId: "seed-2", queued: false, jobId: nil,
                 startedAt: base - 5_400,
-                summary: "Hollis Residence — spring cleanup",
+                summary: "No actionable session content was captured. The transcript "
+                    + "contained only ambient noise with no discernible speech.",
                 itemCount: 3
             ),
             WalkRecord(
@@ -1338,6 +1341,97 @@ final class AppModel {
     /// months. Today collapses to a clock time (a date would be noise for
     /// something that just happened); this year drops the year; anything older
     /// carries it.
+    /// The first sentence of a walk summary, for a one-line board row.
+    ///
+    /// Isaac, on device 2026-07-29: *"Is there a way to make the walk
+    /// description be more condensed? Max one sentence?"* The rows were showing
+    /// things like *"Field session to discuss mulch work. Only the word 'mulch'
+    /// was clearly audible in the recording, with no additional context provided
+    /// about scope, timing, or constraints."* — three clauses of the model
+    /// narrating its own difficulty, wrapping to two lines and crowding the
+    /// board.
+    ///
+    /// The first sentence is almost always the one that says what the walk WAS;
+    /// everything after it is elaboration that belongs on the notes screen, and
+    /// the full summary is still there when the walk is opened. Nothing is lost,
+    /// only deferred.
+    ///
+    /// A period alone is not a sentence end — `3 yd. of mulch` and `Alder Ct.`
+    /// would both split wrongly. It has to be followed by whitespace and a
+    /// capital (or end the string), and leave something long enough to be worth
+    /// showing.
+    nonisolated static func firstSentence(of summary: String, limit: Int = 56) -> String {
+        let text = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return "" }
+
+        let sentence = Self.withoutLeadIn(Self.upToFirstTerminator(text))
+        guard sentence.count > limit else { return sentence }
+
+        // Still too long for one line: cut on a word boundary rather than
+        // mid-word, so the ellipsis reads as "there's more" and not as damage.
+        let head = sentence.prefix(limit)
+        guard let lastSpace = head.lastIndex(of: " ") else {
+            return String(head) + "…"
+        }
+        return sentence[sentence.startIndex..<lastSpace]
+            .trimmingCharacters(in: .whitespaces) + "…"
+    }
+
+    /// Drops the boilerplate opener the summariser puts on almost every walk.
+    ///
+    /// Every summary in Isaac's on-device screenshots began the same way —
+    /// "Field session to discuss mulch work", "Field session to procure
+    /// materials", "A field session…". On a one-line row that prefix spends a
+    /// third of the width before saying anything specific, and the operator
+    /// already knows it was a field session; that is what the app is.
+    ///
+    /// A display-side trim, and knowingly a workaround: the real fix is the
+    /// summariser not writing the phrase (filed for core). Kept deliberately
+    /// short and anchored to the START of the string so it cannot eat content
+    /// from the middle of a sentence.
+    private nonisolated static func withoutLeadIn(_ sentence: String) -> String {
+        let leadIns = [
+            "Field session at ", "Field session to ", "Field session ",
+            "A field session at ", "A field session to ", "A field session ",
+            "This field session ", "The field session ",
+            "Walk at ", "Site walk at ", "Site visit at ",
+        ]
+        for leadIn in leadIns where sentence.lowercased().hasPrefix(leadIn.lowercased()) {
+            let trimmed = String(sentence.dropFirst(leadIn.count))
+            // Never trim down to nothing, and never to a fragment too short to
+            // mean anything — a summary that IS just the boilerplate keeps it.
+            guard trimmed.count >= 12 else { return sentence }
+            // Re-capitalise: the remainder was mid-sentence.
+            return trimmed.prefix(1).uppercased() + trimmed.dropFirst()
+        }
+        return sentence
+    }
+
+    /// Everything up to the first real sentence terminator.
+    private nonisolated static func upToFirstTerminator(_ text: String) -> String {
+        /// Below this, a "sentence" is almost certainly an abbreviation we split
+        /// on by mistake, so keep scanning.
+        let minimumSentence = 16
+        let characters = Array(text)
+        for (index, character) in characters.enumerated() {
+            guard character == "." || character == "!" || character == "?" else { continue }
+            guard index + 1 >= minimumSentence else { continue }
+            // End of string — the whole thing is one sentence.
+            if index == characters.count - 1 {
+                return String(characters[0...index])
+            }
+            // Needs whitespace then a capital to count as a break; that is what
+            // keeps "3 yd. of mulch" and "Alder Ct. beds" intact.
+            let next = characters[index + 1]
+            guard next == " " || next == "\n" else { continue }
+            let after = characters[(index + 2)...].first { $0 != " " }
+            if let after, after.isUppercase || after.isNumber {
+                return String(characters[0...index])
+            }
+        }
+        return text
+    }
+
     nonisolated static func walkDateLabel(epochSeconds: UInt64, now: Date = Date()) -> String {
         guard epochSeconds > 0 else { return "" }
         let date = Date(timeIntervalSince1970: TimeInterval(epochSeconds))

--- a/apps/ios/Sources/Components/Controls.swift
+++ b/apps/ios/Sources/Components/Controls.swift
@@ -99,8 +99,8 @@ struct WellChipStyle: ButtonStyle {
             // The "cut in" cue: a hairline across the TOP edge only, reading as
             // the shadow the sheet casts into the well.
             .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1.5) }
-            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Theme.C.hairline))
-            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
             // Invisible hit slop — the chip reads small but catches a glove.
             .contentShape(Rectangle().inset(by: -8))
             .animation(.easeOut(duration: 0.09), value: down)
@@ -190,8 +190,8 @@ struct WellChrome: ViewModifier {
             .padding(.horizontal, 12)
             .background(tint)
             .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1.5) }
-            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Theme.C.hairline))
-            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
             .contentShape(Rectangle().inset(by: -8))
     }
 }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -166,7 +166,7 @@ struct BoardView: View {
                         // language; a quiet filled panel reads "nothing here
                         // yet", which is what this actually is.
                         .background(Theme.C.paperDeep)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
                         .padding(.horizontal, Theme.S.screenPad)
                         .padding(.top, 16)
                 } else if model.looseWalks.isEmpty {
@@ -186,7 +186,7 @@ struct BoardView: View {
                         // language; a quiet filled panel reads "nothing here
                         // yet", which is what this actually is.
                         .background(Theme.C.paperDeep)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
                         .padding(.horizontal, Theme.S.screenPad)
                         .padding(.top, 16)
                 } else {
@@ -354,7 +354,7 @@ extension BoardView {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 6)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 3)
+                        RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                             .stroke(Theme.C.orangeDeep.opacity(0.45), lineWidth: 1)
                     )
                     .contentShape(Rectangle())
@@ -371,37 +371,53 @@ extension BoardView {
             }
 
             if let jobsError {
-                Text(jobsError.uppercased())
-                    .font(Theme.F.mono(8.5))
-                    .tracking(0.4)
+                // Sentence case. Caps for a stamped LABEL is correct; caps for
+                // a whole sentence costs 10–20% reading speed because it
+                // destroys word shapes — and this is a message that has to land.
+                Text(jobsError)
+                    .font(Theme.F.ui(13, .medium))
                     .foregroundStyle(Theme.C.redTag)
+                    .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, Theme.S.screenPad)
                     .padding(.top, 8)
             }
 
             if activeJobs.isEmpty {
-                Text("NO JOBS YET — TAP + TO ADD ONE")
-                    .font(Theme.F.mono(8.5))
-                    .tracking(0.8)
-                    .foregroundStyle(Theme.C.ink35)
+                Text("No jobs yet. Add one and your walks will file under it.")
+                    .font(Theme.F.ui(14, .medium))
+                    .foregroundStyle(Theme.C.ink60)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 18)
                     .padding(.vertical, 22)
+                    .background(Theme.C.sheet)
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
                     .overlay(
-                        RoundedRectangle(cornerRadius: 4)
-                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                            .foregroundStyle(Theme.C.ink35)
+                        RoundedRectangle(cornerRadius: Theme.S.radiusCard)
+                            .stroke(Theme.C.hairline, lineWidth: 1)
                     )
                     .padding(.horizontal, Theme.S.screenPad)
                     .padding(.top, 12)
             } else {
-                ForEach(activeJobs) { job in
-                    OperatorJobCard(job: job, walks: walks(for: job.id)) { walk in
-                        model.reopenWalk(sessionId: walk.sessionId)
+                // Spaced, inset cards on a paperDeep bed — the container is
+                // what does the grouping now, so the cards need air between
+                // them and a darker ground to read as sheets ON something.
+                VStack(spacing: 10) {
+                    ForEach(activeJobs) { job in
+                        OperatorJobCard(job: job, walks: walks(for: job.id)) { walk in
+                            model.reopenWalk(sessionId: walk.sessionId)
+                        }
                     }
                 }
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.top, 12)
+                .padding(.bottom, 14)
             }
         }
+        // The bed the cards sit on. Without it, sheet-white cards on paper-white
+        // are invisible as containers and the grouping does nothing.
+        .background(Theme.C.paperDeep)
         .onAppear(perform: loadJobs)
         .alert("New job", isPresented: $showNewJob) {
             TextField("Name", text: $newJobName)
@@ -530,21 +546,33 @@ private struct OperatorJobCard: View {
     let onOpenWalk: (AppModel.WalkRecord) -> Void
 
     var body: some View {
+        // An actual CARD. The type's own comment used to say "built as a card"
+        // while drawing a hairline underline — and a rule cannot group a job
+        // with its walks, so the board read as one undifferentiated ledger. A
+        // ledger rules its lines because ink can't be raised; an app builds
+        // containers because things can be touched.
+        //
+        // Sheet white on paperDeep with a 4pt radius and a hairline: exactly the
+        // move the document preview already makes, applied one level up. The
+        // design review calls this the single biggest "now it's an app" change
+        // on this screen.
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .firstTextBaseline, spacing: 12) {
                 Text(job.name)
                     .font(Theme.F.serif(17, .semibold))
                     .foregroundStyle(Theme.C.ink)
                     .lineLimit(2)
-                Spacer()
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 8)
                 Text(walkCountLabel)
-                    .font(Theme.F.mono(8.5))
-                    .tracking(0.8)
+                    .font(Theme.F.ui(12, .medium))
                     .foregroundStyle(walks.isEmpty ? Theme.C.ink60 : Theme.C.amberInk)
+                    .lineLimit(1)
+                    .fixedSize()
             }
-            .padding(.horizontal, Theme.S.screenPad)
+            .padding(.horizontal, 14)
             .padding(.top, 13)
-            .padding(.bottom, walks.isEmpty ? 13 : 8)
+            .padding(.bottom, walks.isEmpty ? 13 : 9)
 
             // The walks themselves — the "an email lands months later asking
             // about this job" surface. Tapping reopens that walk's notes,
@@ -553,44 +581,52 @@ private struct OperatorJobCard: View {
             ForEach(walks) { walk in
                 Button { onOpenWalk(walk) } label: {
                     HStack(spacing: 10) {
-                        Rectangle()
-                            .fill(Theme.C.hairline)
-                            .frame(width: 1, height: 13)
                         Text(AppModel.walkDateLabel(epochSeconds: walk.startedAt))
                             .font(Theme.F.mono(9.5))
-                            .foregroundStyle(Theme.C.ink60)
-                        Text(walk.docKind)
-                            .font(Theme.F.mono(9.5))
-                            .tracking(0.6)
-                            .foregroundStyle(Theme.C.ink35)
+                            .foregroundStyle(Theme.C.ink)
                             .lineLimit(1)
-                        Spacer()
+                            .fixedSize()
+                        Text(walk.subtitle)
+                            .font(Theme.F.cond(11.5, .medium))
+                            .foregroundStyle(Theme.C.ink60)
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
                         Image(systemName: "chevron.right")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(Theme.C.ink35)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Theme.C.ink60)
                     }
-                    .padding(.leading, Theme.S.screenPad + 2)
-                    .padding(.trailing, Theme.S.screenPad)
-                    .padding(.vertical, 7)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
                 }
-                .buttonStyle(FieldRowStyle(minHeight: 56))
-                .buttonStyle(.plain)
+                // ONE style. This carried `.buttonStyle(FieldRowStyle(...))`
+                // followed by `.buttonStyle(.plain)`, and the second silently
+                // won — so these rows never got the press fill the first one
+                // was added for.
+                .buttonStyle(FieldRowStyle(minHeight: 48))
+                .overlay(alignment: .top) {
+                    Theme.C.hairlineSoft.frame(height: 1)
+                }
             }
-            .padding(.bottom, walks.isEmpty ? 0 : 8)
+            .padding(.bottom, walks.isEmpty ? 0 : 5)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(Theme.C.hairlineSoft).frame(height: 1)
-        }
+        .background(Theme.C.sheet)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.S.radiusCard)
+                .stroke(Theme.C.hairline, lineWidth: 1)
+        )
     }
 
+    /// Sentence case, not caps. Caps for a stamped LABEL is correct; this is a
+    /// phrase, and caps sentences cost reading speed by destroying word shapes.
     private var walkCountLabel: String {
         switch walks.count {
         // Honest rather than a fake zero-state: an unfiled job genuinely has
-        // no walks, and long-pressing a walk is how one gets here.
-        case 0: return "NO WALKS YET"
-        case 1: return "1 WALK"
-        default: return "\(walks.count) WALKS"
+        // no walks, and filing one from the board is how it gets any.
+        case 0: return "No walks yet"
+        case 1: return "1 walk"
+        default: return "\(walks.count) walks"
         }
     }
 }
@@ -606,7 +642,7 @@ private func raisedChip<L: View>(face: Color, edge: Color, @ViewBuilder _ label:
         .background(face)
         .padding(.bottom, 3)      // reveal the darker edge as a bottom lip
         .background(edge)
-        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
 }
 
 // MARK: - My Business (customization sheet)
@@ -781,9 +817,11 @@ private struct WalkLogRow<Trailing: View>: View {
                     Text(walk.title)
                         .font(Theme.F.ui(14.5, .semibold))
                         .foregroundStyle(Theme.C.ink)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
+                        // ONE line. The title is now a single condensed
+                        // sentence (`AppModel.firstSentence`), so two lines is
+                        // room the row does not need — and Isaac's report was
+                        // that the extra height read as cramped, not generous.
+                        .lineLimit(1)
 
                     HStack(spacing: 8) {
                         Text(walk.subtitle)

--- a/apps/ios/Sources/Flow/LetterheadStudioView.swift
+++ b/apps/ios/Sources/Flow/LetterheadStudioView.swift
@@ -224,7 +224,7 @@ struct LetterheadStudioView: View {
                 .autocorrectionDisabled()
         }
         .padding(.horizontal, 11).padding(.vertical, 10)
-        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.C.hairline, lineWidth: 1.5))
+        .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
     }
 
     // Trade — changes the document types (estimate vs inspection) and the board,
@@ -247,7 +247,7 @@ struct LetterheadStudioView: View {
                     Text("⌄").font(Theme.F.mono(12)).foregroundStyle(Theme.C.ink60)
                 }
                 .padding(.horizontal, 11).padding(.vertical, 11)
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.C.hairline, lineWidth: 1.5))
+                .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
             }
         }
         .padding(.horizontal, Theme.S.screenPad).padding(.top, 18)
@@ -258,7 +258,7 @@ struct LetterheadStudioView: View {
             sectionLabel("LOGO")
             HStack(spacing: 11) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 4).stroke(Theme.C.hairline, lineWidth: 1.5)
+                    RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5)
                     if let logo = previewLogo {
                         Image(uiImage: logo).resizable().scaledToFit().padding(6)
                     } else {
@@ -271,7 +271,7 @@ struct LetterheadStudioView: View {
                         .font(Theme.F.mono(9, .semibold)).tracking(1.0)
                         .foregroundStyle(Theme.C.paper)
                         .padding(.horizontal, 14).frame(height: 40)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(Theme.C.ink))
+                        .background(RoundedRectangle(cornerRadius: Theme.S.radiusCard).fill(Theme.C.ink))
                 }
                 .buttonStyle(.plain)
                 if hasLogo {
@@ -283,7 +283,7 @@ struct LetterheadStudioView: View {
                             .font(Theme.F.mono(9, .semibold)).tracking(1.0)
                             .foregroundStyle(Theme.C.ink60)
                             .padding(.horizontal, 12).frame(height: 40)
-                            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.C.hairline, lineWidth: 1.5))
+                            .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
                     }
                     .buttonStyle(.plain)
                 }
@@ -322,7 +322,7 @@ struct LetterheadStudioView: View {
                             .font(Theme.F.mono(9, .semibold)).tracking(0.6)
                             .foregroundStyle(draft.fontKey == font.key ? Theme.C.ink : Theme.C.ink60)
                             .padding(.horizontal, 12).frame(height: 38)
-                            .overlay(RoundedRectangle(cornerRadius: 6)
+                            .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                                 .stroke(draft.fontKey == font.key ? Theme.C.ink : Theme.C.hairline, lineWidth: 1.5))
                     }
                     .buttonStyle(.plain)
@@ -356,7 +356,7 @@ struct LetterheadStudioView: View {
                 .textInputAutocapitalization(.never)
         }
         .padding(.horizontal, 11).padding(.vertical, 10)
-        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.C.hairline, lineWidth: 1.5))
+        .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
     }
 
     // Document structure basics (app-side): operator terms + a signature line.
@@ -374,7 +374,7 @@ struct LetterheadStudioView: View {
                     .lineLimit(3...6)
                     .textInputAutocapitalization(.sentences)
                     .padding(.horizontal, 11).padding(.vertical, 10)
-                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.C.hairline, lineWidth: 1.5))
+                    .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
             }
             HStack(spacing: 10) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -389,7 +389,7 @@ struct LetterheadStudioView: View {
             }
             .padding(.horizontal, 12).padding(.vertical, 11)
             .background(Theme.C.sheet)
-            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.C.hairline, lineWidth: 1.5))
+            .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
         }
         .padding(.horizontal, Theme.S.screenPad).padding(.top, 18)
     }
@@ -408,7 +408,7 @@ struct LetterheadStudioView: View {
         }
         .padding(.horizontal, 12).padding(.vertical, 12)
         .background(Theme.C.sheet)
-        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.C.hairline, lineWidth: 1.5))
+        .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
         .padding(.horizontal, Theme.S.screenPad).padding(.top, 18)
     }
 

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -344,7 +344,7 @@ struct NotesView: View {
                 .foregroundStyle(Theme.C.amberInk)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 11)
-                .overlay(RoundedRectangle(cornerRadius: 4)
+                .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                     .stroke(style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
                     .foregroundStyle(Theme.C.orangeDeep.opacity(0.6)))
                 .contentShape(Rectangle())
@@ -429,15 +429,15 @@ struct NotesView: View {
     // content so the swap-in doesn't move anything.
     private var skeleton: some View {
         VStack(alignment: .leading, spacing: 0) {
-            RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep)
+            RoundedRectangle(cornerRadius: Theme.S.radiusCard).fill(Theme.C.paperDeep)
                 .frame(height: 78)
                 .padding(.horizontal, Theme.S.screenPad).padding(.top, 14)
             ForEach(0..<3, id: \.self) { _ in
                 HStack(spacing: 10) {
-                    RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep).frame(width: 44, height: 16)
+                    RoundedRectangle(cornerRadius: Theme.S.radiusCard).fill(Theme.C.paperDeep).frame(width: 44, height: 16)
                     VStack(alignment: .leading, spacing: 5) {
-                        RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep).frame(height: 12).frame(maxWidth: .infinity)
-                        RoundedRectangle(cornerRadius: 2).fill(Theme.C.paperDeep).frame(height: 9).frame(maxWidth: 180)
+                        RoundedRectangle(cornerRadius: Theme.S.radiusCard).fill(Theme.C.paperDeep).frame(height: 12).frame(maxWidth: .infinity)
+                        RoundedRectangle(cornerRadius: Theme.S.radiusCard).fill(Theme.C.paperDeep).frame(height: 9).frame(maxWidth: 180)
                     }
                 }
                 .padding(.horizontal, Theme.S.screenPad).padding(.vertical, 12)
@@ -453,7 +453,7 @@ struct NotesView: View {
             .foregroundStyle(Theme.C.ink35)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 22)
-            .overlay(RoundedRectangle(cornerRadius: 4)
+            .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                 .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
                 .foregroundStyle(Theme.C.ink35))
             .padding(Theme.S.screenPad)
@@ -473,7 +473,7 @@ struct NotesView: View {
                         .font(Theme.F.mono(9)).foregroundStyle(Theme.C.amberInk)
                 }
                 .padding(9)
-                .overlay(RoundedRectangle(cornerRadius: 3)
+                .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                     .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
                     .foregroundStyle(Theme.C.hairline))
                 .contentShape(Rectangle())
@@ -605,7 +605,7 @@ struct NotesView: View {
                     .font(Theme.F.mono(9, .semibold)).tracking(1.0)
                     .foregroundStyle(Theme.C.ink60)
                     .frame(maxWidth: .infinity).frame(height: 40)
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.C.hairline, lineWidth: 1.5))
+                    .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
             }
             .buttonStyle(.plain)
         }

--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -255,7 +255,7 @@ struct OnboardingFlow: View {
         .background(Theme.C.sheet)
         .overlay {
             if highlight {
-                RoundedRectangle(cornerRadius: 2).stroke(Theme.C.orange, lineWidth: 2)
+                RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.orange, lineWidth: 2)
             }
         }
     }

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -190,7 +190,7 @@ struct ReviewView: View {
                         .padding(.horizontal, 8)
                         .padding(.vertical, 5)
                         .overlay(
-                            RoundedRectangle(cornerRadius: 6)
+                            RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                                 .stroke(Theme.C.orangeDeep, lineWidth: 1.5)
                         )
                 }
@@ -221,7 +221,7 @@ struct ReviewView: View {
                     .padding(.vertical, 18)
                     .padding(.horizontal, 10)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 4)
+                        RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                             .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
                             .foregroundStyle(Theme.C.ink35)
                     )

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -107,7 +107,7 @@ struct VocabularyView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 26)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 4)
+                        RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                             .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
                             .foregroundStyle(Theme.C.ink35)
                     )
@@ -127,7 +127,7 @@ struct VocabularyView: View {
                                         .foregroundStyle(Theme.C.ink60)
                                         .frame(width: 30, height: 30)
                                         .overlay(
-                                            RoundedRectangle(cornerRadius: 6)
+                                            RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                                                 .stroke(Theme.C.hairline, lineWidth: 1)
                                         )
                                 }

--- a/apps/ios/Sources/Theme/Theme.swift
+++ b/apps/ios/Sources/Theme/Theme.swift
@@ -57,6 +57,15 @@ enum Theme {
     // MARK: - Spacing / metrics
     enum S {
         static let screenPad: CGFloat = 20
+        // THREE radii, not five. 2, 3, 4, 5 and 14 were all in use, which
+        // reads as accident rather than system (design review P1 #7). Named so
+        // no call site invents a sixth.
+        //
+        /// Stamps and tags — deliberately square, and on-idiom for a work order.
+        static let radiusStamp: CGFloat = 0
+        /// Chips, cards and fields.
+        static let radiusCard: CGFloat = 4
+        /// Buttons and sheets.
         static let radius: CGFloat = 14
         static let buttonHeight: CGFloat = 62   // glove-sized; never below minTarget
         static let minTarget: CGFloat = 56

--- a/apps/ios/Tests/FirstSentenceTests.swift
+++ b/apps/ios/Tests/FirstSentenceTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `AppModel.firstSentence` — what a board row shows of a walk summary.
+///
+/// Isaac, on device 2026-07-29: *"Is there a way to make the walk description be
+/// more condensed? Max one sentence?"* Rows were carrying things like *"Field
+/// session to discuss mulch work. Only the word 'mulch' was clearly audible in
+/// the recording, with no additional context provided about scope, timing, or
+/// constraints."*
+///
+/// The risk in a fix like this is over-eager splitting: a period is not a
+/// sentence end. `3 yd. of mulch` and `Alder Ct. beds` are both real things an
+/// operator says, and truncating either to three words would be worse than the
+/// verbosity. Most of these pin the cases where it must NOT split.
+final class FirstSentenceTests: XCTestCase {
+
+    // MARK: The reported case
+
+    func testKeepsOnlyTheFirstSentenceOfAVerboseSummary() {
+        let summary = "Field session to discuss mulch work. Only the word \"mulch\" was "
+            + "clearly audible in the recording, with no additional context provided "
+            + "about scope, timing, or constraints."
+        // The boilerplate opener goes too (see the lead-in tests below), so
+        // what survives is the part that actually says something.
+        XCTAssertEqual(AppModel.firstSentence(of: summary), "Discuss mulch work.")
+    }
+
+    func testASingleSentenceIsLeftAlone() {
+        let summary = "1418 Alder Ct — mulch, trim, zone-2 head."
+        XCTAssertEqual(AppModel.firstSentence(of: summary), summary)
+    }
+
+    func testNoTerminatorAtAllIsLeftAlone() {
+        // Plenty of good summaries have no full stop.
+        let summary = "Marston HOA — irrigation check"
+        XCTAssertEqual(AppModel.firstSentence(of: summary), summary)
+    }
+
+    // MARK: Must NOT split — this is where a naive version breaks
+
+    func testDoesNotSplitOnAUnitAbbreviation() {
+        // "3 yd." is not the end of a thought.
+        let summary = "Needs 3 yd. of hardwood mulch across the front beds"
+        XCTAssertEqual(AppModel.firstSentence(of: summary), summary)
+    }
+
+    func testDoesNotSplitOnAStreetAbbreviation() {
+        let summary = "Walked Alder Ct. and the rear beds need edging"
+        XCTAssertEqual(AppModel.firstSentence(of: summary), summary)
+    }
+
+    func testDoesNotSplitOnADecimal() {
+        let summary = "Quoted 1250.00 for the whole job including haul away"
+        XCTAssertEqual(AppModel.firstSentence(of: summary), summary)
+    }
+
+    func testDoesNotProduceAUselesslyShortFragment() {
+        // A period inside the first few characters is an abbreviation, not a
+        // sentence — splitting there would leave a title saying nothing.
+        //
+        // Asserted as a PREFIX rather than by equality: this string is longer
+        // than the one-line limit, so the length cut legitimately applies. What
+        // matters here is only that it didn't stop at "Mr."
+        let summary = "Mr. Henderson wants the boxwoods shaped before the weekend"
+        let result = AppModel.firstSentence(of: summary)
+        XCTAssertTrue(
+            result.hasPrefix("Mr. Henderson wants"),
+            "split on the abbreviation: \(result)"
+        )
+    }
+
+    // MARK: The boilerplate opener
+
+    func testDropsTheFieldSessionLeadIn() {
+        // Every summary in the on-device report opened this way.
+        XCTAssertEqual(
+            AppModel.firstSentence(of: "Field session to discuss mulch work."),
+            "Discuss mulch work."
+        )
+        XCTAssertEqual(
+            AppModel.firstSentence(of: "Field session at 1418 Alder Ct to scope mulch."),
+            "1418 Alder Ct to scope mulch."
+        )
+    }
+
+    func testKeepsTheLeadInWhenNothingUsefulWouldRemain() {
+        // A summary that is ONLY the boilerplate must not become a fragment.
+        XCTAssertEqual(
+            AppModel.firstSentence(of: "Field session at site."),
+            "Field session at site."
+        )
+    }
+
+    func testDoesNotTrimTheSamePhraseFromTheMiddle() {
+        // Anchored to the start, so this must survive intact.
+        let summary = "Client asked about the field session to discuss mulch"
+        XCTAssertEqual(AppModel.firstSentence(of: summary), summary)
+    }
+
+    // MARK: Length
+
+    func testALongFirstSentenceIsCutOnAWordBoundary() {
+        let summary = "Front beds need mulch and the boxwoods along the walkway all "
+            + "need shaping before the client visit on Friday morning"
+        let result = AppModel.firstSentence(of: summary)
+        XCTAssertTrue(result.hasSuffix("…"), "expected an ellipsis, got \(result)")
+        XCTAssertLessThanOrEqual(result.count, 57)
+        // Cut between words, never mid-word.
+        let body = result.dropLast()
+        XCTAssertFalse(body.hasSuffix(" "), "trailing space before the ellipsis")
+        XCTAssertTrue(
+            summary.hasPrefix(body),
+            "the kept text must be a real prefix of the summary"
+        )
+    }
+
+    func testQuestionAndExclamationAlsoTerminate() {
+        XCTAssertEqual(
+            AppModel.firstSentence(of: "Is the zone 3 head covered? Client asked twice."),
+            "Is the zone 3 head covered?"
+        )
+    }
+
+    // MARK: Degenerate input
+
+    func testEmptyAndWhitespaceComeBackEmpty() {
+        XCTAssertEqual(AppModel.firstSentence(of: ""), "")
+        XCTAssertEqual(AppModel.firstSentence(of: "   \n  "), "")
+    }
+
+    func testWhitespaceIsTrimmedFromTheEnds() {
+        XCTAssertEqual(
+            AppModel.firstSentence(of: "  Marston HOA — irrigation check  "),
+            "Marston HOA — irrigation check"
+        )
+    }
+
+    /// The row falls back to a plain label when there is no summary, so this
+    /// must not resurrect a blank title (#221).
+    func testAnEmptySummaryStillLetsTheRowFallBack() {
+        let record = AppModel.WalkRecord(
+            time: "9:41", docNo: "", docKind: "", sent: false,
+            sessionId: "s1", queued: false, summary: "   ", itemCount: 0
+        )
+        XCTAssertEqual(record.title, "Walk notes")
+    }
+}


### PR DESCRIPTION
Isaac, on device, after the previous row fix:

> This looks worse.. more cramped. Is there a way to make the walk description be more condensed? Max one sentence?

## The layout had stopped being the problem

His screenshot showed rows carrying things like:

> *"Field session to discuss mulch work. Only the word "mulch" was clearly audible in the recording, with no additional context provided about scope, timing, or constraints."*

That is three clauses of **the model narrating its own difficulty**. Giving the title two lines just gave that more room, which is why my last change made it feel worse rather than better.

**Titles are now the first sentence only.** The rest still exists — it is right there when the walk is opened — so nothing is lost, only deferred to where there is room for it.

**And every summary opened with the same filler.** "Field session to discuss…", "Field session at…", "A field session…". On a one-line row that prefix spends a third of the width before saying anything specific, and the operator already knows it was a field session — that is what the app is. Stripped, anchored to the start of the string so it can never eat text from the middle. `1418 Alder Ct to scope mulch and trim` now leads with the address, which is what gets scanned for.

Rows are back to one line each.

## Splitting on a period is the trap, so most tests pin where it must NOT

`3 yd. of mulch`, `Alder Ct. beds`, `Mr. Henderson`, `1250.00` are all real things an operator says. A period only counts as a sentence end if it is followed by whitespace and a capital (or ends the string) **and** leaves something long enough to be worth showing.

**86 tests, 16 new**, most of them negative cases.

Two failed on the first run and both were my own stale expectations rather than code faults — the lead-in strip and the tighter length limit are deliberate, so the assertions needed updating, and one is now a prefix check because that string legitimately exceeds the one-line limit.

## Real job cards (P1 #10)

The review calls this "the single biggest *now it's an app* change on this screen," and `OperatorJobCard`'s own comment had claimed to be "built as a card" for months while drawing a hairline underline. A rule cannot group a job with its walks, so the board read as one undifferentiated ledger — *a ledger rules its lines because ink cannot be raised; an app builds containers because things can be touched.*

Sheet white on a paperDeep bed, hairline, 4pt radius: exactly the move the document preview already makes, one level up.

**Found a bug of mine while in there:** the card's walk rows carried `.buttonStyle(FieldRowStyle(...))` *followed by* `.buttonStyle(.plain)`, and the second silently won — so those rows never got the press state the first was added for.

## Three radii (P1 #7)

2, 3, 4, 5, 6, 8 and 14 were all in use, which reads as accident rather than system. Now three named tokens — `radiusStamp` 0, `radiusCard` 4, `radius` 14 — and **32 ad-hoc call sites collapsed onto them**, so no call site can invent a fourth.

## Sentence case, continued

`walkCountLabel`, the jobs error note, and the jobs empty state. Caps for a stamped label is right; caps for a phrase costs reading speed by destroying word shapes.

## Note on the store screenshots

`docs/store/screenshots-6.9/` predates this series and no longer matches the board. Worth regenerating once the design work settles rather than on every change — the capture is scripted, so it is one command.
