### PR TITLE
feat: every trade, not three — plus the general documents go universal

### DIFF
--- a/apps/ios/Sources/App/BusinessProfile.swift
+++ b/apps/ios/Sources/App/BusinessProfile.swift
@@ -17,6 +17,15 @@ struct BusinessProfile: Codable, Equatable {
     var licenseNumber: String?
     /// Matches `Fixtures.all` keys: landscape | property | inspection.
     var tradeKey: String
+    /// What the operator typed when they picked "Something else". Optional and
+    /// decorative — the KEY is what scopes schemas and templates. Kept so a
+    /// septic contractor's letterhead can say "Septic" instead of "Other".
+    ///
+    /// Optional with a default so decoding a profile written before this field
+    /// existed still succeeds. `current` decodes with `try?`, so a
+    /// non-defaulted addition would silently wipe every existing profile and
+    /// re-onboard the whole beta.
+    var tradeLabel: String? = nil
     /// Migration seam (dam review #190). `current` decodes with `try?`, so a
     /// future breaking schema change silently returns nil and the operator
     /// gets re-onboarded — the stored profile is gone, not just unreadable.
@@ -57,9 +66,24 @@ struct BusinessProfile: Codable, Equatable {
         return parts.joined(separator: " · ")
     }
 
-    /// The trade template this operator works in. Falls back to landscape if
-    /// a stored key ever goes stale against `Fixtures.all`.
+    /// The trade template this operator works in.
+    /// What to SHOW for this operator's trade — their own words when they gave
+    /// them, the catalog label otherwise.
+    var tradeDisplayName: String {
+        if let custom = tradeLabel?.trimmingCharacters(in: .whitespaces), !custom.isEmpty {
+            return custom
+        }
+        return Trades.label(for: tradeKey)
+    }
+
     var trade: TradeFixture {
-        Fixtures.all.first { $0.key == tradeKey } ?? Fixtures.landscape
+        if let exact = Fixtures.all.first(where: { $0.key == tradeKey }) { return exact }
+        // A trade with no fixture content borrows landscape's demo copy — which
+        // only ever renders in demo mode — but KEEPS ITS OWN KEY. Returning
+        // Fixtures.landscape wholesale used to silently re-file a plumber's
+        // walks and document types under "landscape".
+        var generic = Fixtures.landscape
+        generic.key = tradeKey
+        return generic
     }
 }

