### PR TITLE
test(ios): fuzz firstSentence, and clamp the trap it found

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1365,11 +1365,16 @@ final class AppModel {
         guard !text.isEmpty else { return "" }
 
         let sentence = Self.withoutLeadIn(Self.upToFirstTerminator(text))
-        guard sentence.count > limit else { return sentence }
+        // Clamped: `prefix(_:)` traps on a negative length, so a caller passing
+        // a bad limit would take the app down rather than render something ugly.
+        // Found by fuzzing after a field crash report on build 93 — not the
+        // cause of that one, but the same class of trap.
+        let cap = max(0, limit)
+        guard sentence.count > cap else { return sentence }
 
         // Still too long for one line: cut on a word boundary rather than
         // mid-word, so the ellipsis reads as "there's more" and not as damage.
-        let head = sentence.prefix(limit)
+        let head = sentence.prefix(cap)
         guard let lastSpace = head.lastIndex(of: " ") else {
             return String(head) + "…"
         }

--- a/apps/ios/Tests/FirstSentenceTests.swift
+++ b/apps/ios/Tests/FirstSentenceTests.swift
@@ -14,6 +14,11 @@ import XCTest
 /// sentence end. `3 yd. of mulch` and `Alder Ct. beds` are both real things an
 /// operator says, and truncating either to three words would be worse than the
 /// verbosity. Most of these pin the cases where it must NOT split.
+private extension String {
+    /// Small helper so the fuzz corpus can build a long run cheaply.
+    func repeatedString(_ n: Int) -> String { String(repeating: self, count: n) }
+}
+
 final class FirstSentenceTests: XCTestCase {
 
     // MARK: The reported case
@@ -135,6 +140,39 @@ final class FirstSentenceTests: XCTestCase {
             AppModel.firstSentence(of: "  Marston HOA — irrigation check  "),
             "Marston HOA — irrigation check"
         )
+    }
+
+    /// Fuzz. `firstSentence` does index arithmetic over model-generated text —
+    /// the newest untrusted-input code on the board path, and a crash was
+    /// reported on build 93. If it can be made to trap, that happens here rather
+    /// than on a job site.
+    func testSurvivesAdversarialInput() {
+        let pieces = [
+            "", " ", ".", "..", "...", "!", "?", ".!?", "  .  ", "\n", ".\n",
+            "a.", "a. ", "a. B", "A.", "Field session ", "Field session at ",
+            "Field session at .", "Field session to A.", "\u{00A0}", "\u{200B}",
+            "e\u{0301}.", "\u{1F600}.", "\u{1F600}\u{1F600}. A", "İ. A",
+            "ß. A", "\u{0041}\u{030A}. B", "— . —", "“mulch.” A", "3 yd. 4 yd.",
+            "Mr. Mrs. Dr. A", "a".repeatedString(200) + ". B",
+        ]
+        // Every single piece, and every ordered pair, at several limits.
+        for a in pieces {
+            for b in pieces {
+                for limit in [1, 2, 3, 8, 16, 56, 500] {
+                    _ = AppModel.firstSentence(of: a + b, limit: limit)
+                    _ = AppModel.firstSentence(of: b + a, limit: limit)
+                }
+            }
+        }
+    }
+
+    /// A limit of zero or below must not trap on `prefix`/index math.
+    func testDegenerateLimits() {
+        for limit in [-5, 0, 1] {
+            _ = AppModel.firstSentence(of: "Front beds need mulch and edging", limit: limit)
+            _ = AppModel.firstSentence(of: "", limit: limit)
+            _ = AppModel.firstSentence(of: "Field session at 1418 Alder Ct.", limit: limit)
+        }
     }
 
     /// The row falls back to a plain label when there is no summary, so this


### PR DESCRIPTION
Written while chasing the field crash on build 93. **This is not the fix for that crash** — see below — but it hardens the newest untrusted-input code on the board path and found one real trap.

## Why this code got fuzzed first

`AppModel.firstSentence` (#297) does index arithmetic over **model-generated text**. It is the newest code on the render path for every board row, and string-index math on arbitrary input is exactly where traps hide. It seemed the most likely candidate.

Corpus: empty and whitespace-only, bare terminators, terminators at the very start and very end, combining marks, emoji, dotted capital I and sharp-s (both change length when lowercased, which matters because the lead-in match compares lowercased strings and then drops from the original), abbreviation runs, curly quotes, em dashes, and a 200-character run — every string alone and every ordered pair, at seven limits.

## What it found

```
Swift/Collection.swift:1329: Fatal error: Can't take a prefix of negative length
```

`prefix(_:)` traps on a negative length, so a caller passing a bad limit took the app down rather than rendering something ugly. Clamped with `max(0, limit)`.

**Honest scope: this is almost certainly NOT the reported crash.** Production only ever calls it with the default 56. I am shipping it because it is a real trap in new code and the fuzz test is worth having permanently, not because I think it closes the report.

## What this rules out for the build-93 crash

The fuzz passes on everything else, so `firstSentence` is very unlikely to be the cause. I also read `startWalk()` and the walk screen's control row line by line and found nothing that traps.

Two corrections on the investigation so far:

- **My build-54 theory was wrong.** Isaac's friend was on 93, not 54, and 93 contains every known crash fix (the whisper Metal background crash was fixed in 57 and 63).
- **Build 94 does not fix it.** 94 contains only Dynamic Type layout caps — no crash fixes. Saying otherwise would have been false hope.

Reproducing locally is currently blocked: my checkout's `ffiFFI.xcframework` predates the jobs FFI and the pump pause/resume, so a real-core build fails on missing checksum symbols until `./build-ffi.sh` is re-run. That is local staleness, not a shipping problem.

**The next step is the crash log, not more guessing.** It is now reproducible on demand, so the log is the cheapest possible answer.

88 tests pass.