### PR TITLE
fix(ios): system parts instead of hand-made ones, and stop shouting sentences

### DIFF
--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -329,7 +329,7 @@ struct GalleryRoot: View {
                                 .tracking(1.2)
                                 .foregroundStyle(Theme.C.ink)
                             Spacer()
-                            Text("→")
+                            Image(systemName: "arrow.right")
                                 .font(Theme.F.mono(11))
                                 .foregroundStyle(Theme.C.amberInk)
                         }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -17,7 +17,10 @@ struct BoardView: View {
     // needs the list too.
     @State private var operatorJobs: [JobModel] = []
     @State private var jobsError: String?
-    @State private var showNewJob = false
+    // `newjob=1` opens the sheet on launch. simctl can't tap, and shipping a
+    // brand-new UI surface unseen is how the inline FILE chip ended up 130pt
+    // tall. Same precedent as `paywall=1`.
+    @State private var showNewJob = ProcessInfo.processInfo.arguments.contains("newjob=1")
     @State private var newJobName = ""
     /// TODAY collapses so JOBS clears the fold. Expanding shows the rest.
     @State private var showAllWalks = false
@@ -94,8 +97,10 @@ struct BoardView: View {
                             Text(model.trade.bizCaps)
                                 .font(Theme.F.mono(9.5))
                                 .tracking(0.8)
-                            Text("⌄")
-                                .font(Theme.F.mono(9))
+                            // SF Symbol, not a typed glyph: correct optical
+                            // alignment, free Dynamic Type, free VoiceOver.
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 11, weight: .semibold))
                         }
                         .foregroundStyle(Theme.C.ink60)
                     }
@@ -240,9 +245,8 @@ struct BoardView: View {
 
                     if let reopenError = model.reopenError {
                         // F4 floor: the breadcrumb surfaces; chrome is sac's.
-                        Text(reopenError.uppercased())
-                            .font(Theme.F.mono(8.5))
-                            .tracking(0.4)
+                        Text(reopenError)
+                            .font(Theme.F.ui(13, .medium))
                             .foregroundStyle(Theme.C.amberInk)
                             .padding(.horizontal, Theme.S.screenPad)
                             .padding(.top, 8)
@@ -315,6 +319,85 @@ struct BoardView: View {
                 .presentationBackground(Theme.C.paper)
         }
         .manageSubscriptionsSheet(isPresented: $showManageSubscription)
+    }
+}
+
+
+// MARK: - New job
+
+/// Creating a job, as a sheet.
+///
+/// The `.alert` this replaces gave a ~30pt field and no room for a hint — the
+/// two things this screen needs most, because it is used one-handed standing at
+/// a truck. A sheet affords a 56pt field, a trade-shaped example, and a real
+/// 62pt Save.
+private struct NewJobSheet: View {
+    @Binding var name: String
+    let onCancel: () -> Void
+    let onSave: () -> Void
+    /// Focus the field on appear: this sheet exists to take one short string,
+    /// so making the operator tap again first is a wasted step.
+    @FocusState private var focused: Bool
+
+    private var trimmed: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                SectionLabel("NEW JOB")
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .font(Theme.F.ui(13, .semibold))
+                    .foregroundStyle(Theme.C.ink60)
+            }
+            .padding(.horizontal, Theme.S.screenPad)
+            .padding(.top, 18)
+            .padding(.bottom, 14)
+
+            Text("Call it whatever you call it on site.")
+                .font(Theme.F.ui(14, .medium))
+                .foregroundStyle(Theme.C.ink60)
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.bottom, 12)
+
+            // 56pt and recessed, matching the Tier 3 well: a field is something
+            // you type INTO, so it is cut into the sheet rather than raised off
+            // it.
+            TextField("", text: $name, prompt: Text("14 Oakfield — back beds")
+                .foregroundColor(Theme.C.ink35))
+                .font(Theme.F.ui(17, .medium))
+                .foregroundStyle(Theme.C.ink)
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+                .submitLabel(.done)
+                .onSubmit { if !trimmed.isEmpty { onSave() } }
+                .focused($focused)
+                .padding(.horizontal, 14)
+                .frame(height: 56)
+                .background(Theme.C.paperDeep)
+                .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1.5) }
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.S.radiusCard)
+                        .stroke(Theme.C.hairline)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
+                .padding(.horizontal, Theme.S.screenPad)
+
+            Spacer(minLength: 0)
+
+            Button(action: onSave) { BlockLabel("SAVE JOB") }
+                .buttonStyle(RaisedBlockStyle(leadingDot: false))
+                // Core rejects an empty name rather than coercing it (R6), so
+                // the button simply does not offer to send one — the style goes
+                // flat, which is now what unpressable looks like.
+                .disabled(trimmed.isEmpty)
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.bottom, 14)
+        }
+        .background(Theme.C.paper)
+        .onAppear { focused = true }
     }
 }
 