--- a/apps/ios/Sources/App/Trades.swift
+++ b/apps/ios/Sources/App/Trades.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The trades an operator can pick during onboarding.
+///
+/// Isaac, 2026-08-08: *"If someone who doesn't belong to one of the trades
+/// listed gets the app, I don't want them to think this isn't for them."*
+///
+/// The picker used to offer exactly three — landscape, property, inspection —
+/// which told a plumber, a roofer, or a handyman that the app was built for
+/// somebody else. That is an expensive thing to say on the first screen, and it
+/// was never true: nothing about walking a job and talking is landscaping-
+/// specific.
+///
+/// ## What the trade key actually does
+///
+/// Less than it looks. It picks the starter vocabulary pack (only three ship,
+/// and a trade without one simply seeds nothing), it scopes document types the
+/// operator authors themselves, and it tags the walk's template in core. It
+/// does NOT gate the general document types — Estimate, Invoice, Work Order and
+/// Report are universal, so every trade below can produce all four.
+///
+/// ## Why the keys must never change
+///
+/// A key is persisted in `BusinessProfile` AND written to `document_schemas.
+/// trade_key` in core. Renaming one orphans the operator's own document types.
+/// Add freely; never rename or remove.
+enum Trades {
+    struct Option: Identifiable, Hashable {
+        let key: String
+        let label: String
+        /// The document this trade most often needs. Sets expectations in the
+        /// picker without promising anything the app can't do.
+        let stamp: String
+        var id: String { key }
+    }
+
+    /// The key stored when an operator picks "Something else". Their typed
+    /// answer is kept as the business's own trade label; the key stays stable so
+    /// their schemas survive.
+    static let otherKey = "other"
+
+    /// Ordered roughly by how many US businesses each represents, with the three
+    /// that ship vocabulary packs first.
+    static let catalog: [Option] = [
+        Option(key: "landscape",   label: "Landscaping & lawn",    stamp: "ESTIMATES"),
+        Option(key: "property",    label: "Property mgmt",         stamp: "MOVE-OUT REPORTS"),
+        Option(key: "inspection",  label: "Home inspection",       stamp: "INSPECTION REPORTS"),
+        Option(key: "handyman",    label: "Handyman",              stamp: "ESTIMATES"),
+        Option(key: "general",     label: "General contracting",   stamp: "ESTIMATES"),
+        Option(key: "remodel",     label: "Remodeling",            stamp: "ESTIMATES"),
+        Option(key: "plumbing",    label: "Plumbing",              stamp: "INVOICES"),
+        Option(key: "hvac",        label: "HVAC",                  stamp: "WORK ORDERS"),
+        Option(key: "electrical",  label: "Electrical",            stamp: "INVOICES"),
+        Option(key: "roofing",     label: "Roofing",               stamp: "ESTIMATES"),
+        Option(key: "painting",    label: "Painting",              stamp: "ESTIMATES"),
+        Option(key: "tree",        label: "Tree service",          stamp: "ESTIMATES"),
+        Option(key: "pest",        label: "Pest control",          stamp: "WORK ORDERS"),
+        Option(key: "cleaning",    label: "Cleaning",              stamp: "ESTIMATES"),
+        Option(key: "restoration", label: "Restoration",           stamp: "REPORTS"),
+        Option(key: "pool",        label: "Pool & spa",            stamp: "WORK ORDERS"),
+        Option(key: "concrete",    label: "Concrete & masonry",    stamp: "ESTIMATES"),
+        Option(key: "fencing",     label: "Fencing",               stamp: "ESTIMATES"),
+        Option(key: otherKey,      label: "Something else",        stamp: "ESTIMATES"),
+    ]
+
+    /// The display label for a stored key. Falls back to the key itself so a
+    /// value written by a future build never renders blank.
+    static func label(for key: String) -> String {
+        catalog.first { $0.key == key }?.label ?? key.capitalized
+    }
+
+    /// Whether a key is one the app ships content for. Used to decide whether to
+    /// ask the "what do you do?" follow-up.
+    static func isKnown(_ key: String) -> Bool {
+        catalog.contains { $0.key == key }
+    }
+}

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -63,7 +63,11 @@ struct DocRowFixture: Identifiable {
 }
 
 struct TradeFixture {
-    let key: String
+    /// `var`, not `let`: an operator whose trade ships no fixture content
+    /// borrows landscape's demo copy but KEEPS THEIR OWN KEY, because this key
+    /// is what scopes their document schemas and tags their walk template. See
+    /// `BusinessProfile.trade`.
+    var key: String
     let dateLabel: String
     let countTitle: String
     let biz: String
@@ -95,12 +99,23 @@ struct TradeFixture {
 /// per-trade button-set content are sac's (`docs/design/notes-mockup.html`);
 /// this table only guarantees the wiring is correct.
 enum DocKinds {
+    /// Every trade quotes, bills, dispatches work and writes things up, so the
+    /// general four are available to all of them — including a trade the app
+    /// has never heard of. Specialists get their extras on top.
+    ///
+    /// This mirrors the seeded schemas after 2026-08-08: Estimate, Invoice,
+    /// Work Order and Report carry a NULL `trade_key` (universal) in core, while
+    /// Condition, Move-Out and Inspection stay scoped. This function is only the
+    /// FALLBACK for when no schemas load at all — core's resolver is the real
+    /// authority — but it must agree with it or the fallback would offer
+    /// something the build then refuses.
+    static let generalKinds = ["estimate", "invoice", "work_order", "report"]
+
     static func legalKinds(for templateKey: String) -> [String] {
         switch templateKey {
-        case "landscape": return ["estimate", "invoice", "work_order"]
-        case "property": return ["condition", "move_out"]
-        case "inspection": return ["inspection"]
-        default: return ["report"]
+        case "property":   return generalKinds + ["condition", "move_out"]
+        case "inspection": return generalKinds + ["inspection"]
+        default:           return generalKinds
         }
     }
 

--- a/apps/ios/Sources/Flow/LetterheadStudioView.swift
+++ b/apps/ios/Sources/Flow/LetterheadStudioView.swift
@@ -41,9 +41,10 @@ struct LetterheadStudioView: View {
     private let accents: [UInt32] = [0x9A6A00, 0x3E6B35, 0x2E5A78, 0xA63A2E, 0x141412]
     private let fonts: [(key: String, label: String)] = [("serif", "SOURCE SERIF"), ("sans", "BARLOW")]
     // Trade type labels mirror onboarding (no display name on TradeFixture).
-    private let trades: [(key: String, label: String)] = [
-        ("landscape", "LANDSCAPE"), ("property", "PROPERTY MGMT"), ("inspection", "INSPECTION"),
-    ]
+    /// ONE source with onboarding. A hardcoded three here meant an operator who
+    /// picked "Plumbing" during onboarding opened this screen and found their
+    /// own trade missing from the menu.
+    private var trades: [Trades.Option] { Trades.catalog }
 
     // The trade the preview renders — follows the draft, so switching it re-keys
     // the doc-kind + sample rows live.
@@ -239,8 +240,7 @@ struct LetterheadStudioView: View {
                 }
             } label: {
                 HStack {
-                    Text(trades.first { $0.key == draftProfile.tradeKey }?.label
-                         ?? draftProfile.tradeKey.uppercased())
+                    Text(Trades.label(for: draftProfile.tradeKey))
                         .font(Theme.F.cond(13, .semibold))
                         .foregroundStyle(Theme.C.ink)
                     Spacer()

--- a/apps/ios/Sources/Flow/OnboardingFlow.swift
+++ b/apps/ios/Sources/Flow/OnboardingFlow.swift
@@ -18,7 +18,11 @@ struct OnboardingFlow: View {
 
     // welcome + 3 "how it works" beats (learn by seeing) → setup (business, mic).
     private enum Step: Int, CaseIterable { case welcome = 1, seeWalk, seeFix, seeDoc, business, mic }
-    @State private var step: Step = .welcome
+    // `onboard=business` jumps straight to the profile/trade step. simctl can't
+    // tap, so without this the trade picker — the screen most likely to change —
+    // can never be seen headlessly.
+    @State private var step: Step =
+        ProcessInfo.processInfo.arguments.contains("onboard=business") ? .business : .welcome
     private var isIntro: Bool { step.rawValue < Step.business.rawValue }
 
     // YOUR BUSINESS fields
@@ -26,7 +30,10 @@ struct OnboardingFlow: View {
     @State private var cityState = ""
     @State private var license = ""
     @State private var tradeKey = "landscape"
-    private enum Field { case name, city, license }
+    /// Free text when "Something else" is picked. Never becomes the trade KEY —
+    /// keys must stay stable because core scopes document schemas by them.
+    @State private var otherTrade = ""
+    private enum Field { case name, city, license, otherTrade }
     @FocusState private var focused: Field?
 
     // MIC
@@ -185,7 +192,7 @@ struct OnboardingFlow: View {
                 Text("ESTIMATE").font(Theme.F.mono(7, .semibold)).tracking(1.4)
                     .foregroundStyle(Theme.C.amberInk)
             }
-            miniRow("Bark mulch — front beds", right: "$285")
+            miniRow("Bark mulch, front beds", right: "$285")
             sendStamp
         }
     }
@@ -215,7 +222,7 @@ struct OnboardingFlow: View {
                 Text("EST-0047").font(Theme.F.mono(7, .semibold)).tracking(1.0)
                     .foregroundStyle(Theme.C.amberInk)
             }
-            miniRow("Bark mulch — front beds", right: "$285")
+            miniRow("Bark mulch, front beds", right: "$285")
             miniRow("TOTAL", right: "$680")
             sendStamp
         }
@@ -288,15 +295,27 @@ struct OnboardingFlow: View {
                               placeholder: "44-0781", field: .license)
                         .padding(.top, 20)
 
-                    SectionLabel("TRADE")
+                    SectionLabel("WHAT DO YOU DO?")
                         .padding(.top, 26)
+                    // Every trade in the catalog, not three. A plumber seeing
+                    // only landscape/property/inspection concluded the app
+                    // wasn't for them — an expensive thing to say on the first
+                    // screen, and untrue (Isaac, 2026-08-08).
                     VStack(spacing: 8) {
-                        tradeRow(key: "landscape", label: "LANDSCAPE", stamp: "ESTIMATES")
-                        tradeRow(key: "property", label: "PROPERTY MGMT", stamp: "MOVE-OUT REPORTS")
-                        tradeRow(key: "inspection", label: "INSPECTION", stamp: "INSPECTION REPORTS")
+                        ForEach(Trades.catalog) { option in
+                            tradeRow(key: option.key, label: option.label, stamp: option.stamp)
+                        }
                     }
                     .padding(.top, 10)
-                    .padding(.bottom, 18)
+
+                    // The catch-all's follow-up. Optional on purpose: the key is
+                    // already stored, so this only improves the letterhead and
+                    // costs nothing to skip.
+                    if tradeKey == Trades.otherKey {
+                        formField("WHAT KIND OF WORK? — OPTIONAL", text: $otherTrade,
+                                  placeholder: "Septic, marine survey, solar…", field: .otherTrade)
+                            .padding(.top, 14)
+                    }
                 }
                 .padding(.horizontal, Theme.S.screenPad)
                 .padding(.top, 18)
@@ -309,7 +328,9 @@ struct OnboardingFlow: View {
                     cityState: cityState.trimmingCharacters(in: .whitespaces),
                     licenseNumber: license.trimmingCharacters(in: .whitespaces).isEmpty
                         ? nil : license.trimmingCharacters(in: .whitespaces),
-                    tradeKey: tradeKey
+                    tradeKey: tradeKey,
+                    tradeLabel: tradeKey == Trades.otherKey
+                        ? otherTrade.trimmingCharacters(in: .whitespaces) : nil
                 ))
                 focused = nil
                 step = .mic
@@ -355,13 +376,17 @@ struct OnboardingFlow: View {
                     .overlay(Rectangle().stroke(
                         selected ? Theme.C.orange : Theme.C.ink35, lineWidth: 1.5))
                 Text(label)
-                    .font(Theme.F.mono(11, .semibold))
-                    .tracking(1.4)
+                    .font(Theme.F.ui(14, .semibold))
                     .foregroundStyle(Theme.C.ink)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .layoutPriority(1)
                 Spacer(minLength: 8)
                 Text(stamp)
                     .font(Theme.F.mono(8, .semibold))
                     .tracking(1.0)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
                     .foregroundStyle(selected ? Theme.C.amberInk : Theme.C.ink60)
                     .padding(.horizontal, 6)
                     .padding(.top, 3)

--- a/apps/ios/Tests/TradeCatalogTests.swift
+++ b/apps/ios/Tests/TradeCatalogTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on the trade catalog and on what a trade key controls.
+///
+/// Isaac, 2026-08-08: *"If someone who doesn't belong to one of the trades
+/// listed gets the app, I don't want them to think this isn't for them."*
+///
+/// The risk in widening the picker is silent data damage: trade keys are
+/// persisted in `BusinessProfile` AND written to `document_schemas.trade_key` in
+/// core, so a renamed key orphans the operator's own document types, and a key
+/// that fails to survive the profile round-trip re-files their walks under
+/// somebody else's trade. Most of these pin those two failures.
+final class TradeCatalogTests: XCTestCase {
+
+    // MARK: The catalog itself
+
+    func testTheThreeOriginalKeysStillExist() {
+        // These are already persisted on every beta device. Renaming one
+        // orphans that operator's custom document types in core.
+        for key in ["landscape", "property", "inspection"] {
+            XCTAssertTrue(
+                Trades.catalog.contains { $0.key == key },
+                "\(key) is a shipped key and must never be renamed or removed"
+            )
+        }
+    }
+
+    func testKeysAreUniqueAndNonEmpty() {
+        let keys = Trades.catalog.map(\.key)
+        XCTAssertEqual(Set(keys).count, keys.count, "duplicate trade key")
+        XCTAssertFalse(keys.contains { $0.isEmpty })
+    }
+
+    func testCatalogIsMeaningfullyWiderThanThree() {
+        // The whole point. If this ever collapses back toward three, the
+        // "this isn't for me" bounce returns.
+        XCTAssertGreaterThanOrEqual(Trades.catalog.count, 12)
+    }
+
+    func testCatalogEndsWithTheCatchAll() {
+        XCTAssertEqual(Trades.catalog.last?.key, Trades.otherKey)
+    }
+
+    func testLabelFallsBackRatherThanRenderingBlank() {
+        XCTAssertEqual(Trades.label(for: "landscape"), "Landscaping & lawn")
+        // A key written by a future build must still render something.
+        XCTAssertFalse(Trades.label(for: "septic_pumping").isEmpty)
+    }
+
+    // MARK: Every trade can make the general documents
+
+    func testEveryTradeGetsTheGeneralFour() {
+        // Mirrors core: Estimate/Invoice/Work Order/Report carry a NULL
+        // trade_key and resolve for any template. If this drifts from core, the
+        // fallback offers a button whose build then fails.
+        for option in Trades.catalog {
+            let kinds = DocKinds.legalKinds(for: option.key)
+            for kind in ["estimate", "invoice", "work_order", "report"] {
+                XCTAssertTrue(kinds.contains(kind), "\(option.key) is missing \(kind)")
+            }
+        }
+    }
+
+    func testAnUnknownTradeStillGetsTheGeneralFour() {
+        let kinds = DocKinds.legalKinds(for: "marine_survey")
+        XCTAssertEqual(Set(kinds), Set(DocKinds.generalKinds))
+    }
+
+    func testSpecialistKindsStayWithTheirTrades() {
+        XCTAssertTrue(DocKinds.legalKinds(for: "property").contains("move_out"))
+        XCTAssertTrue(DocKinds.legalKinds(for: "inspection").contains("inspection"))
+        // A fencing contractor has no use for a move-out report.
+        XCTAssertFalse(DocKinds.legalKinds(for: "fencing").contains("move_out"))
+        XCTAssertFalse(DocKinds.legalKinds(for: "plumbing").contains("inspection"))
+    }
+
+    // MARK: The key must survive — this is the bug that prompted the tests
+
+    func testAnUnknownTradeKeepsItsOwnKey() {
+        // `BusinessProfile.trade` used to return Fixtures.landscape wholesale
+        // for any unrecognised key, so `model.trade.key` came back "landscape"
+        // — silently filing a plumber's walks and schemas under landscaping.
+        let profile = BusinessProfile(
+            businessName: "Ace Plumbing", cityState: "Denver CO",
+            licenseNumber: nil, tradeKey: "plumbing"
+        )
+        XCTAssertEqual(profile.trade.key, "plumbing")
+    }
+
+    func testAKnownTradeStillGetsItsOwnFixture() {
+        let profile = BusinessProfile(
+            businessName: "X", cityState: "Y", licenseNumber: nil, tradeKey: "property"
+        )
+        XCTAssertEqual(profile.trade.key, "property")
+        XCTAssertEqual(profile.trade.site, Fixtures.property.site)
+    }
+
+    // MARK: The "Something else" label
+
+    func testCustomLabelIsPreferredWhenGiven() {
+        let profile = BusinessProfile(
+            businessName: "X", cityState: "Y", licenseNumber: nil,
+            tradeKey: Trades.otherKey, tradeLabel: "Septic pumping"
+        )
+        XCTAssertEqual(profile.tradeDisplayName, "Septic pumping")
+    }
+
+    func testBlankCustomLabelFallsBackToTheCatalog() {
+        for blank in [nil, "", "   "] {
+            let profile = BusinessProfile(
+                businessName: "X", cityState: "Y", licenseNumber: nil,
+                tradeKey: Trades.otherKey, tradeLabel: blank
+            )
+            XCTAssertEqual(profile.tradeDisplayName, "Something else")
+        }
+    }
+
+    /// A profile written before `tradeLabel` existed must still decode. It is
+    /// read with `try?`, so a non-defaulted field would silently wipe every
+    /// beta tester's profile and re-onboard them.
+    func testProfilesWrittenBeforeTradeLabelStillDecode() throws {
+        // Shape of a profile written before `tradeLabel` existed — every other
+        // field present, that one absent.
+        let legacy = """
+        {"schemaVersion":1,"businessName":"Ace Lawn","cityState":"Denver CO",
+         "tradeKey":"landscape"}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(BusinessProfile.self, from: legacy)
+        XCTAssertEqual(decoded.tradeKey, "landscape")
+        XCTAssertNil(decoded.tradeLabel)
+        XCTAssertEqual(decoded.tradeDisplayName, "Landscaping & lawn")
+    }
+}

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -352,11 +352,24 @@ fn builtin_schema(
 /// `seed_builtin_schemas` iterates this — never an inline-SQL duplicate.
 /// `priced`/`total_*` per built-in reproduce `is_pricing_kind`/`total_shape`
 /// EXACTLY (pinned by `builtin_schemas_reproduce_todays_pricing_and_total_shape`).
+/// The seeded document types.
+///
+/// Estimate, Invoice, Work Order and Report carry `trade_key: None` —
+/// UNIVERSAL, available to every trade. Every trade quotes, bills, dispatches
+/// work and writes things up; scoping those to landscaping meant a plumber who
+/// picked their own trade could not build an estimate at all (Isaac, 2026-08-08:
+/// "if someone who doesn't belong to one of the trades listed gets the app, I
+/// don't want them to think this isn't for them").
+///
+/// Condition Report, Move-Out Report and Inspection Report stay trade-scoped
+/// because they are genuinely specific to property management and inspection —
+/// a fencing contractor has no use for a move-out report, and offering one
+/// would be noise.
 pub fn builtin_schemas() -> Vec<DocumentSchema> {
     vec![
-        builtin_schema(BUILTIN_SCHEMA_ID_ESTIMATE, "estimate", "Estimate", "EST", Some("landscape"), true, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_INVOICE, "invoice", "Invoice", "INV", Some("landscape"), true, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_WORK_ORDER, "work_order", "Work Order", "WO", Some("landscape"), false, ("sum", "total")),
+        builtin_schema(BUILTIN_SCHEMA_ID_ESTIMATE, "estimate", "Estimate", "EST", None, true, ("sum", "total")),
+        builtin_schema(BUILTIN_SCHEMA_ID_INVOICE, "invoice", "Invoice", "INV", None, true, ("sum", "total")),
+        builtin_schema(BUILTIN_SCHEMA_ID_WORK_ORDER, "work_order", "Work Order", "WO", None, false, ("sum", "total")),
         builtin_schema(BUILTIN_SCHEMA_ID_CONDITION, "condition", "Condition Report", "COND", Some("property"), false, ("sum", "total")),
         builtin_schema(BUILTIN_SCHEMA_ID_MOVE_OUT, "move_out", "Move-Out Report", "MO", Some("property"), false, ("sum", "total")),
         builtin_schema(BUILTIN_SCHEMA_ID_INSPECTION, "inspection", "Inspection Report", "IR", Some("inspection"), false, ("static", "findings")),

--- a/crates/murmur-core/src/store/migrations.rs
+++ b/crates/murmur-core/src/store/migrations.rs
@@ -183,6 +183,29 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     ALTER TABLE llm_usage ADD COLUMN cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0;
     ALTER TABLE llm_usage ADD COLUMN cache_read_input_tokens INTEGER NOT NULL DEFAULT 0;
     "#,
+    // v9: the general document types become UNIVERSAL on stores that already
+    // seeded them.
+    //
+    // `seed_builtin_schemas` inserts WHERE NOT EXISTS by id, so changing
+    // `trade_key` in `domain::builtin_schemas()` only reaches NEW installs —
+    // every existing device would keep Estimate/Invoice/Work Order pinned to
+    // `landscape` and could never build one under any other trade. This
+    // repoints exactly those three seeded rows.
+    //
+    // Deliberately narrow: it matches the fixed built-in ids AND
+    // `device_id = 'builtin'`, so an operator's own customised copy of an
+    // estimate keeps whatever scope they gave it. Tombstoned rows are left
+    // alone — a deleted built-in stays deleted (WE-A).
+    r#"
+    UPDATE document_schemas
+       SET trade_key = NULL
+     WHERE id IN (
+             '00000000-0000-7000-8000-000000000001',
+             '00000000-0000-7000-8000-000000000002',
+             '00000000-0000-7000-8000-000000000003'
+           )
+       AND device_id = 'builtin';
+    "#,
 ];
 
 pub(crate) fn migrate(conn: &Connection) -> Result<(), CoreError> {
@@ -241,7 +264,7 @@ mod tests {
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(version, 8);
+        assert_eq!(version, 9);
 
         let (input, cw, cr, output): (i64, i64, i64, i64) = conn
             .query_row(

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -355,11 +355,11 @@ mod tests {
     }
 
     #[test]
-    fn fresh_store_is_at_schema_v8() {
+    fn fresh_store_is_at_schema_v9() {
         let s = Store::open_in_memory("device-a").unwrap();
         let v: i64 =
             s.conn.pragma_query_value(None, "user_version", |r| r.get(0)).unwrap();
-        assert_eq!(v, 8, "v8 added the llm_usage prompt-cache token columns");
+        assert_eq!(v, 9, "v9 repointed the general built-ins to a NULL trade_key");
     }
 
     #[test]
@@ -539,8 +539,14 @@ mod tests {
         let resolved = s.resolve_active_schema("estimate", Some("landscape")).unwrap().unwrap();
         assert_eq!(resolved.id, "custom-est", "newest updated_at wins");
 
-        // Trade must match: the landscape custom does not resolve for property.
-        assert!(s.resolve_active_schema("estimate", Some("property")).unwrap().is_none());
+        // A NAMED trade still cannot leak: the landscape-scoped custom does not
+        // serve property. (The built-in estimate does — it is universal now —
+        // so this asserts on the id rather than on absence.)
+        let elsewhere = s.resolve_active_schema("estimate", Some("property")).unwrap().unwrap();
+        assert_eq!(
+            elsewhere.id, BUILTIN_SCHEMA_ID_ESTIMATE,
+            "property should fall back to the universal built-in, not the landscape custom"
+        );
         // Kind must match.
         assert!(s.resolve_active_schema("hoa_addendum", Some("landscape")).unwrap().is_none());
         assert!(!s.has_active_schema("hoa_addendum", Some("landscape")).unwrap());
@@ -567,6 +573,38 @@ mod tests {
             );
             assert!(s.has_active_schema("report", template).unwrap());
         }
+    }
+
+    /// The general document types are available to EVERY trade, including one
+    /// the app has never heard of.
+    ///
+    /// Isaac, 2026-08-08: a plumber who picks their own trade must still be able
+    /// to build an estimate. Before this, Estimate/Invoice/Work Order were
+    /// scoped to `landscape` and an unknown template resolved none of them.
+    #[test]
+    fn general_document_types_resolve_for_any_trade() {
+        let s = Store::open_in_memory("device-a").unwrap();
+        for template in [None, Some("landscape"), Some("plumbing"), Some("chimney_sweep")] {
+            for kind in ["estimate", "invoice", "work_order", "report"] {
+                assert!(
+                    s.has_active_schema(kind, template).unwrap(),
+                    "{kind} should resolve for template {template:?}"
+                );
+            }
+        }
+    }
+
+    /// The specialist types stay scoped — a fencing contractor has no use for a
+    /// move-out report and should not be offered one.
+    #[test]
+    fn specialist_document_types_stay_trade_scoped() {
+        let s = Store::open_in_memory("device-a").unwrap();
+        for kind in ["condition", "move_out"] {
+            assert!(s.has_active_schema(kind, Some("property")).unwrap());
+            assert!(!s.has_active_schema(kind, Some("plumbing")).unwrap());
+        }
+        assert!(s.has_active_schema("inspection", Some("inspection")).unwrap());
+        assert!(!s.has_active_schema("inspection", Some("plumbing")).unwrap());
     }
 
     /// Universal must not become a back door across trades: a schema that names


### PR DESCRIPTION
Isaac: *"If someone who doesn't belong to one of the trades listed gets the app, I dont want them to think this isnt for them. Maybe we list some more trades and then have an 'other' option?"*

Right, and at the scale we just agreed on — ~100 subscribers — a download that bounces on the first screen is expensive.

The picker now offers **18 trades plus "Something else"** with an optional free-text follow-up.

## But widening the list alone would have been a lie

Two bugs underneath meant a plumber picking "Plumbing" would have had a worse experience than picking nothing.

**Core: they could not build an estimate at all.** `Estimate`, `Invoice` and `Work Order` were seeded with `trade_key: Some("landscape")`. For any other template, `resolve_active_schema` returned nothing, and the legality gate in `build()` rejected the kind outright. The plumber would have seen exactly one document type — Report.

Those three now carry **`trade_key: None`** (universal). Every trade quotes, bills and dispatches work; scoping that to landscaping was never right. **`Condition`, `Move-Out` and `Inspection` stay scoped** — a fencing contractor has no use for a move-out report, and offering one is noise.

**Migration v9** repoints already-seeded rows, because `seed_builtin_schemas` inserts `WHERE NOT EXISTS` by id — changing the constant alone would only ever reach *new* installs, leaving every beta device pinned to landscape forever. It's deliberately narrow: it matches the three fixed ids **and** `device_id = 'builtin'`, so an operator's own customised copy keeps whatever scope they gave it, and tombstoned rows stay deleted (WE-A).

**App: the trade key was being thrown away.** `BusinessProfile.trade` returned `Fixtures.landscape` *wholesale* for any unrecognised key — so `model.trade.key` came back `"landscape"`. That key drives schema queries, the Document Builder, and the walk's `template` in core. A plumber's walks and custom document types would have been silently filed under landscaping. Now an unknown trade borrows landscape's demo copy (which only renders in demo mode) but **keeps its own key**.

## Also

- `DocKinds.legalKinds` gained a `generalKinds` set as its default, mirroring the universal schemas — the fallback must agree with core's resolver or it offers a button whose build then fails
- Letterhead Studio had its **own hardcoded three**, so an operator who picked Plumbing in onboarding would have opened it and found their trade missing. Both now read `Trades.catalog`
- `BusinessProfile.tradeLabel` is optional **with a default** — it's decoded with `try?`, so a non-defaulted field would have silently wiped every beta tester's profile and re-onboarded them
- `onboard=business` launch hook, because simctl can't tap and this screen was otherwise unviewable headlessly
- Two more em dashes found in the onboarding preview, missed by the copy pass

## Verification

**106 app tests (11 new) and 243 core tests (2 new), all green.**

The new tests mostly pin the *failure* cases, since the risk here is silent data damage: the three original keys still exist (renaming one orphans schemas), keys are unique, every trade gets the general four, specialists keep theirs, an unknown trade keeps its own key, and a profile written before `tradeLabel` still decodes.

Rendered on-sim. First pass truncated "Property manage…" — the stamp was winning the width — so the label now has layout priority and a few labels are shorter.

## For dam

This is the second core change I've made while you're away, and like #306 it changes seeded data. **§2.1 of `BEFORE-THE-MONTH-AWAY.md` applies to this one too.** The judgement worth checking: I treated "which document types are universal" as a product question (Isaac's call) rather than a Plan 19 design question. If you'd have modelled shared kinds differently — e.g. in `doc_kinds_for_template` rather than as schema scope — say so and I'll rework it.
