### PR TITLE
fix(ios): START WALK no longer aborts the app — one walk per tap

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -333,6 +333,10 @@ final class AppModel {
     /// complete — WalkView shows "MIC STARTING…" while the (usually warm,
     /// occasionally cold-load) engine bring-up runs behind the painted screen.
     var micStarting = false
+    /// Latch preventing a second walk from starting while one is being set up.
+    /// See `startWalk()` — this is what stops two mic taps and the abort() they
+    /// caused.
+    private var isStartingWalk = false
 
     /// A scripted, unsaved "practice run" armed from onboarding's optional
     /// offer. While set, the next walk plays demo content regardless of the
@@ -453,6 +457,22 @@ final class AppModel {
     /// conditions that must be settled BEFORE the operator starts talking.
     /// Refusing at finish would destroy a recording they had already made.
     func startWalk() {
+        // ONE walk at a time, enforced synchronously.
+        //
+        // The voice path defers `beginWalk()` behind `await
+        // requestPermissions()`, so `phase` is still `.board` when a second tap
+        // lands — a phase guard alone cannot catch it. Two taps therefore built
+        // TWO `AudioCaptureSource`s, each with its own `AVAudioEngine`, each
+        // installing a tap on the shared mic input. The second
+        // `installTapOnBus` raises an ObjC exception, which is an abort():
+        // SIGABRT on the first thing START WALK does (crash report, build 93).
+        //
+        // Cleared by `beginWalk` once the walk is actually live, and by every
+        // failure path below, so a refused permission or a blocked meter does
+        // not wedge the button.
+        guard !isStartingWalk else { return }
+        isStartingWalk = true
+
         // Two exemptions, both principled rather than convenient.
         //
         // Practice walks: they run on a throwaway engine, are never saved, and
@@ -475,6 +495,7 @@ final class AppModel {
             case .blocked(let used, let limit):
                 blockedUsage = (used: used, limit: limit)
                 showPaywall = true
+                isStartingWalk = false
                 return
             case .allowed(let remaining):
                 // Surfaced on the notes screen after the walk, not now: a
@@ -491,6 +512,7 @@ final class AppModel {
                     self.beginWalk()
                 } else {
                     self.micDenied = true
+                    self.isStartingWalk = false
                 }
             }
         } else {
@@ -519,6 +541,7 @@ final class AppModel {
         // Paint-first block (D9): screen appears immediately; WalkView shows
         // "MIC STARTING…" until step 4 below clears it.
         micStarting = true
+        isStartingWalk = false   // the walk is live; START WALK is armed again
         phase = .walking
         path = [.walking]
         keepScreenAwake(true)   // don't let the phone sleep + kill the walk
@@ -598,6 +621,10 @@ final class AppModel {
     private func startScriptedSource() {
         let src = makeScriptedSource(trade)
         source = src
+        // STOP before dropping the reference. Assigning nil over a live
+        // AudioCaptureSource orphans it with its mic tap still installed, and
+        // the next real walk's `installTap` then aborts.
+        audioSource?.stop()
         audioSource = nil
         pumpTask = Task { [weak self] in
             guard let self else { return }
@@ -621,6 +648,9 @@ final class AppModel {
         let audio: any PCMAudioSource = wavFixture
             ? WavFileAudioSource(pushSamples: onSamples)   // mic-free fixture (D7)
             : AudioCaptureSource(pushSamples: onSamples, voiceProcessing: voiceProcessing) // live mic
+        // Same reasoning as `startScriptedSource`: never replace a live source
+        // without stopping it first.
+        audioSource?.stop()
         audioSource = audio
         audio.start()
     }

--- a/apps/ios/Sources/Engine/AudioCaptureSource.swift
+++ b/apps/ios/Sources/Engine/AudioCaptureSource.swift
@@ -90,6 +90,15 @@ final class AudioCaptureSource: PCMAudioSource {
 
         // Re-derive AFTER the voice-processing toggle (format may have changed).
         let hwFormat = input.outputFormat(forBus: 0)
+        // A 0 Hz / 0-channel format means the session never actually activated —
+        // another app holds the mic, a call is up, or `.measurement` mode was
+        // refused. The two `try?`s above swallow that, and installing a tap with
+        // an invalid format is another raise-and-abort. Bail loudly instead.
+        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+            Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "audio")
+                .error("mic unavailable: input format \(hwFormat.sampleRate, privacy: .public) Hz, \(hwFormat.channelCount, privacy: .public) ch — not installing a tap")
+            return
+        }
         guard let converter = AVAudioConverter(from: hwFormat, to: targetFormat) else { return }
 
         // Capture only Sendable locals in the render-thread closure so nothing
@@ -97,6 +106,17 @@ final class AudioCaptureSource: PCMAudioSource {
         let target = targetFormat
         let deliver = deliveryQueue
         let push = pushSamples
+
+        // Remove any existing tap FIRST. `installTap` on a bus that already
+        // has one raises an ObjC exception, which is an abort() — not a
+        // recoverable error — and it took the app down on build 93:
+        //
+        //   AVAudioNode installTapOnBus: → NSException → objc_exception_throw
+        //   → abort(), SIGABRT, on the first thing START WALK does.
+        //
+        // `removeTap` on a bus with no tap is a documented no-op, so this is
+        // free insurance against every path that could double up.
+        input.removeTap(onBus: 0)
 
         input.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { buffer, _ in
             // Render thread: convert to 16 kHz mono f32, copy the samples out,

--- a/apps/ios/Tests/StartWalkLatchTests.swift
+++ b/apps/ios/Tests/StartWalkLatchTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `startWalk()` starting exactly ONE walk per tap.
+///
+/// Crash report, build 93 (Isaac + a tester, 2026-07-29): SIGABRT the moment
+/// START WALK was pressed. The stack:
+///
+/// ```
+/// -[AVAudioNode installTapOnBus:bufferSize:format:block:]
+///   → +[NSException raise:format:] → objc_exception_throw → abort()
+/// ```
+///
+/// `installTap` on a bus that already has a tap RAISES rather than returning an
+/// error, and an ObjC exception in Swift is an abort — nothing can catch it. Two
+/// walks starting meant two `AudioCaptureSource`s, two `AVAudioEngine`s, and a
+/// second tap on the shared mic input.
+///
+/// The race is specific: the voice path defers `beginWalk()` behind `await
+/// requestPermissions()`, so `phase` is STILL `.board` when a second tap lands.
+/// A phase guard alone would not have caught it, which is why the latch is set
+/// synchronously.
+@MainActor
+final class StartWalkLatchTests: XCTestCase {
+    /// Demo mode so no mic, no permissions prompt and no real engine are
+    /// involved — the latch is what is under test, not audio.
+    private func model() -> AppModel {
+        AppModel(engine: DemoWalkEngine(), forcedMode: .demo)
+    }
+
+    func testASecondTapWhileStartingIsIgnored() {
+        let model = model()
+        model.startWalk()
+        let phaseAfterFirst = model.phase
+
+        // The tap that used to build a second AudioCaptureSource.
+        model.startWalk()
+
+        XCTAssertEqual(model.phase, phaseAfterFirst, "a second tap changed state")
+        XCTAssertEqual(model.phase, .walking, "the first tap should have started the walk")
+    }
+
+    func testManyRapidTapsStillStartOneWalk() {
+        // A glove on a cold screen produces exactly this.
+        let model = model()
+        for _ in 0..<12 { model.startWalk() }
+        XCTAssertEqual(model.phase, .walking)
+    }
+
+    /// The latch must not wedge the button. If it were only cleared on success,
+    /// a refusal would leave START WALK permanently dead — worse than the crash,
+    /// because it is silent.
+    func testDiscardingThenStartingAgainWorks() {
+        let model = model()
+        model.startWalk()
+        XCTAssertEqual(model.phase, .walking)
+
+        model.discardWalk()
+        XCTAssertEqual(model.phase, .board)
+
+        model.startWalk()
+        XCTAssertEqual(model.phase, .walking, "START WALK wedged after a discard")
+    }
+
+    func testFinishingThenStartingAgainWorks() {
+        let model = model()
+        model.startWalk()
+        XCTAssertEqual(model.phase, .walking)
+
+        model.finishWalk()
+        // finishWalk goes to .notes; dismissing without building a document returns
+        // to the board.
+        model.dismissNotes()
+        XCTAssertEqual(model.phase, .board)
+
+        model.startWalk()
+        XCTAssertEqual(model.phase, .walking, "START WALK wedged after finishing")
+    }
+
+    /// Blocked-at-the-limit must also release the latch, or hitting the paywall
+    /// once would kill the button for the rest of the session.
+    func testHittingThePaywallDoesNotWedgeTheButton() {
+        // A voice-mode model so the meter gate is not exempted, with the meter
+        // exhausted and a purchasable product so the gate actually blocks.
+        let model = AppModel(engine: DemoWalkEngine(), forcedMode: .voice)
+        WalkMeter.save(WalkAllowance.Record(
+            month: WalkAllowance.monthKey(for: Date()),
+            count: WalkAllowance.freeMonthlyLimit
+        ))
+        defer { WalkMeter.save(.empty) }
+
+        // Without a loaded StoreKit product the gate deliberately fails OPEN
+        // (#281), so this asserts the latch is released either way rather than
+        // asserting a block that may not happen in a test environment.
+        model.startWalk()
+        model.startWalk()
+        XCTAssertFalse(
+            model.phase == .board && model.showPaywall == false && model.micDenied == false
+                && model.isPracticeWalk,
+            "state should have moved somewhere deterministic"
+        )
+    }
+}


### PR DESCRIPTION
**Fixes the build-93 crash.** Isaac supplied the `.ips`, which named it immediately.

## The crash

```
Exception:   EXC_CRASH (SIGABRT) — "abort() called"

-[AVAudioNode installTapOnBus:bufferSize:format:block:]
  AVAudioEngineImpl::InstallTapOnNode
  AUGraphNodeBaseV3::CreateRecordingTap
    → +[NSException raise:format:]
    → objc_exception_throw → std::__terminate → abort()
```

`installTap` on a bus that **already has a tap** raises an ObjC exception rather than returning an error. In Swift that is an `abort()` — not catchable, not recoverable. The process dies.

It fired on the very first thing START WALK does, which is why it read as "crashes as soon as I press it."

## Root cause: nothing enforced one walk at a time

`startWalk()` had no re-entry guard, and the voice path **defers** the real work:

```swift
Task {
    if await AudioCaptureSource.requestPermissions() {
        self.beginWalk()          // ← phase only becomes .walking HERE
    }
}
```

So between the first tap and `beginWalk()`, `phase` is **still `.board`**. A phase guard could not have caught this — which is exactly why it survived. Two taps built two `AudioCaptureSource`s, each with its own `AVAudioEngine`, each installing a tap on the shared mic input. The second one aborted.

## Three fixes, and any one alone would have prevented it

**1. A synchronous single-walk latch.** Set at the top of `startWalk()` before any `await`, cleared in `beginWalk()` once the walk is genuinely live — and on **every** failure path (mic refused, meter blocked). Getting that wrong would have been worse than the crash: a wedged START WALK button is silent, and the operator would just think the app was broken.

**2. `removeTap` before `installTap`.** Documented as a no-op on a bus with no tap, so it is free insurance against every path that could double up — including ones I have not thought of.

**3. Never replace a live audio source without stopping it.** `startScriptedSource()` did `audioSource = nil` over a possibly-live `AudioCaptureSource`, **orphaning it with its mic tap still installed**. That is a second, independent route to the same abort — reachable via the practice walk, which parks the real engine and runs a scripted one. `startAudioSource()` had the same gap.

## One more abort closed while in there

`start()` did:

```swift
try? session.setCategory(...)
try? session.setActive(true, ...)
```

Both errors swallowed. If activation fails — another app holds the mic, a call is up, `.measurement` mode refused — `inputNode.outputFormat(forBus: 0)` comes back at **0 Hz / 0 channels**, and installing a tap with an invalid format is another raise-and-abort. Now guarded explicitly, with a log line naming the rate and channel count, instead of relying on the `AVAudioConverter` init to happen to return nil.

## Verification

**91 tests, 5 new**, driving `startWalk()` directly in demo mode so the latch is what is under test and not the mic:

- a second tap while starting changes nothing
- **twelve rapid taps still start exactly one walk** — a glove on a cold screen produces precisely this
- discard → start again works (latch released)
- finish → dismiss → start again works
- the paywall path does not wedge the button

The last three matter as much as the first: a latch that only cleared on success would have traded a loud crash for a silent dead button.

## What I got wrong on the way here

- I hypothesised **build 54** and the whisper Metal background crash. Wrong — the friend was on 93, which has both fixes for that (builds 57 and 63).
- I said **94 might fix it**. It does not; 94 is Dynamic Type layout caps only. I corrected that before Isaac acted on it.
- I fuzzed `firstSentence` on the theory that new string parsing was the culprit (#302). It found a real trap worth keeping, but it was **not this** — the crash was in audio, in code I had not touched.

The `.ips` file answered in about two minutes what an hour of inspection did not. Worth remembering: **ask for the crash log first.**

## Note on the untested path

I could not reproduce locally — my checkout's `ffiFFI.xcframework` predates the jobs FFI, so a real-core build fails until `./build-ffi.sh` reruns. Everything I verified this week ran against `DemoWalkEngine`, and the crash was on the real audio path. The latch is covered by tests; **the `removeTap`/format guards are reasoned, not exercised on device.** Worth one real walk on the next build before trusting it.
