### PR TITLE
fix(ios): the board survives accessibility text sizes

### DIFF
--- a/apps/ios/Sources/Components/Rows.swift
+++ b/apps/ios/Sources/Components/Rows.swift
@@ -27,6 +27,9 @@ struct JobRow: View {
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.vertical, 13)
         .opacity(job.done ? 0.45 : 1)
+        // A label and a count on one line — capped for the same reason
+        // MetaStrip is (design review P0 #2).
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
         .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
     }
 }

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -71,8 +71,12 @@ struct BoardView: View {
                     Button { showCustomize = true } label: {
                         Text("My business")
                             .font(Theme.F.ui(13, .semibold))
+                            .lineLimit(1)
                     }
                     .buttonStyle(.secondaryChip)
+                    // A header chip cannot grow without truncating its own
+                    // label; capped so the words survive at accessibility sizes.
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
                 }
                 if let profile = model.profile {
                     // Operator mode: the board carries THEIR business. Trade
@@ -449,6 +453,8 @@ extension BoardView {
             .padding(.trailing, Theme.S.screenPad - 8)
             .padding(.top, 10)
             .padding(.bottom, 4)
+            // JOBS · N OPEN · Add job share one line.
+            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             .overlay(alignment: .bottom) {
                 Theme.C.ink.frame(height: 1.5)
             }
@@ -892,10 +898,20 @@ private struct WalkLogRow<Trailing: View>: View {
         // lines; the small stuff moves to a quiet metadata line beneath it.
         Button(action: onOpen) {
             HStack(alignment: .top, spacing: 12) {
+                // Capped, and sized to content rather than a fixed 46pt.
+                //
+                // #294 adopted Dynamic Type in the font helpers but did not
+                // audit the layouts for it, so at accessibility sizes this
+                // column wrapped mid-timestamp — "9:" over "41". A stamped scan
+                // column has to stay on one line; the review names this exact
+                // pattern as the place to cap growth.
                 Text(walk.time)
                     .font(Theme.F.mono(11, .medium))
                     .foregroundStyle(Theme.C.ink)
-                    .frame(width: 46, alignment: .leading)
+                    .lineLimit(1)
+                    .fixedSize()
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                    .frame(minWidth: 46, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 4) {
                     // Two lines, and the full remaining width. A walk summary


### PR DESCRIPTION
Found while checking whether build 93 is safe to promote to external beta. It was not.

## The break

#294 adopted Dynamic Type in the four `Theme.F` helpers — correctly — and **did not audit the layouts for it.** At `accessibility-large`:

- **The time column wrapped mid-timestamp** — `9:` on one line, `41` on the next; `16` / `:2` / `0` on another row. `.frame(width: 46)` cannot grow with the type.
- **The My business chip truncated its own label** to `My busin...`
- **The JOBS row** lost its count to truncation.

This matters more than an average layout bug: the design review's whole argument for the rescale is that **one in five construction workers is 55 or older** and the median trade supervisor is 46. Those are precisely the people who have already turned their system text size up — so the feature meant to serve them was breaking for them specifically.

## The fix

Caps growth at `accessibility1` on the strips that must stay on one line, which is the pattern the review names for exactly this case, and sizes the time column to its content (`minWidth: 46`) instead of pinning it.

Applied to: the walk row's time column, the My business chip, the JOBS header row, and `SectionHead` (a label and a count sharing one line, same as `MetaStrip` already did).

## Correcting myself: #296's verification claim was false

I wrote that #296 was *"rendered on the narrower iPhone 17 with `simctl ui content-size large`."*

**`content-size` is not a valid subcommand** — it's `content_size`, with an underscore. I ran it with `2>/dev/null`, so the usage error was swallowed and the command silently did nothing. Those screenshots were at the **default** text size, and I reported them as large.

That's the second time this pattern has bitten: suppressing stderr on a command whose success I then relied on. The actual verification here used `content_size accessibility-large` and I confirmed the value read back before trusting it.

## Verification

86 tests pass. Rendered at `accessibility-large` on iPhone 17 — before and after — and the readback confirmed the setting applied this time.

Remaining at that size, and deliberately not "fixed": walk titles and subtitles truncate more, and the last job card is clipped at the scroll boundary above START WALK. Both are correct behaviour — the text has an honest ellipsis and the card scrolls into view — rather than the broken wrapping this PR removes.
