### PR TITLE
fix(ios): quiet text that can actually be read — ink35 was 2.39:1

### DIFF
--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -183,7 +183,7 @@ struct BoardView: View {
                     Text("ALL WALKS FILED — SEE JOBS BELOW")
                         .font(Theme.F.mono(8.5))
                         .tracking(0.8)
-                        .foregroundStyle(Theme.C.ink35)
+                        .foregroundStyle(Theme.C.ink45)
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 22)
@@ -366,7 +366,7 @@ private struct NewJobSheet: View {
             // you type INTO, so it is cut into the sheet rather than raised off
             // it.
             TextField("", text: $name, prompt: Text("14 Oakfield — back beds")
-                .foregroundColor(Theme.C.ink35))
+                .foregroundColor(Theme.C.ink45))
                 .font(Theme.F.ui(17, .medium))
                 .foregroundStyle(Theme.C.ink)
                 .textInputAutocapitalization(.words)
@@ -800,7 +800,7 @@ struct CustomizeView: View {
         return Button { tab = t } label: {
             Text(label)
                 .font(Theme.F.ui(13.5, .bold)).tracking(0.8)
-                .foregroundStyle(on ? Theme.C.ink : Theme.C.ink35)
+                .foregroundStyle(on ? Theme.C.ink : Theme.C.ink45)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 13)
                 // Each tab draws its own bottom rule so the bar reads as one

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -193,7 +193,7 @@ private struct SchemaRow: View {
                 Text(summary)
                     .font(Theme.F.mono(10, .regular))
                     .tracking(0.6)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
             }
             Spacer()
             if schema.isBuiltin {
@@ -207,7 +207,7 @@ private struct SchemaRow: View {
             }
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(Theme.C.ink35)
+                .foregroundStyle(Theme.C.ink45)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
@@ -376,7 +376,7 @@ private struct SchemaEditor: View {
             )
             Text("Documents will be numbered \(prefixPreview)-0001, -0002, and so on.")
                 .font(Theme.F.mono(10, .regular))
-                .foregroundStyle(Theme.C.ink35)
+                .foregroundStyle(Theme.C.ink45)
         }
     }
 
@@ -538,7 +538,7 @@ private struct FieldCard: View {
                 TextField("Field name", text: $field.label)
                     .font(Theme.F.ui(14, .regular))
                 Button(action: onDelete) { Image(systemName: "minus.circle") }
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
             }
             HStack(spacing: 8) {
                 Picker("Type", selection: $field.kind) {
@@ -581,7 +581,7 @@ private struct FieldLabel: View {
         Text(text)
             .font(Theme.F.mono(10, .semibold))
             .tracking(1.4)
-            .foregroundStyle(Theme.C.ink35)
+            .foregroundStyle(Theme.C.ink45)
     }
 }
 

--- a/apps/ios/Sources/Flow/DocumentPDF.swift
+++ b/apps/ios/Sources/Flow/DocumentPDF.swift
@@ -84,7 +84,7 @@ private struct PDFPageView: View {
                 Text(footer)
                     .font(Theme.F.mono(7))
                     .tracking(1.6)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.bottom, 8)
             }

--- a/apps/ios/Sources/Flow/LetterheadStudioView.swift
+++ b/apps/ios/Sources/Flow/LetterheadStudioView.swift
@@ -177,7 +177,7 @@ struct LetterheadStudioView: View {
             if let footer = draft.footerText {
                 Text(footer)
                     .font(Theme.F.mono(7)).tracking(1.6)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.top, 12)
             }
