### PR TITLE
fix(ios): slim the document buttons, and finish the copy pass

### DIFF
--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -217,7 +217,7 @@ final class DemoWalkEngine: WalkEngine {
         try? await Task.sleep(for: .seconds(0.8))
         let itemWord = board.count == 1 ? "item" : "items"
         let notes = NotesModel(
-            summary: "Walked \(trade.site.capitalized(with: nil)) — \(board.count) \(itemWord) captured.",
+            summary: "Walked \(trade.site.capitalized(with: nil)), \(board.count) \(itemWord) captured.",
             items: board,
             docKind: DocKinds.primaryKind(for: trade.key),
             queued: false,
@@ -258,7 +258,7 @@ final class DemoWalkEngine: WalkEngine {
     private static let sampleNotes: [NotesEntryFixture] = [
         NotesEntryFixture(
             bucket: .scopeOfWork,
-            label: "Mulch — front beds",
+            label: "Mulch, front beds",
             detail: "Darker mulch than last year; the old mulch faded."
         ),
         NotesEntryFixture(
@@ -269,7 +269,7 @@ final class DemoWalkEngine: WalkEngine {
         NotesEntryFixture(
             bucket: .conditionsAndIssues,
             label: "Zone-2 irrigation head broken",
-            detail: "Replace — parts + labor."
+            detail: "Replace. Parts and labor."
         )
     ]
 
@@ -550,7 +550,7 @@ final class DemoWalkEngine: WalkEngine {
                  scheduledAt: nil, status: .active, createdAt: 3, updatedAt: 3),
         JobModel(id: "job-2", name: "The Hendersons", client: nil, site: nil,
                  scheduledAt: nil, status: .active, createdAt: 2, updatedAt: 2),
-        JobModel(id: "job-3", name: "412 Maple — retaining wall", client: nil, site: nil,
+        JobModel(id: "job-3", name: "412 Maple retaining wall", client: nil, site: nil,
                  scheduledAt: nil, status: .done, createdAt: 1, updatedAt: 1),
     ]
     private var nextJobOrdinal = 4

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -145,7 +145,7 @@ enum Fixtures {
 
     static let landscape = TradeFixture(
         key: "landscape",
-        dateLabel: "TUE — JUL 01",
+        dateLabel: "TUE · JUL 01",
         countTitle: "4 sites today",
         biz: "Ridgeline Landscape Co.",
         bizCaps: "RIDGELINE LANDSCAPE CO.",
@@ -176,18 +176,18 @@ enum Fixtures {
             DocRowFixture(title: "Boxwood trim, walkway line", sub: "SHAPE + HAUL CLIPPINGS", qty: "× 4", amount: "$140"),
             DocRowFixture(title: "Irrigation head, zone 2", sub: "PARTS + LABOR", hint: "↺ LAST 3: $110 · $120 · $125", qty: "× 1", amount: "$120", isEdit: true),
             DocRowFixture(title: "Bed edging, front beds", sub: "SPADE EDGE, RE-CUT", qty: "60 LF", amount: "$310"),
-            DocRowFixture(title: "Haul & disposal", sub: "NOT HEARD — TAP OR SAY IT", subWarn: true, qty: "× 1", amount: "——", isGap: true),
+            DocRowFixture(title: "Haul & disposal", sub: "NOT HEARD, TAP OR SAY IT", subWarn: true, qty: "× 1", amount: "——", isGap: true),
             DocRowFixture(title: "Crew labor", sub: "2-MAN CREW · HALF DAY", qty: "4 HR", amount: "$355"),
         ],
         totalKey: "TOTAL",
         totalValue: "$1,210",
-        note: "1 GAP LEFT — \u{201C}haul and disposal, ninety-five\u{201D} fills it. Never guessed for you.",
+        note: "1 GAP LEFT: \u{201C}haul and disposal, ninety-five\u{201D} fills it. Never guessed for you.",
         send: "SEND ESTIMATE"
     )
 
     static let property = TradeFixture(
         key: "property",
-        dateLabel: "TUE — JUL 01",
+        dateLabel: "TUE · JUL 01",
         countTitle: "5 units today",
         biz: "Corbett Property Group",
         bizCaps: "CORBETT PROPERTY GROUP",
@@ -218,17 +218,17 @@ enum Fixtures {
             DocRowFixture(title: "Blinds, kitchen", sub: "2 SLATS MISSING · PHOTO ×1", qty: "DEDUCT", amount: "$45"),
             DocRowFixture(title: "Walls, all rooms", sub: "NORMAL WEAR AND TEAR", qty: "OK", amount: "—"),
             DocRowFixture(title: "Water heater", sub: "MFG 2019 · SERIAL LOGGED", qty: "NOTE", amount: "—"),
-            DocRowFixture(title: "Garage remote", sub: "NOT HEARD — RETURNED? SAY IT", subWarn: true, qty: "DEDUCT", amount: "——", isGap: true),
+            DocRowFixture(title: "Garage remote", sub: "NOT HEARD, RETURNED? SAY IT", subWarn: true, qty: "DEDUCT", amount: "——", isGap: true),
         ],
         totalKey: "DEPOSIT DEDUCTION",
         totalValue: "$185",
-        note: "PHOTOS PIN TO THE LINE YOU\u{2019}RE SPEAKING ABOUT — SAY \u{201C}PHOTO\u{201D} OR TAP",
+        note: "PHOTOS PIN TO THE LINE YOU\u{2019}RE SPEAKING ABOUT: SAY \u{201C}PHOTO\u{201D} OR TAP",
         send: "SEND REPORT"
     )
 
     static let inspection = TradeFixture(
         key: "inspection",
-        dateLabel: "TUE — JUL 01",
+        dateLabel: "TUE · JUL 01",
         countTitle: "2 inspections today",
         biz: "TrueLine Home Inspection",
         bizCaps: "TRUELINE HOME INSPECTION",
@@ -238,7 +238,7 @@ enum Fixtures {
         jobs: [
             JobFixture(time: "8:30", name: "212 Garfield Ave", sub: "Pre-purchase · 1954 SFR", tag: TagFixture(kind: .green, label: "SENT"), done: true),
             JobFixture(time: "12:00", name: "77 Larkspur Ln", sub: "Pre-purchase · 2001 SFR", tag: TagFixture(kind: .plain, label: "NEXT")),
-            JobFixture(time: "—", name: "Report follow-up", sub: "Buyer Q — 212 Garfield", tag: TagFixture(kind: .yellow, label: "F/U")),
+            JobFixture(time: "—", name: "Report follow-up", sub: "Buyer Q, 212 Garfield", tag: TagFixture(kind: .yellow, label: "F/U")),
             JobFixture(time: "—", name: "Thu hold", sub: "4-point · insurer req.", tag: TagFixture(kind: .plain, label: "HOLD")),
         ],
         site: "77 LARKSPUR LN",
@@ -259,11 +259,11 @@ enum Fixtures {
             DocRowFixture(title: "GFCI, hall bathroom", sub: "FAILS TO TRIP ON TEST", hint: "↺ AUTO-FILED FROM YOUR LAST 12 REPORTS", qty: "SAFETY", amount: "§ 6.4", isEdit: true),
             DocRowFixture(title: "Attic ventilation", sub: "RIDGE + SOFFIT, ADEQUATE", qty: "OK", amount: "§ 3.2"),
             DocRowFixture(title: "Furnace filter", sub: "REPLACEMENT OVERDUE", qty: "MAINT", amount: "§ 5.1"),
-            DocRowFixture(title: "Water heater TPR valve", sub: "NOT ACCESSED — VERIFY OR EXCLUDE", subWarn: true, qty: "——", amount: "§ 5.3", isGap: true),
+            DocRowFixture(title: "Water heater TPR valve", sub: "NOT ACCESSED, VERIFY OR EXCLUDE", subWarn: true, qty: "——", amount: "§ 5.3", isGap: true),
         ],
         totalKey: "FINDINGS",
         totalValue: "1 SAFETY · 3 REPAIR",
-        note: "FINDINGS FILE INTO TREC SECTIONS AUTOMATICALLY — REORDER BY DRAG",
+        note: "FINDINGS FILE INTO TREC SECTIONS AUTOMATICALLY: REORDER BY DRAG",
         send: "SEND REPORT"
     )
 

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -629,19 +629,20 @@ struct NotesView: View {
                 if building {
                     ProgressView().tint(hero ? Theme.C.onOrange : Theme.C.ink)
                 } else {
-                    VStack(spacing: 2) {
-                        Text(choice.label)
-                            .font(Theme.F.ui(12, .bold)).tracking(0.04)
-                            .foregroundStyle(hero ? Theme.C.onOrange : Theme.C.ink)
-                            .lineLimit(1)
-                        Text(choice.stamp)
-                            .font(Theme.F.mono(6.5, .semibold)).tracking(0.6)
-                            .foregroundStyle(hero ? Theme.C.onOrange.opacity(0.85) : Theme.C.ink60)
-                            .lineLimit(1)
-                    }
+                    // ONE line. The stamp under the label ("Estimate" over
+                    // "EST") said the same thing twice, and the type ramp made
+                    // it the bigger problem of the two: at 6.5pt it sat below
+                    // the 11pt floor, so it was forced up 69% while the label
+                    // grew 30%. A redundant sub-label ended up nearly the size
+                    // of the real one, which is what made these read as chunky
+                    // and cut off (Isaac, on device).
+                    Text(choice.label)
+                        .font(Theme.F.ui(12, .bold)).tracking(0.04)
+                        .foregroundStyle(hero ? Theme.C.onOrange : Theme.C.ink)
+                        .lineLimit(1)
                     // Breathing room INSIDE the border, so the shape grows with
                     // the label instead of the label escaping the shape.
-                    .padding(.horizontal, 14)
+                    .padding(.horizontal, 16)
                     .fixedSize(horizontal: true, vertical: false)
                 }
             }
@@ -650,8 +651,10 @@ struct NotesView: View {
             // the horizontal ScrollView, which is how "Invoice" and "Work
             // Order" ended up printed across their own borders once the type
             // ramp grew them (Isaac, on device 2026-07-30).
-            .frame(height: 54)
-            .frame(minWidth: 96)
+            // 46 rather than 54: a single line needs less box, and a shorter
+            // row leaves more of the notes visible above it.
+            .frame(height: 46)
+            .frame(minWidth: 88)
             .fixedSize(horizontal: true, vertical: false)
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
Isaac, on device:

> the buttons look off ... the ones you press after the walk. Maybe they need to be a little smaller?

## Cause: the type ramp's floor, hitting the wrong label hardest

The ramp (#294) has an **11pt floor**. The stamp under each button ("EST" beneath "Estimate") was set at **6.5pt** — well below it — so it was forced up to 11pt, a **69% jump**, while the label it sat under grew only 30% (12 → 15.6pt).

A redundant sub-label ended up nearly the size of the real one, in a fixed 54pt box. That is what read as chunky and clipped.

## Fix: delete the stamp, don't shrink it

"Estimate" over "EST" says the same thing twice. The stamp was decoration, and it was the decoration causing the problem — so it goes rather than getting tuned.

One line, **46pt tall instead of 54**, sized to its label with 16pt of internal padding and an 88pt floor. Shorter row, more notes visible above it, more buttons fit before scrolling.

Verified on-sim: "Estimate" and "Invoice" now sit properly inside their borders.

## The copy pass missed the demo data

While looking at the render I could see em dashes still on screen that #307 had not caught, because they live in **fixtures and the demo engine** rather than in `Text(...)` literals:

- `"NOT HEARD — TAP OR SAY IT"` → `"NOT HEARD, TAP OR SAY IT"`
- `"Walked 1418 Alder Ct — 5 items captured."` → `", 5 items captured."`
- `"Replace — parts + labor."` → `"Replace. Parts and labor."`
- `"Mulch — front beds"`, `"412 Maple — retaining wall"`, `"1 GAP LEFT — …"`, the date strip

These are not dead data. They render in the demo build, which is the no-credential fallback **and the path the App Store screenshots are captured on**.

**Every user-visible em dash in the app is now gone.** The only one left in non-comment code is inside a code comment on the same line as an append.

93 tests pass.

## Note on the screenshots

`docs/store/screenshots-6.9/` now predates the design series, the copy pass, and this button change. Regenerating is one scripted command and worth doing once the app settles rather than after each change.