@@ -419,12 +502,17 @@ extension BoardView {
         // are invisible as containers and the grouping does nothing.
         .background(Theme.C.paperDeep)
         .onAppear(perform: loadJobs)
-        .alert("New job", isPresented: $showNewJob) {
-            TextField("Name", text: $newJobName)
-            Button("Cancel", role: .cancel) { newJobName = "" }
-            Button("Add") { createJob() }
-        } message: {
-            Text("Call it whatever you call it on site.")
+        // A SHEET, not an `.alert` (design review P1 #9). A TextField inside an
+        // alert is a ~30pt target with no room for a real placeholder — the two
+        // things this needs most, since it is used one-handed on a job site.
+        .sheet(isPresented: $showNewJob) {
+            NewJobSheet(
+                name: $newJobName,
+                onCancel: { newJobName = ""; showNewJob = false },
+                onSave: { createJob(); showNewJob = false }
+            )
+            .presentationDetents([.height(300)])
+            .presentationBackground(Theme.C.paper)
         }
     }
 
@@ -770,7 +858,7 @@ struct CoachCallout: View {
             .background(Theme.C.orangeTint)
             .overlay(Rectangle().stroke(Theme.C.orange, lineWidth: 1.5))
 
-            Text("▾")
+            Image(systemName: "arrowtriangle.down.fill")
                 .font(Theme.F.ui(15, .bold))
                 .foregroundStyle(Theme.C.orange)
                 .frame(maxWidth: .infinity, alignment: pointer)

--- a/apps/ios/Sources/Flow/LetterheadStudioView.swift
+++ b/apps/ios/Sources/Flow/LetterheadStudioView.swift
@@ -244,7 +244,9 @@ struct LetterheadStudioView: View {
                         .font(Theme.F.cond(13, .semibold))
                         .foregroundStyle(Theme.C.ink)
                     Spacer()
-                    Text("⌄").font(Theme.F.mono(12)).foregroundStyle(Theme.C.ink60)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.C.ink60)
                 }
                 .padding(.horizontal, 11).padding(.vertical, 11)
                 .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -469,7 +469,7 @@ struct NotesView: View {
                         .font(Theme.F.mono(8.5, .semibold)).tracking(0.8)
                         .foregroundStyle(Theme.C.ink60)
                     Spacer()
-                    Text(showTranscript ? "▾" : "▸")
+                    Image(systemName: showTranscript ? "chevron.down" : "chevron.right")
                         .font(Theme.F.mono(9)).foregroundStyle(Theme.C.amberInk)
                 }
                 .padding(9)
@@ -543,7 +543,7 @@ struct NotesView: View {
                     }
                 } label: {
                     HStack(spacing: 5) {
-                        Text(filedJob?.name.uppercased() ?? "CHOOSE A JOB")
+                        Text(filedJob?.name ?? "Choose a job")
                             .font(Theme.F.mono(9, .semibold)).tracking(0.8)
                             .lineLimit(1).truncationMode(.tail)
                         Image(systemName: "chevron.down")
@@ -565,8 +565,8 @@ struct NotesView: View {
                 // indistinguishable from a bug the first time it guesses
                 // wrong — and the operator needs to know a choice was made
                 // on their behalf so they can correct it.
-                Text("HEARD “\(auto.jobName.uppercased())” IN THE WALK — FILED THERE. TAP TO CHANGE.")
-                    .font(Theme.F.mono(8)).tracking(0.4)
+                Text("Heard “\(auto.jobName)” in the walk — filed there. Tap to change.")
+                    .font(Theme.F.ui(13, .medium))
                     .foregroundStyle(Theme.C.amberInk)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -631,7 +631,7 @@ struct NotesView: View {
                     ProgressView().tint(hero ? Theme.C.onOrange : Theme.C.ink)
                 } else {
                     VStack(spacing: 2) {
-                        Text(choice.label.uppercased())
+                        Text(choice.label)
                             .font(Theme.F.ui(12, .bold)).tracking(0.04)
                             .foregroundStyle(hero ? Theme.C.onOrange : Theme.C.ink)
                             .lineLimit(1).minimumScaleFactor(0.75)

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -200,10 +200,10 @@ struct ReviewView: View {
             if let error = model.photoError {
                 HStack(spacing: 0) {
                     Theme.C.redTag.frame(width: 3)
-                    Text(error.uppercased())
-                        .font(Theme.F.mono(8))
-                        .tracking(0.4)
+                    Text(error)
+                        .font(Theme.F.ui(13, .medium))
                         .foregroundStyle(Theme.C.redTag)
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.horizontal, 9)
                         .padding(.vertical, 6)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/ios/Sources/Flow/VocabSeedCard.swift
+++ b/apps/ios/Sources/Flow/VocabSeedCard.swift
@@ -75,10 +75,10 @@ struct VocabSeedCard: View {
                 }
 
                 if let confirmation {
-                    Text(confirmation.uppercased())
-                        .font(Theme.F.mono(9, .semibold))
-                        .tracking(1.0)
+                    Text(confirmation)
+                        .font(Theme.F.ui(13, .semibold))
                         .foregroundStyle(Theme.C.greenTag)
+                        .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.top, 10)
                 }

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -83,10 +83,10 @@ struct VocabularyView: View {
             if let error = model.vocabularyError {
                 HStack(spacing: 0) {
                     Theme.C.yellowTag.frame(width: 3)
-                    Text(error.uppercased())
-                        .font(Theme.F.mono(8))
-                        .tracking(0.4)
+                    Text(error)
+                        .font(Theme.F.ui(13, .medium))
                         .foregroundStyle(Theme.C.ink60)
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.horizontal, 9)
                         .padding(.vertical, 6)
                         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Three more from the queue — the "stop hand-making parts iOS already ships" cluster.

## Typed glyphs → SF Symbols (P1 #8)

The review calls these "the most literally *handwritten* thing in the codebase," and it's right:

| was | now |
|---|---|
| `Text("⌄")` as a menu chevron | `chevron.down` |
| `Text("▾")` as a callout pointer | `arrowtriangle.down.fill` |
| `Text("▾" / "▸")` as a disclosure | `chevron.down` / `chevron.right` |
| `Text("→")` as a row arrow | `arrow.right` |

Symbols bring correct optical alignment, Dynamic Type scaling and VoiceOver labels for free — all three of which the typed characters silently lacked.

## Sentence case, where it's a sentence (P0 #3)

The rule from the review, applied literally: **caps for a stamped LABEL stays** — `SITE`, `FINDINGS`, `TODAY`, `RECORDING`, doc-number prefixes, letterhead metadata. Caps for a **sentence** goes, because it costs 10–20% reading speed by destroying word shapes, and reads as shouting.

7 of the 23 `.uppercased()` calls were sentences. 16 were genuinely stamps and were left alone.

Two were worse than shouting:

- `filedJob?.name.uppercased()` — **an operator's own job name, shouted back at them.**
- `choice.label.uppercased()` — likewise, for a document type they named themselves.

Also `HEARD "X" IN THE WALK — FILED THERE. TAP TO CHANGE.` → sentence case. That's the auto-filing confirmation, one of the few messages that has to land instantly.

The fonts moved with the copy: stamped mono with tracking is a print device for labels, and on a sentence it slows reading *further*. Those four are now the UI face with no tracking.

## New job is a sheet, not an alert (P1 #9)

A `TextField` inside `.alert` is a ~30pt target with no room for a real placeholder — the two things this particular screen needs most, since it's used one-handed standing at a truck.

Now: a 56pt **recessed** field (a field is something you type *into*, so it's cut into the sheet rather than raised off it), a trade-shaped hint — `14 Oakfield — back beds` — auto-focus so there's no wasted tap, submit-on-return, and a real 62pt SAVE JOB.

**Rendered and verified**, via a `newjob=1` hook in the same style as `paywall=1`. I added that deliberately: shipping a brand-new UI surface unseen is exactly how the inline FILE chip ended up 130pt tall, and simctl can't tap.

Worth looking at in the screenshot: **SAVE JOB is flat, with no lip**, because the name is empty. Core rejects an empty name rather than coercing it (R6), so the button doesn't offer to send one — and "flat means off" is now carrying that meaning without a word of explanation.

86 tests pass.

## Left in the queue

`ink35` at 2.39:1 (measured, documented in the brief as a known exception), deleting the drifting `Sources/Screens/*` duplicates, and the P2 chrome layer and dark-mode unlock.