@@ -216,7 +216,7 @@ struct LetterheadStudioView: View {
         HStack(spacing: 10) {
             Text(key)
                 .font(Theme.F.mono(8, .semibold)).tracking(1.0)
-                .foregroundStyle(Theme.C.ink35)
+                .foregroundStyle(Theme.C.ink45)
                 .frame(width: 56, alignment: .leading)
             TextField(placeholder, text: text)
                 .font(Theme.F.cond(13, .medium))
@@ -264,7 +264,7 @@ struct LetterheadStudioView: View {
                     if let logo = previewLogo {
                         Image(uiImage: logo).resizable().scaledToFit().padding(6)
                     } else {
-                        Text("NONE").font(Theme.F.mono(8)).foregroundStyle(Theme.C.ink35)
+                        Text("NONE").font(Theme.F.mono(8)).foregroundStyle(Theme.C.ink45)
                     }
                 }
                 .frame(width: 54, height: 54)
@@ -349,7 +349,7 @@ struct LetterheadStudioView: View {
         HStack(spacing: 10) {
             Text(key)
                 .font(Theme.F.mono(8, .semibold)).tracking(1.0)
-                .foregroundStyle(Theme.C.ink35)
+                .foregroundStyle(Theme.C.ink45)
                 .frame(width: 46, alignment: .leading)
             TextField("", text: text)
                 .font(Theme.F.cond(13, .medium))
@@ -369,7 +369,7 @@ struct LetterheadStudioView: View {
             VStack(alignment: .leading, spacing: 5) {
                 Text("TERMS / PAYMENT")
                     .font(Theme.F.mono(7.5, .semibold)).tracking(1.0)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
                 TextField("50% deposit to schedule · balance on completion · quote valid 30 days",
                           text: $draftLayout.termsText, axis: .vertical)
                     .font(Theme.F.cond(13, .medium))

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -297,7 +297,7 @@ struct NotesView: View {
                 Text("MISSING")
                     .font(Theme.F.mono(7, .semibold))
                     .tracking(0.6)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Theme.C.paperDeep)
             }
@@ -450,12 +450,12 @@ struct NotesView: View {
     private var emptyState: some View {
         Text("NOTHING WAS CAPTURED ON THIS WALK")
             .font(Theme.F.mono(9)).tracking(0.6)
-            .foregroundStyle(Theme.C.ink35)
+            .foregroundStyle(Theme.C.ink45)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 22)
             .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                 .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                .foregroundStyle(Theme.C.ink35))
+                .foregroundStyle(Theme.C.ink45))
             .padding(Theme.S.screenPad)
     }
 
@@ -858,7 +858,7 @@ private struct NoteItemEditSheet: View {
         VStack(alignment: .leading, spacing: 5) {
             Text(label)
                 .font(Theme.F.mono(8, .semibold)).tracking(1.4)
-                .foregroundStyle(Theme.C.ink35)
+                .foregroundStyle(Theme.C.ink45)
             TextField(placeholder, text: text)
                 .font(Theme.F.cond(15, .semibold))
                 .autocorrectionDisabled()

--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -66,7 +66,7 @@ struct OnboardingFlow: View {
                     Text("SKIP")
                         .font(Theme.F.mono(9, .semibold))
                         .tracking(1.5)
-                        .foregroundStyle(Theme.C.ink35)
+                        .foregroundStyle(Theme.C.ink45)
                 }
                 .buttonStyle(.plain)
             } else {

--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -114,7 +114,7 @@ struct PaywallView: View {
                 // doesn't match. Say nothing about price rather than invent one.
                 Text("Loading…")
                     .font(Theme.F.mono(11))
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
             }
         }
         .padding(.horizontal, Theme.S.screenPad)
@@ -149,7 +149,7 @@ struct PaywallView: View {
             Text("Payment is charged to your Apple ID at confirmation. It renews monthly unless you cancel at least 24 hours before the period ends. Manage or cancel it any time in your Apple ID settings.")
                 .font(Theme.F.mono(9))
                 .lineSpacing(2)
-                .foregroundStyle(Theme.C.ink35)
+                .foregroundStyle(Theme.C.ink45)
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 14) {
                 Link("TERMS OF USE", destination: Self.termsURL)

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -215,7 +215,7 @@ struct ReviewView: View {
                 Text("NO PHOTOS — USE THE PHOTO BUTTON DURING A WALK, OR ADD HERE")
                     .font(Theme.F.mono(8))
                     .tracking(0.6)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 18)
@@ -223,7 +223,7 @@ struct ReviewView: View {
                     .overlay(
                         RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                             .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                            .foregroundStyle(Theme.C.ink35)
+                            .foregroundStyle(Theme.C.ink45)
                     )
             } else {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 76), spacing: 10)], alignment: .leading, spacing: 10) {

--- a/apps/ios/Sources/Flow/VocabSeedCard.swift
+++ b/apps/ios/Sources/Flow/VocabSeedCard.swift
@@ -140,7 +140,7 @@ private struct WrapChips: View {
                 } label: {
                     Text(term)
                         .font(Theme.F.mono(11, .semibold))
-                        .foregroundStyle(on ? Theme.C.ink : Theme.C.ink35)
+                        .foregroundStyle(on ? Theme.C.ink : Theme.C.ink45)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(on ? Theme.C.orangeTint : Theme.C.paperDeep)

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -101,7 +101,7 @@ struct VocabularyView: View {
                 Text("NO TERMS YET — ADD THE WORDS CREWS ACTUALLY SAY.\n\u{201C}BOXWOOD\u{201D} · \u{201C}GFCI\u{201D} · \u{201C}HOLLIS\u{201D}")
                     .font(Theme.F.mono(8.5))
                     .tracking(0.6)
-                    .foregroundStyle(Theme.C.ink35)
+                    .foregroundStyle(Theme.C.ink45)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
                     .frame(maxWidth: .infinity)
@@ -109,7 +109,7 @@ struct VocabularyView: View {
                     .overlay(
                         RoundedRectangle(cornerRadius: Theme.S.radiusCard)
                             .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                            .foregroundStyle(Theme.C.ink35)
+                            .foregroundStyle(Theme.C.ink45)
                     )
                     .padding(.horizontal, Theme.S.screenPad)
                     .padding(.top, 16)

--- a/apps/ios/Sources/Theme/Theme.swift
+++ b/apps/ios/Sources/Theme/Theme.swift
@@ -24,7 +24,17 @@ enum Theme {
         static let sheet      = Color(hex: 0xFFFFFE)
         static let ink        = Color(hex: 0x141412)
         static let ink60      = Color(hex: 0x5E5C54)
+        /// Decoration ONLY — hairline strokes, dashes, disabled fills.
+        ///
+        /// 2.39:1 on paper, which fails every WCAG threshold. That is fine for a
+        /// rule or a border, and was not fine for the 23 places it was being
+        /// used as TEXT. Disabled-control text is the one exemption (WCAG 1.4.3
+        /// excludes it), which is why `RaisedBlockStyle` still uses it there.
         static let ink35      = Color(hex: 0xA7A49A)
+        /// Quiet TEXT — 5.1:1 on paper, 4.7:1 on paperDeep, so it clears AA on
+        /// both grounds the app actually uses. The level between `ink60` and
+        /// decoration: still visibly secondary, still legible in sun.
+        static let ink45      = Color(hex: 0x6E6B62)
         static let hairline     = Color(hex: 0x141412).opacity(0.16)
         static let hairlineSoft = Color(hex: 0x141412).opacity(0.09)
 

--- a/docs/design/BRIEF.md
+++ b/docs/design/BRIEF.md
@@ -25,12 +25,13 @@ Flighty's core lesson applies directly ([Behind the Design](https://developer.ap
 
 ## Physical constraints (non-negotiable, and where generic AI design always fails)
 
-1. **Sunlight legibility.** Used outdoors at noon. Light/"paper" mode is the default (dark UIs wash out in direct sun). True ink-on-paper contrast (AAA) for body copy; no mid-gray-on-white text.
-   **Known exception, not yet fixed:** deep amber `#9A6A00` on paper is ~4.4:1 —
-   AA for large text, short of the AAA claimed here — so it must not be used
-   below 14pt. `ink35` is weaker still (~2.4:1) and is doing real work in job
-   cards. Either the tokens change or this line does; today the line is
-   aspirational for those two. Dark mode is the secondary theme, not the identity.
+1. **Sunlight legibility.** Used outdoors at noon. Light/"paper" mode is the default (dark UIs wash out in direct sun). True ink-on-paper contrast for body copy; no mid-gray-on-white text. Every
+   token used as TYPE is measured against both grounds the app draws on
+   (`paper` and `paperDeep`): ink is AAA, `amberInk` `#6B4900` is 7.8:1, and
+   quiet text uses `ink45` `#6E6B62` at 5.1:1 / 4.7:1. **`ink35` and
+   `orangeDeep` are deliberately below threshold and are decoration only** —
+   hairlines, dashes, fills, lips — plus disabled-control text, which WCAG
+   1.4.3 exempts and where being faint is the point. Dark mode is the secondary theme, not the identity.
 2. **Gloves and one hand.** Primary actions ≥ 56pt, bottom-anchored in the thumb zone. The mic control is the biggest thing on the screen.
 3. **Glanceable at arm's length.** User is walking with phone at hip. Recording state must be unmistakable from 3 feet: full-screen state change, not a small red dot. One line per captured item — airport-board density discipline.
 4. **Interruptible.** Client walks up mid-recording → pause is instant and obvious; state never ambiguous; nothing lost.


### PR DESCRIPTION
The last measured-and-unfixed item from the design review, and the worst of them.

## The number

`ink35` `#A7A49A` on paper `#FAFAF7` is **2.39:1**. That fails every WCAG threshold — AA normal (4.5), AA large (3.0), all of it. Worse than the amber I fixed in #295, and it was being used as **text** in 26 places.

I recorded it in the brief as a known exception at the time rather than rush it, because it spans text, borders, glyphs and disabled states and each needed a judgement about whether it's type at all. This is that pass.

## Split by role, not by darkening one token

Darkening `ink35` itself would have dragged every hairline and dashed border with it. So:

- **`ink35` keeps its value and becomes decoration only** — strokes, dashes, disabled fills, the bullet squares. 2.39:1 is perfectly fine for a rule.
- **New `ink45` `#6E6B62` carries quiet text** — **5.09:1 on paper, 4.67:1 on paperDeep.**

Both grounds were checked, which mattered: the obvious candidate (`#757268`, 4.6:1 on paper) drops to **4.22:1 on paperDeep** and would have failed on the ground the new job cards actually sit on. The app uses two backgrounds, so a token has to clear both.

26 sites moved. Three needed individual judgement:

- **The new-job placeholder.** Placeholders are conventionally faint, but WCAG applies to them, and this one carries the example that teaches the field (`14 Oakfield — back beds`). Moved — visible in the screenshot as the clearest difference.
- **Inactive tab labels** (LOOK / STRUCTURE / WORDS, and the seed card's). An inactive tab is *not* a disabled control — it is readable, tappable text. Moved.
- **Disabled button text stayed on `ink35`.** WCAG 1.4.3 explicitly exempts disabled controls, and after #293 "flat and faint means off" is doing real semantic work — making disabled text darker would blunt the one signal that distinguishes off from secondary.

## Verification

Contrast computed rather than eyeballed, for every candidate against both grounds. 86 tests pass; the new-job sheet rendered on-sim.

The brief's "true ink-on-paper contrast (AAA)" line now has no outstanding exceptions in text — body copy is ink, quiet text is `ink45`, amber type is `amberInk` at 7.79:1, and the only sub-threshold uses left are decoration and disabled states.

## Queue after this

Deleting the drifting `Sources/Screens/*` duplicates, then the two P2 items — the chrome layer and unlocking dark mode.
