### PR TITLE
fix(ios): activate the audio session before tapping the mic — the real crash

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -333,6 +333,10 @@ final class AppModel {
     /// complete — WalkView shows "MIC STARTING…" while the (usually warm,
     /// occasionally cold-load) engine bring-up runs behind the painted screen.
     var micStarting = false
+    /// The mic could not be opened — the session would not activate, or the
+    /// input reported an invalid format. Surfaced on the walk screen; the walk
+    /// is live but deaf, and the operator has to know that immediately.
+    var micUnavailable = false
     /// Latch preventing a second walk from starting while one is being set up.
     /// See `startWalk()` — this is what stops two mic taps and the abort() they
     /// caused.
@@ -541,6 +545,7 @@ final class AppModel {
         // Paint-first block (D9): screen appears immediately; WalkView shows
         // "MIC STARTING…" until step 4 below clears it.
         micStarting = true
+        micUnavailable = false
         isStartingWalk = false   // the walk is live; START WALK is armed again
         phase = .walking
         path = [.walking]
@@ -645,9 +650,23 @@ final class AppModel {
         let onSamples: @Sendable ([Float]) -> Void = { [weak self] samples in
             Task { @MainActor in self?.engine.pushAudio(samples) }
         }
-        let audio: any PCMAudioSource = wavFixture
-            ? WavFileAudioSource(pushSamples: onSamples)   // mic-free fixture (D7)
-            : AudioCaptureSource(pushSamples: onSamples, voiceProcessing: voiceProcessing) // live mic
+        let audio: any PCMAudioSource
+        if wavFixture {
+            audio = WavFileAudioSource(pushSamples: onSamples)   // mic-free fixture (D7)
+        } else {
+            let mic = AudioCaptureSource(pushSamples: onSamples, voiceProcessing: voiceProcessing)
+            // A walk whose mic never opened must SAY so. Sitting on a live
+            // RECORDING screen capturing silence is worse than the crash it
+            // replaced: the operator talks through a whole site and gets
+            // nothing, with no clue why.
+            mic.onUnavailable = { [weak self] in
+                Task { @MainActor in
+                    self?.micUnavailable = true
+                    self?.micStarting = false
+                }
+            }
+            audio = mic
+        }
         // Same reasoning as `startScriptedSource`: never replace a live source
         // without stopping it first.
         audioSource?.stop()

--- a/apps/ios/Sources/Engine/AudioCaptureSource.swift
+++ b/apps/ios/Sources/Engine/AudioCaptureSource.swift
@@ -44,6 +44,14 @@ final class AudioCaptureSource: PCMAudioSource {
     /// `AVAudioEngine.inputNode.setVoiceProcessingEnabled`, which is what this
     /// knob toggles.
     private let voiceProcessing: Bool
+    private let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "audio"
+    )
+    /// Called when the mic could not be opened at all. Without this the walk
+    /// would sit on a live-looking RECORDING screen capturing silence, which is
+    /// worse than saying so — the operator would talk through a whole site and
+    /// get nothing.
+    var onUnavailable: (@Sendable () -> Void)?
     private let audioEngine = AVAudioEngine()
     /// 16 kHz mono f32 — whisper's expected input (SttConfig.sample_rate).
     private let targetFormat = AVAudioFormat(
@@ -67,9 +75,53 @@ final class AudioCaptureSource: PCMAudioSource {
     }
 
     func start() {
+        // Configure and ACTIVATE the session, surfacing failure instead of
+        // swallowing it.
+        //
+        // The two `try?`s this replaces hid the cause of a launch-race abort
+        // (crash report, build 93, 0.87s after process start): START WALK
+        // pressed within a second of opening the app runs this before the
+        // session can activate, `inputNode.outputFormat` then reports 0 Hz /
+        // 0 channels, and `installTap` raises on the invalid format — which is
+        // an abort(), not a catchable error.
+        //
+        // `.duckOthers` is also not a documented option for `.record`, so the
+        // ideal configuration is tried first and a plain `.record` is the
+        // fallback rather than leaving the session in whatever state a rejected
+        // setCategory left behind.
         let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.record, mode: .measurement, options: .duckOthers)
-        try? session.setActive(true, options: .notifyOthersOnDeactivation)
+        do {
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        } catch {
+            log.error("setCategory(.record, .measurement, .duckOthers) refused: \(error, privacy: .public) — retrying plain .record")
+            do {
+                try session.setCategory(.record, mode: .measurement)
+            } catch {
+                log.error("setCategory(.record, .measurement) refused too: \(error, privacy: .public)")
+            }
+        }
+
+        // Activation can legitimately fail while the app is still becoming
+        // active, or if another app holds the mic. Retry briefly rather than
+        // proceeding into an abort — a walk is worth a few milliseconds.
+        var activated = false
+        for attempt in 0..<3 {
+            do {
+                try session.setActive(true, options: .notifyOthersOnDeactivation)
+                activated = true
+                break
+            } catch {
+                log.error("setActive attempt \(attempt + 1, privacy: .public) failed: \(error, privacy: .public)")
+                // 40ms, twice — enough to clear a foreground transition without
+                // making START WALK feel unresponsive.
+                Thread.sleep(forTimeInterval: 0.04)
+            }
+        }
+        guard activated else {
+            log.error("audio session would not activate — no tap installed, walk will capture nothing")
+            onUnavailable?()
+            return
+        }
 
         let input = audioEngine.inputNode
 
@@ -95,8 +147,11 @@ final class AudioCaptureSource: PCMAudioSource {
         // refused. The two `try?`s above swallow that, and installing a tap with
         // an invalid format is another raise-and-abort. Bail loudly instead.
         guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
-            Logger(subsystem: Bundle.main.bundleIdentifier ?? "sitewalk", category: "audio")
-                .error("mic unavailable: input format \(hwFormat.sampleRate, privacy: .public) Hz, \(hwFormat.channelCount, privacy: .public) ch — not installing a tap")
+            // THE abort from the build-93 crash report. installTap raises on an
+            // invalid format, and a raise is an abort — so this guard is the
+            // difference between a dead mic and a dead app.
+            log.error("mic unavailable: input format \(hwFormat.sampleRate, privacy: .public) Hz, \(hwFormat.channelCount, privacy: .public) ch — not installing a tap")
+            onUnavailable?()
             return
         }
         guard let converter = AVAudioConverter(from: hwFormat, to: targetFormat) else { return }

--- a/apps/ios/Sources/Flow/WalkView.swift
+++ b/apps/ios/Sources/Flow/WalkView.swift
@@ -137,6 +137,25 @@ struct WalkView: View {
             .padding(.bottom, 10)
             .overlay(alignment: .top) { Theme.C.hairline.frame(height: 1) }
         }
+        // A deaf walk has to announce itself. Same red-note grammar as the
+        // mic-denied bar on the board.
+        .overlay(alignment: .top) {
+            if model.micUnavailable {
+                HStack(spacing: 0) {
+                    Theme.C.redTag.frame(width: 3)
+                    Text("Jefe can't hear the mic — another app may be using it. Tap DONE and start again.")
+                        .font(Theme.F.ui(13, .medium))
+                        .foregroundStyle(Theme.C.redTag)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(Theme.C.redTint)
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.top, 8)
+            }
+        }
         .animation(.easeOut(duration: 0.25), value: coachDoneShown)
         .background(Theme.C.paper.ignoresSafeArea())
         .toolbar(.hidden, for: .navigationBar)


### PR DESCRIPTION
**Corrects my diagnosis in #303.** The latch there was not the fix, and I said so with more confidence than the evidence supported.

## The number that broke my theory

The crash report's process lifetime:

```
procStartAbsTime → procExitAbsTime  =  0.87 seconds
```

**START WALK was pressed within a second of launch.** No human double-taps in 870ms, and `startAudioSource()` has exactly one call site — so two taps were never required.

## What actually happens

```swift
try? session.setCategory(.record, mode: .measurement, options: .duckOthers)
try? session.setActive(true, options: .notifyOthersOnDeactivation)
```

Tapping START WALK while the app is still becoming active means `setActive` fails. Both `try?`s swallow it. `inputNode.outputFormat(forBus: 0)` then reports **0 Hz / 0 channels**, and `installTap` **raises** on an invalid format — which in Swift is an `abort()`, not a catchable error.

Reliable, single-tap, and it explains why two different people hit it on the same press: both were tapping quickly to test. On iOS 26.5.2, iPhone 17.

`.duckOthers` is also **not a documented option for `.record`**, so that `setCategory` may have been failing all along, leaving the session in whatever state a rejected call left behind.

## The fix

- **Retry activation** three times over ~80ms. A foreground transition clears in far less than that, and a walk is worth 80ms.
- **Fall back to plain `.record`** if `.duckOthers` is refused, rather than proceeding on a rejected configuration.
- **Stop swallowing both errors** — every failure is logged with its reason.
- The invalid-format guard from #303 stays as the last line of defence.

## And if the mic genuinely cannot open, say so

This is the part I would not ship without. Previously the guard just `return`ed, which meant the operator sat on a live-looking **RECORDING** screen capturing silence — talk through an entire site, get nothing, no explanation. That is *worse* than the crash, because a crash at least tells you something went wrong.

`onUnavailable` now surfaces a red note on the walk screen: *"Jefe can't hear the mic — another app may be using it. Tap DONE and start again."*

## What I got wrong, plainly

I diagnosed #303 as a double-tap race and shipped a latch as the headline fix. The latch is still correct — two walks at once is a real bug, and 12 rapid taps now start one walk — but **it is not what was crashing.** I had the crash log in hand and did not check the process lifetime, which is the field that decides between "user pressed twice" and "pressed too early."

The format guard in #303 would have stopped the abort by accident. This PR fixes the cause.

## Verification

93 tests pass. **Not reproducible locally** — the launch race needs a device, and my checkout cannot build real-core (stale `ffiFFI.xcframework`). The reasoning is anchored to the crash log's own numbers rather than a repro, and that is worth knowing when reading it.

**Immediate workaround for anyone on 94:** wait a second after opening the app before pressing START WALK.
