### PR TITLE
feat(core): a blank trade means UNIVERSAL — custom doc types work everywhere

### DIFF
--- a/apps/ios/Sources/Engine/DocumentSchemaModel.swift
+++ b/apps/ios/Sources/Engine/DocumentSchemaModel.swift
@@ -93,14 +93,10 @@ struct DocumentSchemaModel: Identifiable, Hashable {
     var numberPrefix: String
     /// Which trade this belongs to.
     ///
-    /// **`nil` does NOT mean "works for every trade."** It means "resolves only
-    /// for a session with no template" — core's `resolve_active_schema` matches
-    /// `trade_key = ?template OR (trade_key IS NULL AND ?template IS NULL)`.
-    /// The listing query is looser and *does* return nil-trade rows for any
-    /// trade, which is what made the shipped universal `report` schema appear
-    /// in a landscape operator's picker and then fail to build (Isaac,
-    /// TestFlight 2026-07-28). Filter with `buildable(from:tradeKey:)` before
-    /// offering anything.
+    /// **`nil` means UNIVERSAL — available on every trade.** Core's
+    /// `resolve_active_schema` matches `trade_key = ?template OR trade_key IS
+    /// NULL`, preferring a trade-specific row when one exists. Filter with
+    /// `buildable(from:tradeKey:)`, which mirrors that ordering.
     var tradeKey: String?
     var totalKind: String
     var totalLabelKey: String
@@ -123,13 +119,12 @@ struct DocumentSchemaModel: Identifiable, Hashable {
     ///
     /// Two rules, both copied from the resolver rather than invented here:
     ///
-    /// 1. **Trade must match exactly**, including nil-to-nil. `listDocumentSchemas`
-    ///    is deliberately looser — it returns nil-trade rows for every trade —
-    ///    so the shipped universal `report` schema showed up in a landscape
-    ///    operator's picker and then failed with *"'report' is not a legal
-    ///    document kind for template Some(\"landscape\")"*. Duplicating Report in
-    ///    the Document Builder stamps it with the operator's trade, which is how
-    ///    a landscaper gets a working Report.
+    /// 1. **Trade matches, or the schema is UNIVERSAL.** A nil `tradeKey` means
+    ///    "any trade" — Isaac's call, 2026-07-30: *"They should come in
+    ///    regardless of trade!"* A type the operator authored belongs to them,
+    ///    not to whichever trade they were in when they made it. Core's
+    ///    resolver was changed to match, so a universal schema is now genuinely
+    ///    buildable rather than merely listable.
     /// 2. **One winner per kind**, the newest. Core resolves with
     ///    `ORDER BY updated_at DESC LIMIT 1`, so when two schemas share a kind
     ///    exactly one is ever built; showing both would put a dead button on
@@ -140,9 +135,24 @@ struct DocumentSchemaModel: Identifiable, Hashable {
     static func buildable(
         from schemas: [DocumentSchemaModel], tradeKey: String?
     ) -> [DocumentSchemaModel] {
-        let matching = schemas.filter { $0.tradeKey == tradeKey }
+        let matching = schemas.filter { $0.tradeKey == tradeKey || $0.tradeKey == nil }
         return Dictionary(grouping: matching, by: \.kind)
-            .compactMap { _, group in group.max(by: { $0.updatedAt < $1.updatedAt }) }
+            .compactMap { _, group in
+                // Mirrors the resolver's ORDER BY exactly: a trade-specific
+                // schema beats a universal one for the same kind whatever the
+                // timestamps say, so an operator's own version is never
+                // shadowed by a shared default. Newest breaks the remaining tie.
+                // Trade-specific ranks 1, universal ranks 0, so `max` picks
+                // the specific one. (Getting this backwards made the shared
+                // default win — caught by
+                // `testATradeSpecificSchemaBeatsAUniversalOneOfTheSameKind`.)
+                // Core expresses the same order as `ORDER BY (trade_key IS
+                // NULL) ASC` with LIMIT 1.
+                group.max {
+                    ($0.tradeKey == nil ? 0 : 1, $0.updatedAt)
+                        < ($1.tradeKey == nil ? 0 : 1, $1.updatedAt)
+                }
+            }
             .sorted { $0.label < $1.label }
     }
 

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -282,18 +282,16 @@ private struct SchemaEditor: View {
         var copy = draft
         copy.id = ""            // create, don't overwrite the shipped default
         copy.isBuiltin = false
-        // Stamp the operator's trade. The shipped `report` built-in carries
-        // `trade_key: nil`, and core only resolves a nil-trade schema for a
-        // nil-template session — so copying the nil through produced a document
-        // type that appeared in every picker and built under none of them
-        // (Isaac, TestFlight 2026-07-28: "'prf' is not a legal document kind
-        // for template Some(\"landscape\")").
+        // INHERIT the source's trade — do not stamp the operator's.
         //
-        // A copy belongs to the operator who made it, so their trade is the
-        // right answer regardless. For an already trade-scoped built-in this is
-        // a no-op; for the universal one it's what makes duplicating Report the
-        // way a landscaper gets a working Report.
-        copy.tradeKey = tradeKey
+        // #283 stamped the current trade here, to work around a nil-trade copy
+        // being unbuildable. Core now treats nil as universal, so the
+        // workaround is not only unnecessary but backwards: stamping would pin
+        // a copy of the universal Report to one trade, and Isaac's call
+        // (2026-07-30) is the opposite — "They should come in regardless of
+        // trade!" A duplicate of Report stays universal; a duplicate of the
+        // landscape Estimate stays landscape. The copy keeps whatever scope the
+        // thing it was copied from had.
         if draft.label != original.label {
             copy.kind = Self.slug(draft.label)
         }

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -596,7 +596,6 @@ struct NotesView: View {
                 HStack(spacing: 8) {
                     ForEach(Array(docChoices.enumerated()), id: \.element.kind) { i, choice in
                         docButton(choice, hero: i == 0)
-                            .frame(minWidth: docChoices.count > 3 ? 104 : nil)
                     }
                 }
             }
@@ -634,14 +633,26 @@ struct NotesView: View {
                         Text(choice.label)
                             .font(Theme.F.ui(12, .bold)).tracking(0.04)
                             .foregroundStyle(hero ? Theme.C.onOrange : Theme.C.ink)
-                            .lineLimit(1).minimumScaleFactor(0.75)
+                            .lineLimit(1)
                         Text(choice.stamp)
                             .font(Theme.F.mono(6.5, .semibold)).tracking(0.6)
                             .foregroundStyle(hero ? Theme.C.onOrange.opacity(0.85) : Theme.C.ink60)
+                            .lineLimit(1)
                     }
+                    // Breathing room INSIDE the border, so the shape grows with
+                    // the label instead of the label escaping the shape.
+                    .padding(.horizontal, 14)
+                    .fixedSize(horizontal: true, vertical: false)
                 }
             }
-            .frame(height: 54).frame(maxWidth: .infinity)
+            // Sized to content, with a floor so a short label still reads as a
+            // button. `maxWidth: .infinity` proposed an unbounded width inside
+            // the horizontal ScrollView, which is how "Invoice" and "Work
+            // Order" ended up printed across their own borders once the type
+            // ramp grew them (Isaac, on device 2026-07-30).
+            .frame(height: 54)
+            .frame(minWidth: 96)
+            .fixedSize(horizontal: true, vertical: false)
         }
         .buttonStyle(.plain)
         .disabled(disabled)

--- a/apps/ios/Tests/DocumentChoiceTests.swift
+++ b/apps/ios/Tests/DocumentChoiceTests.swift
@@ -32,36 +32,52 @@ final class DocumentChoiceTests: XCTestCase {
 
     // MARK: The field bug
 
-    func testUniversalSchemaIsNotOfferedToATradeSession() {
-        // The exact shape of Isaac's report: the shipped `report` built-in
-        // carries trade_key nil and was listed for a landscape walk.
+    func testUniversalSchemaIsOfferedOnEveryTrade() {
+        // Isaac, 2026-07-30: "They should come in regardless of trade!" A
+        // nil-trade schema is UNIVERSAL, and core's resolver now agrees, so the
+        // picker offers it everywhere.
         let all = [
             schema("estimate", trade: "landscape"),
             schema("report", trade: nil)
         ]
-        let kinds = DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").map(\.kind)
-        XCTAssertEqual(kinds, ["estimate"], "a nil-trade schema must not be offered to a trade walk")
+        for trade in ["landscape", "property", "inspection"] {
+            let kinds = Set(DocumentSchemaModel.buildable(from: all, tradeKey: trade).map(\.kind))
+            XCTAssertTrue(kinds.contains("report"), "report missing on \(trade)")
+        }
     }
 
-    func testCustomTypeCopiedFromReportIsNotOfferedUntilItHasATrade() {
-        // The PRF case. Duplicating Report used to carry its nil trade through,
-        // producing a doc type visible everywhere and buildable nowhere.
+    func testACustomTypeWithNoTradeShowsUpEverywhere() {
+        // The RFP case, which is what Isaac actually lost: a custom type
+        // duplicated from Report carries nil and must work on every walk.
         let all = [schema("prf", label: "PRF", trade: nil)]
-        XCTAssertTrue(DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").isEmpty)
-    }
-
-    func testTheSameCustomTypeIsOfferedOnceItCarriesTheTrade() {
-        // And the fix: `saveShape` now stamps the operator's trade, so their
-        // own document type works. This is also how a landscaper gets a
-        // working Report — duplicate it, and the copy is trade-scoped.
-        let all = [schema("prf", label: "PRF", trade: "landscape")]
         XCTAssertEqual(
             DocumentSchemaModel.buildable(from: all, tradeKey: "landscape").map(\.kind), ["prf"]
+        )
+        XCTAssertEqual(
+            DocumentSchemaModel.buildable(from: all, tradeKey: "property").map(\.kind), ["prf"]
+        )
+    }
+
+    func testATradeSpecificSchemaBeatsAUniversalOneOfTheSameKind() {
+        // Mirrors the resolver's ORDER BY: the operator's own version must
+        // never be shadowed by a shared default, even if the default is newer.
+        let all = [
+            schema("report", label: "Shared report", trade: nil, updatedAt: 900, id: "universal"),
+            schema("report", label: "My report", trade: "landscape", updatedAt: 100, id: "mine")
+        ]
+        let winners = DocumentSchemaModel.buildable(from: all, tradeKey: "landscape")
+        XCTAssertEqual(winners.count, 1)
+        XCTAssertEqual(winners.first?.id, "mine", "trade-specific must win over universal")
+        // On a trade with no specific version, the universal one serves.
+        XCTAssertEqual(
+            DocumentSchemaModel.buildable(from: all, tradeKey: "property").first?.id, "universal"
         )
     }
 
     // MARK: Trade matching in general
 
+    /// Universal must not become a back door: a schema naming a DIFFERENT trade
+    /// still must not appear.
     func testAnotherTradesSchemaIsNeverOffered() {
         let all = [
             schema("condition", trade: "property"),
@@ -73,9 +89,8 @@ final class DocumentChoiceTests: XCTestCase {
         )
     }
 
-    func testNilTradeSessionGetsExactlyTheUniversalSchemas() {
-        // The mirror image — nil-to-nil matches, and a trade-scoped schema
-        // must not leak into a session with no template.
+    func testNilTradeSessionGetsOnlyTheUniversalSchemas() {
+        // A walk with no template still must not see a trade-scoped schema.
         let all = [
             schema("report", trade: nil),
             schema("estimate", trade: "landscape")

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -271,12 +271,37 @@ impl Store {
         kind: &str,
         template: Option<&str>,
     ) -> Result<Option<DocumentSchema>, CoreError> {
+        // A NULL `trade_key` means UNIVERSAL — resolvable under ANY template,
+        // not only under a NULL one.
+        //
+        // Isaac's product call, 2026-07-30: "They should come in regardless of
+        // trade!" A document type an operator authored belongs to that
+        // operator, not to whichever trade they happened to be in when they
+        // made it — a landscaper who builds an RFP wants it on every walk.
+        //
+        // This is what #284 asked and what the earlier behaviour got wrong.
+        // `list_document_schemas` has always treated NULL as "matches any
+        // trade"; the resolver disagreeing meant a universal schema could be
+        // LISTED and never BUILT, so a custom type showed up and then failed
+        // with "'prf' is not a legal document kind for template
+        // Some(\"landscape\")". A shape that can be offered and never used is
+        // the one combination that cannot be right.
+        //
+        // Trade-specific still WINS over universal: `trade_key IS NULL` sorts 0
+        // for a trade match and 1 for a universal row, so an operator's
+        // landscape-specific `report` beats the shared one. Newest breaks the
+        // remaining tie, preserving the `updated_at DESC` behaviour the app's
+        // picker mirrors.
+        //
+        // Does NOT widen across trades: a `property` schema still has
+        // `trade_key = 'property'`, which matches neither clause under a
+        // landscape session.
         let mut stmt = self.conn.prepare(&format!(
             "SELECT {SCHEMA_COLS} FROM document_schemas
              WHERE kind = ?1
-               AND (trade_key = ?2 OR (trade_key IS NULL AND ?2 IS NULL))
+               AND (trade_key = ?2 OR trade_key IS NULL)
                AND deleted_at IS NULL
-             ORDER BY updated_at DESC LIMIT 1"
+             ORDER BY (trade_key IS NULL) ASC, updated_at DESC LIMIT 1"
         ))?;
         let mut rows = stmt.query(rusqlite::params![kind, template])?;
         match rows.next()? {
@@ -522,14 +547,53 @@ mod tests {
         assert!(s.has_active_schema("estimate", Some("landscape")).unwrap());
     }
 
-    /// Parity guard: `report` (trade NULL) resolves ONLY for a None-template
-    /// session — it stays illegal on a landscape session, matching today.
+    /// A NULL trade is UNIVERSAL: `report` resolves under any template.
+    ///
+    /// This replaces a parity guard that pinned the opposite ("stays illegal on
+    /// a landscape session, matching today"). That preserved pre-Plan-19
+    /// behaviour, and the behaviour was wrong: Isaac, 2026-07-30, on finding
+    /// his own custom types missing — "They should come in regardless of
+    /// trade!" A type the operator authored belongs to the operator, not to
+    /// whichever trade they were in when they made it.
     #[test]
-    fn resolve_report_only_for_none_template_not_for_landscape() {
+    fn resolve_null_trade_is_universal_across_templates() {
         let s = Store::open_in_memory("device-a").unwrap();
-        let resolved = s.resolve_active_schema("report", None).unwrap().unwrap();
-        assert_eq!(resolved.id, BUILTIN_SCHEMA_ID_REPORT);
-        assert!(s.resolve_active_schema("report", Some("landscape")).unwrap().is_none());
+        for template in [None, Some("landscape"), Some("property"), Some("inspection")] {
+            let resolved = s.resolve_active_schema("report", template).unwrap();
+            assert_eq!(
+                resolved.map(|r| r.id),
+                Some(BUILTIN_SCHEMA_ID_REPORT.to_string()),
+                "report should resolve for template {template:?}"
+            );
+            assert!(s.has_active_schema("report", template).unwrap());
+        }
+    }
+
+    /// Universal must not become a back door across trades: a schema that names
+    /// a DIFFERENT trade still must not resolve.
+    #[test]
+    fn a_named_trade_still_does_not_leak_into_another() {
+        let s = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(|| 1000));
+        s.save_document_schema(&custom_schema("hoa", "hoa_addendum", Some("property"))).unwrap();
+        assert!(s.resolve_active_schema("hoa_addendum", Some("landscape")).unwrap().is_none());
+        assert!(s.resolve_active_schema("hoa_addendum", Some("property")).unwrap().is_some());
+    }
+
+    /// Trade-specific beats universal for the same kind, whatever the clock
+    /// says — otherwise a shared default could shadow the operator's own.
+    #[test]
+    fn a_trade_specific_schema_wins_over_a_universal_one() {
+        let s = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(|| 1000));
+        // Universal, and NEWER than the trade-specific one saved next.
+        s.save_document_schema(&custom_schema("universal-rfp", "rfp", None)).unwrap();
+        let s = s.with_clock(Arc::new(|| 2000));
+        s.save_document_schema(&custom_schema("landscape-rfp", "rfp", Some("landscape"))).unwrap();
+
+        let resolved = s.resolve_active_schema("rfp", Some("landscape")).unwrap().unwrap();
+        assert_eq!(resolved.id, "landscape-rfp", "the trade-specific schema must win");
+        // And on a trade with no specific version, the universal one serves.
+        let elsewhere = s.resolve_active_schema("rfp", Some("property")).unwrap().unwrap();
+        assert_eq!(elsewhere.id, "universal-rfp");
     }
 
     /// The resurrection consequence: a tombstoned built-in does not resolve —


### PR DESCRIPTION
Isaac, on device, on finding his own **Report** and **RFP** missing from the notes screen:

> They should come in regardless of trade!

That is the answer to **#284**, which I deferred to dam precisely because I had no product intent to decide it on. Now I do.

## What I had done wrong

The chain, all mine:

1. The shipped `report` built-in carries `trade_key: nil`, and duplicating it copied that nil through — so Isaac's custom types were nil-trade.
2. Core's `resolve_active_schema` only matched a nil-trade schema against a **nil-template** session, so those types could be **listed and never built** — the `'prf' is not a legal document kind` error he first reported.
3. In #283 I "fixed" that by making the picker stop **offering** what core would refuse.

Step 3 is correct in principle and was wrong for him: his types stopped appearing at all. **Hiding a broken thing is not fixing it**, and he lost work he had done.

## The fix, in core where it belongs

`resolve_active_schema` now matches `trade_key = ?template OR trade_key IS NULL`, ordered so a **trade-specific row still beats a universal one** for the same kind — an operator's own version is never shadowed by a shared default. Newest breaks the remaining tie, preserving the existing `updated_at DESC` behaviour.

This replaces a **named parity test** (`resolve_report_only_for_none_template_not_for_landscape`) that pinned the opposite. I left that test alone last time and said so, because its comment — *"it stays illegal on a landscape session, matching today"* — read as deliberate. It was: it preserved pre-Plan-19 behaviour. That behaviour is what Isaac has now called wrong, so the test is replaced rather than worked around, with the reasoning written into it.

It does **not** widen across trades: a `property` schema still names `property` and stays out of a landscape walk. Covered by its own test.

## Two things this let me delete

**#283's trade stamp on duplicates is gone.** It was a workaround for nil being unbuildable, and it is now backwards — stamping would pin a copy of the universal Report to one trade, the opposite of what was asked. A duplicate now **inherits the source's scope**: copy Report, stay universal; copy the landscape Estimate, stay landscape.

**An "adopt orphaned schemas into the current trade" sweep**, which I had written and built before Isaac's message arrived. It would have worked and it would have been wrong — silently stamping his universal types with one trade.

## Also: the doc-kind buttons

He flagged them looking off, and they were: **"Invoice" and "Work Order" printed across their own borders.** `.frame(maxWidth: .infinity)` inside a horizontal `ScrollView` proposes an unbounded width, which the type ramp then overflowed. Now sized to content with internal padding and a `minWidth` floor, so the shape grows with the label.

## Verification

**241 core tests, 93 app tests**, all green. New coverage: universal resolves on every template; a named trade still does not leak; trade-specific beats universal even when the universal row is newer.

That last one **failed on the first run** — I had the tuple ordering inverted, so the shared default won. Exactly what the test was written to catch.

## Still open, and I need Isaac on it

He also reports **photos are not attaching**. I have not diagnosed that and am not guessing at it — today has already cost us one wrong theory chased without data.