### PR TITLE
proxy: verify App Attest attestations and assertions (server half)

### DIFF
--- a/apps/ios/Jefe.storekit
+++ b/apps/ios/Jefe.storekit
@@ -26,7 +26,7 @@
           ],
           "codeOffers" : [
           ],
-          "displayPrice" : "12.99",
+          "displayPrice" : "19.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "31456789",

--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -100,7 +100,7 @@ struct PaywallView: View {
             if let product = entitlement.proProduct {
                 // The price comes from StoreKit, never hardcoded — it is
                 // localized, and it is the number Apple will actually charge.
-                // A hardcoded "$12.99" would be wrong in every other currency
+                // A hardcoded "$19.99" would be wrong in every other currency
                 // and would silently lie after any price change.
                 Text(product.displayPrice)
                     .font(Theme.F.serif(30, .bold))
@@ -142,7 +142,7 @@ struct PaywallView: View {
     ///
     /// The renewal sentence is Apple's own required substance, in plain words:
     /// billing is on the Apple ID, it renews unless cancelled, and cancellation
-    /// is 24 hours before the period ends. Anyone paying $12.99 a month deserves
+    /// is 24 hours before the period ends. Anyone paying $19.99 a month deserves
     /// to read that before paying rather than discover it after.
     private var legalBlock: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/apps/ios/Sources/Theme/Theme.swift
+++ b/apps/ios/Sources/Theme/Theme.swift
@@ -98,7 +98,7 @@ enum Theme {
         ///
         /// Who is holding the phone settles it: the median US construction
         /// worker is 42, one in five is 55 or older, and the median trade
-        /// supervisor — the person paying $12.99/mo — is 46 and needs reading
+        /// supervisor — the person paying $19.99/mo — is 46 and needs reading
         /// glasses for 8pt mono. Type size is not a polish item for this
         /// audience; it is the product working or not working.
         ///

--- a/docs/design/2026-07-28-app-store-readiness-audit.md
+++ b/docs/design/2026-07-28-app-store-readiness-audit.md
@@ -222,7 +222,7 @@ Ordered by what blocks what, not by size.
 | 1.1 | StoreKit 2 products + purchase + **restore** | sac | **done (#277)** |
 | 1.2 | 5-walks/month meter | sac | **done (#277)** — keychain-backed, 16 tests |
 | 1.3 | Paywall at the limit | sac | **done (#277, #279)** |
-| 1.4 | Create the ASC subscription product | **Isaac** | `com.damsac.jefe.pro.monthly`, $12.99/mo, + Paid Apps agreements. Until this exists the paywall shows no price |
+| 1.4 | Create the ASC subscription product | **Isaac** | `com.damsac.jefe.pro.monthly`, **$19.99/mo** (superseded the $12.99 below on 2026-08-08 — see the GTM doc §8.3), + Paid Apps agreements. Until this exists the paywall shows no price |
 | 1.5 | Sandbox purchase on a device | **Isaac** | the one path no simulator can prove |
 | 1.6 | Proxy-side entitlement enforcement | sac/dam | **deliberately deferred** — v1 gates on-device. Pairs with App Attest (§5); the dollar caps bound the abuse until then |
 

--- a/docs/store/SUBMISSION-KIT.md
+++ b/docs/store/SUBMISSION-KIT.md
@@ -83,7 +83,7 @@ Big buttons that work with gloves on. Keeps recording with the screen locked.
 Your audio never leaves your phone. Jefe transcribes it right on the device.
 
 FREE AND PRO
-Five walks a month, free. Jefe Pro takes the limit off for $12.99/month.
+Five walks a month, free. Jefe Pro takes the limit off for $19.99/month.
 
 Made for landscapers, property managers and inspectors, and anyone who'd rather
 be on site than at a desk.
@@ -127,7 +127,7 @@ Required for real walks. The app also keeps recording with the screen locked
 the property. Without it, iOS suspends the app and the walk is lost mid-job.
 
 SUBSCRIPTION
-Jefe Pro, $12.99/month auto-renewing. The free tier is 5 completed walks per
+Jefe Pro, $19.99/month auto-renewing. The free tier is 5 completed walks per
 calendar month. The paywall shows the price, the renewal terms, and links to the
 Terms of Use and Privacy Policy. Restore Purchase is on the same screen.
 
@@ -203,7 +203,7 @@ don't refuse someone's money and their work at the same time).
 - **Type:** Auto-renewable subscription
 - **Subscription group:** `Jefe`
 - **Duration:** 1 month
-- **Price:** $12.99 USD
+- **Price:** $19.99 USD
 - **Display name:** `Jefe Pro`
 - **Description:** `Unlimited walks. Talk through as many jobs as you want and
   Jefe writes up the paperwork.`

--- a/docs/strategy/2026-08-08-positioning-and-gtm.md
+++ b/docs/strategy/2026-08-08-positioning-and-gtm.md
@@ -418,3 +418,187 @@ That buyer exists in every trade, which is what the widened trade catalog
   solved it. Our editable-output work is aimed at the right wound; the missing
   half is **memory** of the correction. This is the one feature that would make
   us better rather than merely different.
+
+---
+
+# 9. Getting people to try it (2026-08-08)
+
+Isaac: *"how are we going to market this and get people trying it out? id like
+to spend as little as possible on paid ads."*
+
+Builds on §8. Price ($19.99), buyer (operator with no software) and centrepiece
+(App Store organic) are settled and not reopened here.
+
+## 9.0 The binding constraint is Isaac's calendar, not his budget
+
+He has a full-time consulting job. **Any channel that needs a weekly cadence
+will die quietly**, so this plan front-loads one-time work that compounds
+unattended and refuses anything requiring sustained presence. That rules out
+owning a Facebook group, a YouTube channel, and a content calendar — all of
+which are good advice for someone with 40 hours a week.
+
+Budget for **~5 hours/week**, with a ~15-hour setup block up front.
+
+## 9.1 The spine: one story, and it is not "voice"
+
+Voice is table stakes — Jobber shipped it Sept 2025, VoxTrade is a price twin,
+six new App Store entrants. Leading with it is competing on their ground.
+
+The only claim that is structurally ours:
+
+> **Every competitor uploads your customer's voice to a third-party AI vendor.
+> Jefe never sends the audio anywhere.**
+
+It earns its keep three ways at once, which is why it is the spine rather than
+a bullet:
+
+1. **Legal.** Eleven states require all-party consent to record. A contractor
+   recording a homeowner and shipping that audio to a vendor is a real exposure
+   nobody in the category talks about.
+2. **Apple.** On-device processing is Apple's own marketing narrative. This is
+   the kind of app they feature, and featuring is free.
+3. **The privacy nutrition label** renders the comparison for us, on Apple's
+   own pages, forever, at zero cost. Ours reads clean; theirs cannot.
+
+Everything below is a delivery mechanism for that one sentence.
+
+## 9.2 Three gates before any marketing
+
+Marketing a product nobody outside the building has finished a job with is how
+you spend your one launch on a bug. Two shipping-blockers this month
+(the START WALK crash, the trade-scoped schema bug) were both found by Isaac
+using it. Ten operators will find the next five.
+
+### Gate A — ten real operators on external TestFlight (~6 hrs)
+
+Not friends being nice. People who will walk a paying job and be annoyed.
+
+§5.1 found this is the *only* thing that worked for all five comparable
+companies — Jobber's first customer came from a personal introduction. Concrete
+Denver sources, in order of yield:
+
+- Trades Isaac has personally hired (roofer, plumber, landscaper)
+- Nextdoor and local Facebook "who do you recommend" threads — these enumerate
+  every active solo operator in a 5-mile radius
+- **Home Depot / Lowe's pro desk, 6:30–7:30am.** Where they actually are
+- SiteOne (landscape), Ferguson (plumbing) — trade supply counters
+
+Ask for one walk on one real job, then a 10-minute phone call. Nothing else.
+
+### Gate B — the listing is the marketing (~5 hrs, compounds forever)
+
+Highest-ROI hours in the entire plan, and mostly not written yet:
+
+- **Fix the description.** It currently reads *"Made for landscapers, property
+  managers and inspectors"* — stale since #312, and it tells a plumber the app
+  is not for them, which is the exact bounce Isaac asked to eliminate.
+- **Subtitle + keywords carry 100% of ASO load** because "Jefe" has zero keyword
+  value. Current keywords are single words (`estimate,invoice,contractor…`);
+  §5.3 found ranking comes from **string clusters** — `estimate maker for
+  contractors`, `home inspection report`, `work order app`. Head terms are
+  unwinnable (Invoice Simple: 122,658 ratings); the long tail is wide open —
+  "Estimate Maker for Contractors" ranks on 2,063 ratings and has not shipped
+  since May 2023.
+- **Screenshots must show the finished document, not the app.** The buyer needs
+  to see the estimate, not the mic button. First three are all most people see.
+- **Featuring nomination** (App Store Connect → Featuring). Free, ~30 min,
+  almost nobody submits one. On-device AI is exactly the pitch Apple amplifies.
+- **Enrol in the Small Business Program.** 15% vs 30% commission. At 224 subs
+  that is **$3,000/mo net versus $2,328** — a 22% swing for one form.
+
+### Gate C — the free tier will break the product if marketing works (~3 hrs)
+
+`WalkAllowance.freeMonthlyLimit = 5` is **5 walks per calendar month, forever** —
+a freemium tier, not a trial. §8 reasoned about it as a one-time allowance,
+which is not what is built. Two consequences:
+
+**It shares the paying customers' spend cap.** Free users cost ~$0.90/mo each in
+API. 1,000 free actives = **$900/mo, more than the entire $750/mo global cap.**
+The failure mode is precise and bad: a good week of installs burns the global
+cap and *paying subscribers get 503s mid-job.* Successful marketing is currently
+the thing that breaks the product.
+
+Fix before launch, cheapest first:
+1. Raise the global cap and re-derive it from paid subscriber count, not a
+   fixed $25/day.
+2. Give the free tier its own smaller pool, so free usage can never deny a
+   paying customer. Paying capacity must never be spendable by non-payers.
+
+**And add a trial at the paywall.** Keep 5/month for evaluation, then offer a
+**14-day free trial** as a StoreKit introductory offer at the paywall. 5 walks
+proves it works; 14 days unlimited builds the habit. This is ASC configuration
+plus paywall copy — no new app-side machinery.
+
+## 9.3 The channels, sized to ~3 hrs/week
+
+Ranked by yield per hour, given the constraint in §9.0:
+
+| # | Channel | Cost | Hours | Why |
+|---|---|---|---|---|
+| 1 | **Answer, don't post** — r/Contractor, r/HVAC, r/Plumbing, r/landscaping, trade FB groups | $0 | 1.5/wk | "How do you handle estimates" is asked constantly. Answer usefully, mention the app only when it is the answer. Slow, compounding, zero spend |
+| 2 | **The consent explainer** — *"Can you legally record a customer on a job site?"* state-by-state | $0 | 4 once | Ship as a free tool on getjefe.netlify.app, not a product page. Earns long-tail search, and gives Isaac a non-promotional reason to post anywhere |
+| 3 | **Review prompt** — `SKStoreReviewController` after the first successful export | $0 | 1 once | **Not implemented.** Ratings volume is the ASO flywheel; the long-tail competitor ranks on 2,063. Ask at the moment of relief, never at launch |
+| 4 | **The beta site** — finish the TestFlight link + Formspree id, then redeploy | $0 | 1 once | Already live and currently converting nobody |
+| 5 | **Podcast guest sweep** — dozens of shows at 1k–10k listeners, desperate for guests | $0 | 2/appearance | Real reach, but per-appearance cost is high on a 5-hr week. Do 3, not 15, and lead with the privacy angle |
+| ✗ | Product Hunt | — | — | Comparable indie privacy launches report 84 visitors / 0 sales |
+| ✗ | Franchise networks | — | — | All mandate their own software |
+
+InterNACHI ($49/mo) stays demoted per §8.5 — good channel pointing at buyers who
+already own tools.
+
+## 9.4 Paid ads: not yet, and the trigger is specific
+
+**Recommendation: spend nothing until 60 days of retention data exists.**
+
+Not caution — arithmetic. Net is ~$13.40/sub/mo after commission and API.
+
+| Monthly churn | Avg lifetime | LTV | Verdict at $40 CAC |
+|---|---|---|---|
+| 8% | 12.5 mo | ~$168 | works comfortably |
+| 15% | 6.7 mo | ~$90 | marginal |
+| 25% | 4 mo | ~$54 | loses money |
+
+**Churn is the single number that decides whether ads work, and it cannot be
+known before there are subscribers.** Spending now buys a number that cannot be
+evaluated. This is also why §8.5 put retention above acquisition: at 200 subs,
+10% churn means replacing 20 people every month forever.
+
+**Trigger to start:** 60 days post-launch, measured monthly churn under 10%.
+
+**Then, and only:** Apple Search Ads, exact-match long-tail only (`estimate
+maker for contractors`, not `contractor app`), $10/day hard cap, kill any
+keyword whose CAC exceeds $40. ASA is the one paid channel worth testing because
+it catches existing intent from a buyer with no vendor relationship to defend.
+No Meta, no Google — both sell interest, and we need intent.
+
+*Unverified: current ASA cost-per-tap on these terms. Not fetchable here. Treat
+the $40 ceiling as the decision rule, not the expected price.*
+
+## 9.5 Order of work
+
+**Setup (~15 hrs, before launch)**
+1. Free-tier spend isolation + raise the global cap (Gate C) — *the only true blocker*
+2. Rewrite description, subtitle, keywords; reshoot screenshots on the document
+3. Small Business Program enrolment; ASC product at $19.99 with a 14-day trial
+4. Review prompt after first export
+5. Featuring nomination
+
+**Weeks 1–3 (~6 hrs/wk)**
+6. Ten operators on external TestFlight; one call each
+7. Fix what they hit. Do not market past this gate
+
+**Launch, then ~3 hrs/wk**
+8. Publish the consent explainer; finish the beta site
+9. Answer questions in trade communities
+10. Three podcast appearances
+11. **Measure churn.** At day 60, decide on ASA
+
+## 9.6 What would make this wrong
+
+- **If the ten operators do not finish walks**, no channel matters and the
+  problem is product. That is the real function of Gate A.
+- **If churn runs above 20%**, this is not a subscription business at $19.99 and
+  the answer is the §8.6 memory feature, not more acquisition.
+- **If Apple features it**, everything above is noise for a month — which is
+  precisely why Gate C (the shared spend cap) must be fixed first. Being
+  featured with the current cap would take the product down.

--- a/meta/dam/BEFORE-THE-MONTH-AWAY.md
+++ b/meta/dam/BEFORE-THE-MONTH-AWAY.md
@@ -38,7 +38,7 @@ clause to revert.
 
 ### 1.2 Monetization exists now
 
-StoreKit 2, Jefe Pro at $12.99/mo, free tier 5 finished walks a month
+StoreKit 2, Jefe Pro at $19.99/mo, free tier 5 finished walks a month
 (#277, #279, #281).
 
 - Metered on **output**, not on tapping START — a walk that produces nothing is
@@ -367,7 +367,7 @@ walking 101 once.
 "photos vanish" half), #225, #228, #284, #289.
 
 **Isaac's, and they gate submission**: create the ASC subscription
-(`com.damsac.jefe.pro.monthly`, $12.99/mo) + Paid Apps agreements; the App
+(`com.damsac.jefe.pro.monthly`, $19.99/mo) + Paid Apps agreements; the App
 Privacy answers (exact clicks in `docs/store/SUBMISSION-KIT.md` §4); a sandbox
 purchase on device. **Nothing about billing has ever been observed working** —
 no product exists, so the paywall shows no price and the meter is untested in

--- a/meta/dam/BEFORE-THE-MONTH-AWAY.md
+++ b/meta/dam/BEFORE-THE-MONTH-AWAY.md
@@ -191,7 +191,7 @@ becomes a sac-side feature that can ship in 1.1. Without them it waits a month.
 **This is the single highest-leverage hour of core work available.** If you
 think landing a capability with no consumer is wrong, say so on the issue.
 
-### 3.2 App Attest server half
+### 3.2 App Attest — server half DONE (#315), device half is yours (#316)
 
 Hard prerequisite for a **public** listing. Not for TestFlight.
 
@@ -202,7 +202,29 @@ State the exposure accurately: the **global $25/day cap holds**, so this is
 ~$750/month worst case, not unbounded. The real risk is **availability** — an
 abuser burning the global cap denies service to paying subscribers mid-job.
 
-Needs a device session; attestation cannot be exercised in the simulator.
+**Update 2026-08-08.** I wrote the server half — #315. Chain verification to
+Apple's root, the nonce/keyId/rpId/counter/aaguid checks, assertion counter
+replay protection, and an hourly token so the app asserts once an hour rather
+than once per message. It ships **inert**: `ATTEST_MODE=off`, and nothing on
+the device attests yet, so merging changes nothing about the running service.
+
+The device half is #316 — `DCAppAttestService`, the entitlement, token caching,
+and the `jefeA.` credential. Yours, because it touches app identity and
+provisioning.
+
+**The one thing I could not test.** The sandbox had no network, so I could not
+fetch Apple's real root CA, and I was not willing to paste in a certificate I
+could not verify. The tests build a synthetic chain with real ECDSA keys — that
+proves every check fires on every malformation I could construct (verified by
+mutation), but it means **the verifier has never seen a genuine Apple chain.**
+
+That closes only on a device: configure the worker, `ATTEST_MODE=monitor`, one
+real attestation from a TestFlight build, confirm `attest_ok` in the logs and
+not `chain_signature_invalid`. If it fails, the suspects are all in
+`services/proxy/src/der.ts` and all have unit tests to extend.
+
+Rollout is `off` → `monitor` → `enforce`, and `monitor` is not skippable —
+`enforce` before builds carry the device half locks out every install we have.
 
 ### 3.3 The device session you have been carrying
 
@@ -246,7 +268,7 @@ Options — create silently (manufactures records from a mishearing), suggest on
 the notes screen and let them confirm (R6-shaped), or nothing in v1. I lean
 suggest-and-confirm but the extraction pass is yours.
 
-### 3.6 The CI upload-quota guard (#304) — your call, my proposal
+### 3.6 The CI upload-quota guard (#304) — written, DRAFT PR #314, your call
 
 Rather than cancelling in-flight runs (`cancel-in-progress` is `false` and I
 read that as deliberate), **skip only the ASC upload when `github.sha` is no
@@ -263,8 +285,21 @@ longer the tip of main**:
 ```
 
 Nothing is ever cancelled mid-`altool`; ten rapid merges cost one slot; tags
-unaffected. **I did not change `release.yml` myself** — if I break it while you
-are away, nobody ships for four weeks.
+unaffected.
+
+**Update 2026-08-08.** I wrote it — **#314, left as a DRAFT on purpose.**
+`release.yml` is the one file that strands everyone if it breaks while you are
+away, and this is a convenience fix for a problem I caused, so the decision is
+yours rather than mine. Nothing changes until you click merge.
+
+Shipped version differs from the sketch above in two ways, both deliberate:
+`git ls-remote` instead of `rev-parse origin/main` (one network call, correct
+under `actions/checkout`'s shallow clone), and it **fails open** — if
+`ls-remote` returns nothing the guard is skipped, because burning a quota slot
+is a much better failure than silently not shipping. Guard is scoped to the
+`internal` lane only; tags and `workflow_dispatch` always upload.
+
+Rejecting it outright is a defensible answer. I will just keep batching merges.
 
 ---
 

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -289,7 +289,7 @@ Merged since the last handover: **#277** (StoreKit 2 + the free-tier meter +
 **#267**, which I rebased onto main and merged — a filed walk was still showing
 twice and that was the real half of the "random walks" report.
 
-**Monetization** is Jefe Pro at $12.99/mo, free tier 5 finished walks a month.
+**Monetization** is Jefe Pro at $19.99/mo, free tier 5 finished walks a month.
 Metering is on OUTPUT, not on tapping START; the gate runs at `startWalk()` so a
 refusal can never destroy a recording already made. Practice and demo walks are
 exempt — neither costs anything, and metering demo would break autoflow QA at

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -18,6 +18,17 @@ If you have one hour: **§2.1** (my core change — it replaced a named test of
 yours), **§3.1** (#263), **§4.1** (the ASC key, which has now blocked me twice),
 **§4.2** (do the certs outlive the trip?).
 
+**Since then (2026-08-08), two of your queued items now have code waiting:**
+
+- **#315 — App Attest server half** (§3.2). Verification is written and tested;
+  ships inert behind `ATTEST_MODE=off`. Device half is #316, and it is yours.
+  The residual risk is that the verifier has never seen a *genuine* Apple chain
+  — the sandbox had no network to fetch the real root, so the tests use a
+  synthetic one. That closes with one real attestation in `monitor` mode.
+- **#314 — the CI upload guard** (§3.6). **Deliberately left a DRAFT.**
+  `release.yml` strands everyone if it breaks while you are away, and this is a
+  convenience fix for a problem I caused. Merge, change, or reject — your call.
+
 The sections below are the older, longer-form context. The handover doc
 supersedes them where they disagree.
 

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -36,10 +36,74 @@ becomes downloadable by anyone rather than by testers you invited.
 the app asks the Secure Enclave for a hardware-backed key plus an attestation
 blob; the server validates that blob against Apple's certificate chain and
 pins the key id; every later request carries an assertion signed by that key.
-The seam for it is `authenticate()` in `src/auth.ts` — Phase 2 replaces that
-function's body and adds a key-id store. Nothing else in the worker changes.
 
-Until then, **the daily spend cap is the thing protecting you.** Keep it low.
+### Status: server half done, device half not
+
+`src/attest.ts` implements the verification, and it is wired in behind
+`ATTEST_MODE`, which ships as `off`. **Nothing about the running service has
+changed yet.** What is missing is the iOS side: `DCAppAttestService` key
+generation, the enrolment calls, token caching, and the credential change.
+
+Until the device half lands and has been soaked in `monitor`, **the daily spend
+cap is still the thing protecting you.** Keep it low.
+
+### The exchange
+
+```
+1.  app → POST /v1/attest/challenge        (Phase 1 credential)
+    srv → { challenge, expires_in }        one-time, 5 minutes
+
+2.  app   generates a Secure Enclave key, attests it over the challenge
+    app → POST /v1/attest/attest           { key_id, challenge, attestation }
+    srv   verifies the chain to Apple's root, stores the public key
+
+3.  app → POST /v1/attest/assert           { key_id, challenge, assertion }
+    srv → { token, expires_in }            1 hour
+
+4.  app → POST /v1/messages                credential carries the token
+```
+
+Steps 1–3 run once an hour, not once per message — asserting per request would
+double the round trips on the cellular link this app actually runs on.
+
+### The credential change
+
+`/v1/messages` has nowhere to put a token except the credential field itself,
+because the Rust provider sends `config.api_key` as the only caller-controlled
+header. So Phase 2 adds a second wire format alongside the first:
+
+```
+jefe.<installId>.<appSecret>                     # Phase 1, still accepted
+jefeA.<installId>.<attestToken>~<appSecret>      # Phase 2
+```
+
+The app secret is still checked on attested credentials. Attestation adds a
+layer; it does not remove the one underneath.
+
+### Rolling it out
+
+Move one notch at a time, and never skip `monitor`:
+
+| `ATTEST_MODE` | Behaviour |
+|---|---|
+| `off` (default) | Tokens ignored entirely. |
+| `monitor` | Tokens verified and logged; failures never block a request. |
+| `enforce` | `/v1/messages` requires a valid token. |
+
+`monitor` is what tells you whether `enforce` is safe. Watch for
+`attest_token_rejected` in the logs; the count should fall to roughly zero as
+builds carrying the device half roll out. Going straight to `enforce` bricks
+every already-installed build the moment it lands, testers included.
+
+Anything unrecognised in `ATTEST_MODE` means `off`, so a typo cannot lock the
+fleet out. But `monitor`/`enforce` with missing config is a hard 500 — asking
+for enforcement and quietly getting none is worse than a visibly failed deploy.
+
+### What is deliberately not implemented
+
+The attestation `receipt` is parsed but never sent to Apple for risk metrics or
+key-refresh checks. That is a separate Apple endpoint with its own auth, it is
+optional, and half-shipping it would be worse than not shipping it.
 
 ---
 
@@ -141,6 +205,18 @@ Covers pricing (including the deliberate over-estimate for unknown models),
 credential parsing and rejection, the credential-for-key swap, byte-identical
 body forwarding, both caps refusing *before* upstream is called, fail-closed on
 misconfiguration, and upstream error pass-through.
+
+The attestation tests build a **real certificate chain with real ECDSA keys**
+(`test/appattest-fixtures.ts`) rather than replaying a captured attestation.
+That is the point: holding the private keys means a test can change exactly one
+thing — the challenge, the counter, the aaguid, the signing CA — and assert
+that *that specific check* is what rejects it. A recorded blob can only ever
+prove one happy path, and every negative test against it degenerates into
+"garbage in, error out", which a verifier that rejects everything would also
+pass.
+
+What the synthetic chain cannot prove is that we accept **Apple's** real root.
+That is the residual risk, and the reason the rollout starts in `monitor`.
 
 These are **not** wired into the repo's GitHub Actions CI, which is Rust +
 iOS only. Run them locally before deploying.

--- a/services/proxy/src/attest.ts
+++ b/services/proxy/src/attest.ts
@@ -1,0 +1,626 @@
+/**
+ * App Attest — the server half of Phase 2.
+ *
+ * ## What problem this actually solves
+ *
+ * `auth.ts` is honest that Phase 1 is identification with a speed bump: the
+ * shared app secret ships inside the IPA, so anyone who unzips a build can mint
+ * a valid-looking credential and spend against the cap. That is tolerable while
+ * the only installs are testers we invited by email. It stops being tolerable
+ * the day the App Store listing goes public, because the binary becomes
+ * downloadable by anyone.
+ *
+ * App Attest replaces "knows a secret baked into the app" with "holds a private
+ * key the Secure Enclave generated, on real Apple hardware, in a genuine,
+ * unmodified copy of *this* app". The key is non-exportable — extracting it
+ * from a device is not a matter of effort.
+ *
+ * ## The shape of the exchange
+ *
+ *   1. app  → `POST /v1/attest/challenge`   (Phase 1 credential)
+ *      srv  → a one-time 32-byte challenge
+ *   2. app  generates a Secure Enclave key, attests it over the challenge
+ *      app  → `POST /v1/attest/attest`      { keyId, attestation }
+ *      srv  verifies the chain to Apple's root, stores the public key
+ *   3. app  → `POST /v1/attest/assert`      { keyId, assertion, challenge }
+ *      srv  → a short-lived bearer token
+ *   4. app  → `POST /v1/messages` carrying that token
+ *
+ * Steps 1–3 happen once per token lifetime (an hour), not once per message.
+ * Asserting on every request would double the round trips on a cellular link
+ * at a job site, which is the exact condition this app runs in.
+ *
+ * ## Why the token, rather than an assertion per message
+ *
+ * Also a plumbing constraint. The Rust provider sends `config.api_key` as the
+ * only caller-controlled header, so `/v1/messages` has nowhere to put an
+ * assertion (see `auth.ts`). A compact token fits in the credential string; a
+ * CBOR assertion does not.
+ *
+ * ## Deliberately NOT implemented
+ *
+ * The attestation `receipt` is parsed out but not sent to Apple's server for
+ * risk metrics or key-refresh checks. That is a separate Apple endpoint with
+ * its own auth, it is optional, and shipping it half-done would be worse than
+ * not shipping it. Tracked as a follow-up.
+ */
+
+import {
+  bytesField,
+  decodeCbor,
+  mapField,
+  textField,
+  type CborValue,
+} from './cbor';
+import {
+  componentSize,
+  content,
+  children,
+  decodeOid,
+  ecdsaDerToRaw,
+  parseCertificate,
+  parseTlv,
+  pemToDer,
+  type Certificate,
+} from './der';
+
+export class AttestError extends Error {
+  constructor(
+    message: string,
+    /** Stable, non-identifying reason code. Safe to log; safe to return. */
+    readonly code: string
+  ) {
+    super(message);
+  }
+}
+
+/** Apple's certificate extension carrying the attestation nonce. */
+const NONCE_EXTENSION_OID = '1.2.840.113635.100.8.2';
+
+/** The 16-byte aaguid Apple stamps into attested credential data. */
+const AAGUID_PRODUCTION = 'appattest\0\0\0\0\0\0\0';
+const AAGUID_DEVELOPMENT = 'appattestdevelop';
+
+/** Attestations larger than this are not real. Bounds the parser's work. */
+const MAX_ATTESTATION_BYTES = 64 * 1024;
+const MAX_ASSERTION_BYTES = 8 * 1024;
+
+/** How long a challenge stays claimable. Also KV's floor is 60s. */
+export const CHALLENGE_TTL_SECONDS = 300;
+/** How long an attestation token is good for before the app must re-assert. */
+export const TOKEN_TTL_SECONDS = 60 * 60;
+/** Attested keys outlive tokens by a lot — re-attesting is the expensive step. */
+const KEY_TTL_SECONDS = 60 * 60 * 24 * 400;
+
+// ------------------------------------------------------------------ bytes
+
+export function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function fromBase64(text: string): Uint8Array {
+  const normalised = text.replace(/-/g, '+').replace(/_/g, '/');
+  let binary: string;
+  try {
+    binary = atob(normalised);
+  } catch {
+    throw new AttestError('value is not valid base64', 'malformed_base64');
+  }
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  // `?? 0` never fires — lengths are equal — but keeps the loop branch-free
+  // under `noUncheckedIndexedAccess`, which matters for a constant-time compare.
+  for (let i = 0; i < a.length; i++) diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  return diff === 0;
+}
+
+/** Copies a view into a standalone buffer before handing it to Web Crypto. */
+function copy(bytes: Uint8Array): Uint8Array {
+  return new Uint8Array(bytes);
+}
+
+async function sha256(...parts: Uint8Array[]): Promise<Uint8Array> {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.length;
+  }
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', joined));
+}
+
+// ------------------------------------------------------------- signatures
+
+async function importVerifyKey(spki: Uint8Array, curve: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'spki',
+    copy(spki),
+    { name: 'ECDSA', namedCurve: curve },
+    false,
+    ['verify']
+  );
+}
+
+/**
+ * Verifies an ECDSA signature over `message`.
+ *
+ * Note the message is passed UNHASHED — Web Crypto applies the digest itself.
+ * Apple's documentation describes the signed value as the SHA-256 "nonce", but
+ * that nonce *is* the digest ECDSA computes, so hashing first here would sign
+ * the wrong thing (a double hash) and nothing would ever verify.
+ */
+async function verifyEcdsa(
+  key: CryptoKey,
+  derSignature: Uint8Array,
+  message: Uint8Array,
+  hash: string,
+  curve: string
+): Promise<boolean> {
+  const rawSignature = ecdsaDerToRaw(derSignature, componentSize(curve));
+  return crypto.subtle.verify(
+    { name: 'ECDSA', hash },
+    key,
+    copy(rawSignature),
+    copy(message)
+  );
+}
+
+// --------------------------------------------------------- authenticator data
+
+export interface AuthenticatorData {
+  rpIdHash: Uint8Array;
+  flags: number;
+  signCount: number;
+  aaguid?: Uint8Array;
+  credentialId?: Uint8Array;
+}
+
+/**
+ * Parses WebAuthn authenticator data.
+ *
+ * Layout: 32-byte rpIdHash, 1 flag byte, 4-byte big-endian counter, then — on
+ * attestation only — 16-byte aaguid, a 2-byte credential id length, and the
+ * credential id.
+ */
+export function parseAuthenticatorData(bytes: Uint8Array): AuthenticatorData {
+  if (bytes.length < 37) {
+    throw new AttestError('authenticator data is too short', 'bad_auth_data');
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const base: AuthenticatorData = {
+    rpIdHash: bytes.subarray(0, 32),
+    flags: bytes[32] ?? 0,
+    signCount: view.getUint32(33),
+  };
+  if (bytes.length === 37) return base;
+
+  if (bytes.length < 55) {
+    throw new AttestError('attested credential data is truncated', 'bad_auth_data');
+  }
+  const credentialIdLength = view.getUint16(53);
+  if (bytes.length < 55 + credentialIdLength) {
+    throw new AttestError('credential id runs past the buffer', 'bad_auth_data');
+  }
+  return {
+    ...base,
+    aaguid: bytes.subarray(37, 53),
+    credentialId: bytes.subarray(55, 55 + credentialIdLength),
+  };
+}
+
+// ------------------------------------------------------------ chain checks
+
+/** Pulls the attestation nonce out of Apple's certificate extension. */
+function nonceFromCertificate(cert: Certificate): Uint8Array {
+  const extension = cert.extensions.get(NONCE_EXTENSION_OID);
+  if (!extension) {
+    throw new AttestError('credential certificate has no nonce extension', 'no_nonce_extension');
+  }
+  // SEQUENCE { [1] EXPLICIT { OCTET STRING nonce } }
+  const outer = parseTlv(extension, 0);
+  const tagged = children(extension, outer)[0];
+  if (!tagged) throw new AttestError('nonce extension is empty', 'bad_nonce_extension');
+  const octets = children(extension, tagged)[0];
+  if (!octets || octets.tag !== 0x04) {
+    throw new AttestError('nonce extension does not hold an OCTET STRING', 'bad_nonce_extension');
+  }
+  return content(extension, octets);
+}
+
+/**
+ * Verifies `leaf → … → root`, where `root` is the pinned Apple certificate.
+ *
+ * Each certificate must be signed by the next, its issuer name must match that
+ * signer's subject, and it must be inside its validity window. The root is
+ * trusted because it was configured, not because it is self-signed — checking
+ * a self-signature proves nothing about who issued it.
+ */
+async function verifyChain(chain: Certificate[], root: Certificate, now: Date): Promise<void> {
+  const path = [...chain, root];
+
+  for (const cert of path) {
+    if (now < cert.notBefore || now > cert.notAfter) {
+      throw new AttestError('a certificate in the chain is outside its validity window', 'cert_expired');
+    }
+  }
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const subject = path[i];
+    const issuer = path[i + 1];
+    if (!subject || !issuer) throw new AttestError('certificate chain is malformed', 'chain_broken');
+
+    if (!equalBytes(subject.issuer, issuer.subject)) {
+      throw new AttestError('certificate chain does not link', 'chain_broken');
+    }
+
+    const key = await importVerifyKey(issuer.spki, issuer.curve);
+    const ok = await verifyEcdsa(
+      key,
+      subject.signature,
+      subject.tbs,
+      subject.signatureHash,
+      issuer.curve
+    );
+    if (!ok) {
+      throw new AttestError('certificate signature does not verify', 'chain_signature_invalid');
+    }
+  }
+}
+
+// ------------------------------------------------------------- attestation
+
+export interface AttestationConfig {
+  /** `TEAMID.bundle.id` — what the device hashed into `rpIdHash`. */
+  appId: string;
+  /** Apple's App Attest root, PEM encoded. */
+  rootCaPem: string;
+  /** Whether to accept the development aaguid. False in production. */
+  allowDevelopment: boolean;
+}
+
+export interface AttestedKey {
+  /** SPKI of the attested key, base64. */
+  spki: string;
+  curve: string;
+  /** Highest sign count seen. Replay protection. */
+  counter: number;
+  /** The install this key belongs to. A key is not transferable. */
+  installId: string;
+  attestedAt: number;
+}
+
+/**
+ * Verifies an attestation object and returns the key to remember.
+ *
+ * Follows Apple's documented order. Every step is a real check — none of them
+ * are ceremony, and skipping any one of them makes the rest decorative:
+ *
+ *  1. chain to Apple's root      — proves Apple issued this key's certificate
+ *  2. nonce binds the challenge  — proves this attestation is fresh, not replayed
+ *  3. key id is the key's hash   — proves the client named the key it attested
+ *  4. rpIdHash matches our appId — proves it is *our* app, not another one
+ *  5. counter is zero            — proves the key is brand new
+ *  6. aaguid is Apple's          — proves the environment (prod vs development)
+ */
+export async function verifyAttestation(
+  attestationObject: Uint8Array,
+  keyId: Uint8Array,
+  challenge: Uint8Array,
+  config: AttestationConfig,
+  now: Date = new Date()
+): Promise<{ spki: Uint8Array; curve: string; receipt?: Uint8Array }> {
+  if (attestationObject.length > MAX_ATTESTATION_BYTES) {
+    throw new AttestError('attestation object is implausibly large', 'too_large');
+  }
+
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(attestationObject);
+  } catch (error) {
+    throw new AttestError(`attestation is not valid CBOR: ${error}`, 'malformed_cbor');
+  }
+
+  const fmt = textField(decoded, 'fmt');
+  if (fmt !== 'apple-appattest') {
+    throw new AttestError(`unexpected attestation format "${fmt}"`, 'bad_format');
+  }
+
+  const authData = bytesField(decoded, 'authData');
+  const attStmt = mapField(decoded, 'attStmt');
+  const x5cRaw = mapField(attStmt, 'x5c');
+  if (!Array.isArray(x5cRaw) || x5cRaw.length < 2) {
+    throw new AttestError('attestation statement has no certificate chain', 'no_chain');
+  }
+
+  let chain: Certificate[];
+  let root: Certificate;
+  try {
+    chain = x5cRaw.map((entry) => {
+      if (!(entry instanceof Uint8Array)) throw new Error('x5c entry is not a byte string');
+      return parseCertificate(entry);
+    });
+    root = parseCertificate(pemToDer(config.rootCaPem));
+  } catch (error) {
+    throw new AttestError(`certificate parse failed: ${error}`, 'bad_certificate');
+  }
+
+  // 1. chain
+  await verifyChain(chain, root, now);
+  const credCert = chain[0];
+  if (!credCert) throw new AttestError('attestation has no leaf certificate', 'no_chain');
+
+  // 2. nonce — SHA256(authData ‖ SHA256(challenge)), inside Apple's extension
+  const clientDataHash = await sha256(challenge);
+  const expectedNonce = await sha256(authData, clientDataHash);
+  if (!equalBytes(nonceFromCertificate(credCert), expectedNonce)) {
+    throw new AttestError('attestation nonce does not match the challenge', 'nonce_mismatch');
+  }
+
+  // 3. key id is the hash of the attested public key
+  const publicKeyHash = await sha256(credCert.publicKeyPoint);
+  if (!equalBytes(publicKeyHash, keyId)) {
+    throw new AttestError('key id is not the hash of the attested key', 'key_id_mismatch');
+  }
+
+  const parsed = parseAuthenticatorData(authData);
+
+  // 4. this is our app
+  const expectedRpId = await sha256(new TextEncoder().encode(config.appId));
+  if (!equalBytes(parsed.rpIdHash, expectedRpId)) {
+    throw new AttestError('attestation is for a different app id', 'app_id_mismatch');
+  }
+
+  // 5. a freshly generated key has never signed anything
+  if (parsed.signCount !== 0) {
+    throw new AttestError('attested key has a non-zero counter', 'counter_not_zero');
+  }
+
+  // 6. environment
+  const aaguid = new TextDecoder('utf-8').decode(parsed.aaguid ?? new Uint8Array());
+  const acceptable = config.allowDevelopment
+    ? [AAGUID_PRODUCTION, AAGUID_DEVELOPMENT]
+    : [AAGUID_PRODUCTION];
+  if (!acceptable.includes(aaguid)) {
+    // Rejecting the development aaguid in production is the whole reason this
+    // is configurable: a development attestation can be produced from a build
+    // signed with a development profile, which is a much lower bar.
+    throw new AttestError('unexpected attestation environment', 'bad_aaguid');
+  }
+
+  if (!parsed.credentialId || !equalBytes(parsed.credentialId, keyId)) {
+    throw new AttestError('credential id does not match the key id', 'credential_id_mismatch');
+  }
+
+  const receipt = attStmt instanceof Map ? attStmt.get('receipt') : undefined;
+  return {
+    spki: credCert.spki,
+    curve: credCert.curve,
+    receipt: receipt instanceof Uint8Array ? receipt : undefined,
+  };
+}
+
+// --------------------------------------------------------------- assertion
+
+/**
+ * Verifies an assertion against a previously attested key.
+ *
+ * Returns the new counter, which the caller must persist. The counter is the
+ * only replay defence once a challenge has been consumed: Secure Enclave
+ * increments it on every signature, so a captured assertion replayed later
+ * carries a counter that is no longer strictly greater.
+ */
+export async function verifyAssertion(
+  assertionObject: Uint8Array,
+  challenge: Uint8Array,
+  key: { spki: Uint8Array; curve: string; counter: number },
+  appId: string
+): Promise<{ counter: number }> {
+  if (assertionObject.length > MAX_ASSERTION_BYTES) {
+    throw new AttestError('assertion is implausibly large', 'too_large');
+  }
+
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(assertionObject);
+  } catch (error) {
+    throw new AttestError(`assertion is not valid CBOR: ${error}`, 'malformed_cbor');
+  }
+
+  const signature = bytesField(decoded, 'signature');
+  const authData = bytesField(decoded, 'authenticatorData');
+
+  const clientDataHash = await sha256(challenge);
+  const message = new Uint8Array(authData.length + clientDataHash.length);
+  message.set(authData, 0);
+  message.set(clientDataHash, authData.length);
+
+  const verifyKey = await importVerifyKey(key.spki, key.curve);
+  const ok = await verifyEcdsa(verifyKey, signature, message, 'SHA-256', key.curve);
+  if (!ok) throw new AttestError('assertion signature does not verify', 'assertion_invalid');
+
+  const parsed = parseAuthenticatorData(authData);
+
+  const expectedRpId = await sha256(new TextEncoder().encode(appId));
+  if (!equalBytes(parsed.rpIdHash, expectedRpId)) {
+    throw new AttestError('assertion is for a different app id', 'app_id_mismatch');
+  }
+
+  if (parsed.signCount <= key.counter) {
+    throw new AttestError('assertion counter did not advance', 'counter_replay');
+  }
+
+  return { counter: parsed.signCount };
+}
+
+// ------------------------------------------------------------------ token
+
+/**
+ * A short-lived bearer token, minted after a successful assertion.
+ *
+ * `jat.<payload>.<mac>`, both base64url. The payload names the install, the
+ * key and an expiry; the MAC is HMAC-SHA256 under the app secret. Note this
+ * means the token's unforgeability rests on a secret that also ships in the
+ * binary — so a token is NOT stronger than Phase 1 on its own. What it is, is
+ * a receipt that a real attestation happened within the last hour, which an
+ * extracted secret alone cannot produce.
+ */
+interface TokenPayload {
+  i: string;
+  k: string;
+  e: number;
+}
+
+async function macKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
+
+export async function mintToken(
+  secret: string,
+  installId: string,
+  keyId: string,
+  now: Date = new Date()
+): Promise<string> {
+  const payload: TokenPayload = {
+    i: installId,
+    k: keyId,
+    e: Math.floor(now.getTime() / 1000) + TOKEN_TTL_SECONDS,
+  };
+  const encoded = toBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  const mac = await crypto.subtle.sign('HMAC', await macKey(secret), new TextEncoder().encode(encoded));
+  return `jat.${encoded}.${toBase64Url(new Uint8Array(mac))}`;
+}
+
+export type TokenFailure =
+  | 'malformed'
+  | 'bad_signature'
+  | 'expired'
+  | 'wrong_install';
+
+export type TokenResult =
+  | { ok: true; keyId: string }
+  | { ok: false; reason: TokenFailure };
+
+export async function verifyToken(
+  secret: string,
+  token: string,
+  installId: string,
+  now: Date = new Date()
+): Promise<TokenResult> {
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[0] !== 'jat') return { ok: false, reason: 'malformed' };
+  const encoded = parts[1];
+  const mac = parts[2];
+  if (!encoded || !mac) return { ok: false, reason: 'malformed' };
+
+  // `crypto.subtle.verify` is constant time, which matters: a `===` here would
+  // leak the MAC one byte at a time to anyone who can measure latency.
+  let valid: boolean;
+  try {
+    valid = await crypto.subtle.verify(
+      'HMAC',
+      await macKey(secret),
+      copy(fromBase64(mac)),
+      new TextEncoder().encode(encoded)
+    );
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (!valid) return { ok: false, reason: 'bad_signature' };
+
+  let payload: TokenPayload;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(fromBase64(encoded)));
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (typeof payload.e !== 'number' || typeof payload.i !== 'string') {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (payload.e * 1000 <= now.getTime()) return { ok: false, reason: 'expired' };
+  // A token is bound to the install that earned it, so a leaked token cannot
+  // be pasted into someone else's credential to dodge their spend cap.
+  if (payload.i !== installId) return { ok: false, reason: 'wrong_install' };
+
+  return { ok: true, keyId: payload.k };
+}
+
+// --------------------------------------------------------------- KV access
+
+export function challengeKey(challenge: string): string {
+  return `attest:chal:${challenge}`;
+}
+
+export function attestedKeyKey(keyId: string): string {
+  return `attest:key:${keyId}`;
+}
+
+export async function issueChallenge(kv: KVNamespace, installId: string): Promise<string> {
+  const challenge = toBase64Url(crypto.getRandomValues(new Uint8Array(32)));
+  await kv.put(challengeKey(challenge), installId, { expirationTtl: CHALLENGE_TTL_SECONDS });
+  return challenge;
+}
+
+/**
+ * Claims a challenge, which must have been issued to this same install.
+ *
+ * KV is eventually consistent, so "delete on use" is best-effort rather than a
+ * hard single-use guarantee — two requests racing the same challenge inside the
+ * replication window can both succeed. That is acceptable here because the
+ * challenge is only a freshness bound: replaying an attestation twice in five
+ * minutes gets an attacker a second copy of a token they already had. Durable
+ * Objects would make it exact, and are the upgrade path if that ever matters.
+ */
+export async function claimChallenge(
+  kv: KVNamespace,
+  challenge: string,
+  installId: string
+): Promise<boolean> {
+  const owner = await kv.get(challengeKey(challenge));
+  if (owner !== installId) return false;
+  await kv.delete(challengeKey(challenge));
+  return true;
+}
+
+export async function loadAttestedKey(
+  kv: KVNamespace,
+  keyId: string
+): Promise<AttestedKey | null> {
+  const raw = await kv.get(attestedKeyKey(keyId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AttestedKey;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveAttestedKey(
+  kv: KVNamespace,
+  keyId: string,
+  key: AttestedKey
+): Promise<void> {
+  await kv.put(attestedKeyKey(keyId), JSON.stringify(key), { expirationTtl: KEY_TTL_SECONDS });
+}
+
+/** Key ids are base64 of a SHA-256; anything else is not one. */
+export function isPlausibleKeyId(keyId: string): boolean {
+  return /^[A-Za-z0-9+/_-]{43,44}={0,2}$/.test(keyId);
+}
+
+/** Re-exported so the router can decode without importing der.ts. */
+export { decodeOid };

--- a/services/proxy/src/auth.ts
+++ b/services/proxy/src/auth.ts
@@ -28,11 +28,31 @@
  */
 const PREFIX = 'jefe.';
 
+/**
+ * Phase 2 wire format: `jefeA.<installId>.<attestToken>~<appSecret>`.
+ *
+ * Same one-field constraint, one more value to carry. The `~` separator is
+ * deliberate rather than another dot: the token is itself dotted
+ * (`jat.<payload>.<mac>`), so a pure-dot format would need the parser to know
+ * the token's internal shape to find the secret. `~` appears in neither
+ * base64url nor an install id, so the boundary is unambiguous no matter how
+ * the token is later restructured.
+ *
+ * `jefe.` credentials keep working. Attestation is additive — a build that
+ * predates it must not stop being able to talk to the proxy.
+ */
+const PREFIX_ATTESTED = 'jefeA.';
+
 /** UUID-ish: hex and dashes, bounded so a huge value can't be used as a KV-key DoS. */
 const INSTALL_ID_RE = /^[a-zA-Z0-9-]{8,64}$/;
 
+/** Bounds the token before any crypto touches it. */
+const MAX_TOKEN_LENGTH = 512;
+
 export interface Credential {
   installId: string;
+  /** Present only on `jefeA.` credentials. Unverified at this layer. */
+  attestToken?: string;
 }
 
 export type AuthFailure = 'missing' | 'malformed' | 'bad_secret';
@@ -70,19 +90,35 @@ function timingSafeEqual(a: string, b: string): boolean {
 export function authenticate(headers: Headers, appSecret: string): AuthResult {
   const raw = readRawCredential(headers);
   if (!raw) return { ok: false, reason: 'missing' };
-  if (!raw.startsWith(PREFIX)) return { ok: false, reason: 'malformed' };
 
-  // Split off the prefix, then take the FIRST separator as the id/secret
-  // boundary — the secret itself may legitimately contain dots.
-  const rest = raw.slice(PREFIX.length);
+  // Check the longer prefix first — `jefeA.` also starts with `jefe`, though
+  // not with `jefe.`, so order is belt-and-braces rather than load-bearing.
+  const attested = raw.startsWith(PREFIX_ATTESTED);
+  if (!attested && !raw.startsWith(PREFIX)) return { ok: false, reason: 'malformed' };
+
+  // Split off the prefix, then take the FIRST separator as the id boundary —
+  // the secret itself may legitimately contain dots.
+  const rest = raw.slice((attested ? PREFIX_ATTESTED : PREFIX).length);
   const sep = rest.indexOf('.');
   if (sep <= 0) return { ok: false, reason: 'malformed' };
 
   const installId = rest.slice(0, sep);
-  const secret = rest.slice(sep + 1);
+  let remainder = rest.slice(sep + 1);
   if (!INSTALL_ID_RE.test(installId)) return { ok: false, reason: 'malformed' };
-  if (secret.length === 0) return { ok: false, reason: 'malformed' };
-  if (!timingSafeEqual(secret, appSecret)) return { ok: false, reason: 'bad_secret' };
 
-  return { ok: true, credential: { installId } };
+  let attestToken: string | undefined;
+  if (attested) {
+    const tilde = remainder.indexOf('~');
+    if (tilde <= 0) return { ok: false, reason: 'malformed' };
+    attestToken = remainder.slice(0, tilde);
+    remainder = remainder.slice(tilde + 1);
+    if (attestToken.length > MAX_TOKEN_LENGTH) return { ok: false, reason: 'malformed' };
+  }
+
+  if (remainder.length === 0) return { ok: false, reason: 'malformed' };
+  // The secret is still checked on attested credentials. Attestation adds a
+  // layer; it does not replace the one underneath it.
+  if (!timingSafeEqual(remainder, appSecret)) return { ok: false, reason: 'bad_secret' };
+
+  return { ok: true, credential: { installId, attestToken } };
 }

--- a/services/proxy/src/cbor.ts
+++ b/services/proxy/src/cbor.ts
@@ -1,0 +1,191 @@
+/**
+ * A deliberately tiny CBOR decoder (RFC 8949).
+ *
+ * App Attest hands us two CBOR blobs — the attestation object and each
+ * assertion — and Workers ship no CBOR primitive. Rather than take a
+ * dependency for two call sites, this decodes only the subset Apple actually
+ * emits: unsigned ints, byte strings, text strings, arrays and maps.
+ *
+ * Everything else THROWS rather than being tolerated. That is the point. A
+ * decoder that shrugs at input it doesn't understand is exactly how a parser
+ * becomes an attack surface, and the only writer we accept input from is
+ * Apple's attestation framework, whose output shape is fixed. If this ever
+ * throws on a real device, the right fix is to widen it deliberately — not to
+ * make it lenient.
+ */
+
+export class CborError extends Error {}
+
+export type CborValue =
+  | number
+  | string
+  | Uint8Array
+  | CborValue[]
+  | Map<string | number, CborValue>;
+
+interface Cursor {
+  buf: Uint8Array;
+  view: DataView;
+  pos: number;
+}
+
+/** Bounds check. Every read goes through this — a truncated blob must throw, not read garbage. */
+function need(c: Cursor, n: number): void {
+  if (c.pos + n > c.buf.length) {
+    throw new CborError(`truncated: needed ${n} bytes at ${c.pos}, have ${c.buf.length - c.pos}`);
+  }
+}
+
+/**
+ * Bounds-checked byte read.
+ *
+ * `need` has already proven the bound at every call site; this exists because
+ * `noUncheckedIndexedAccess` is on and silencing it with `!` would make the
+ * next edit to `need` fail silently instead of loudly.
+ */
+function byteAt(c: Cursor, index: number): number {
+  const value = c.buf[index];
+  if (value === undefined) throw new CborError('read past the end of the buffer');
+  return value;
+}
+
+/**
+ * Reads an initial byte and its argument.
+ *
+ * Lengths are capped at `Number.MAX_SAFE_INTEGER` semantics by construction —
+ * a 64-bit argument is assembled as a float64, which is fine because anything
+ * over ~8MB is rejected by the caller's size limit long before precision
+ * matters.
+ */
+function readHead(c: Cursor): { major: number; arg: number } {
+  need(c, 1);
+  const initial = byteAt(c, c.pos++);
+  const major = initial >> 5;
+  const info = initial & 0x1f;
+
+  if (info < 24) return { major, arg: info };
+  if (info === 24) {
+    need(c, 1);
+    return { major, arg: byteAt(c, c.pos++) };
+  }
+  if (info === 25) {
+    need(c, 2);
+    const arg = c.view.getUint16(c.pos);
+    c.pos += 2;
+    return { major, arg };
+  }
+  if (info === 26) {
+    need(c, 4);
+    const arg = c.view.getUint32(c.pos);
+    c.pos += 4;
+    return { major, arg };
+  }
+  if (info === 27) {
+    need(c, 8);
+    const hi = c.view.getUint32(c.pos);
+    const lo = c.view.getUint32(c.pos + 4);
+    c.pos += 8;
+    return { major, arg: hi * 2 ** 32 + lo };
+  }
+  // 28-30 are reserved; 31 is indefinite length, which Apple never emits and
+  // which is the classic source of unbounded-allocation bugs.
+  throw new CborError(`unsupported additional info ${info}`);
+}
+
+function readValue(c: Cursor, depth: number): CborValue {
+  // Nesting is 3 deep in the real payloads. The cap stops a hostile blob from
+  // recursing the stack to death before any length check can fire.
+  if (depth > 16) throw new CborError('nesting too deep');
+
+  const { major, arg } = readHead(c);
+
+  switch (major) {
+    case 0: // unsigned int
+      return arg;
+    case 1: // negative int
+      return -1 - arg;
+    case 2: {
+      // byte string
+      need(c, arg);
+      const bytes = c.buf.subarray(c.pos, c.pos + arg);
+      c.pos += arg;
+      // Copy: subarray aliases the input, and callers hold these past the
+      // decode. Aliasing would make a later mutation spooky at a distance.
+      return new Uint8Array(bytes);
+    }
+    case 3: {
+      // text string
+      need(c, arg);
+      const text = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(
+        c.buf.subarray(c.pos, c.pos + arg)
+      );
+      c.pos += arg;
+      return text;
+    }
+    case 4: {
+      // array
+      const out: CborValue[] = [];
+      for (let i = 0; i < arg; i++) out.push(readValue(c, depth + 1));
+      return out;
+    }
+    case 5: {
+      // map
+      const out = new Map<string | number, CborValue>();
+      for (let i = 0; i < arg; i++) {
+        const key = readValue(c, depth + 1);
+        if (typeof key !== 'string' && typeof key !== 'number') {
+          throw new CborError('map keys must be text or integer');
+        }
+        // Duplicate keys are malformed CBOR and are a known parser-differential
+        // trick — two verifiers disagreeing on which value wins.
+        if (out.has(key)) throw new CborError(`duplicate map key ${String(key)}`);
+        out.set(key, readValue(c, depth + 1));
+      }
+      return out;
+    }
+    default:
+      // 6 = tags, 7 = floats/simple. Neither appears in App Attest payloads.
+      throw new CborError(`unsupported major type ${major}`);
+  }
+}
+
+/**
+ * Decodes one CBOR item and REQUIRES it to consume the whole buffer.
+ *
+ * Trailing bytes are rejected on purpose: "valid prefix, then junk" is how you
+ * smuggle a second interpretation of the same blob past a verifier.
+ */
+export function decodeCbor(bytes: Uint8Array): CborValue {
+  const cursor: Cursor = {
+    buf: bytes,
+    view: new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+    pos: 0,
+  };
+  const value = readValue(cursor, 0);
+  if (cursor.pos !== bytes.length) {
+    throw new CborError(`${bytes.length - cursor.pos} trailing bytes after the CBOR item`);
+  }
+  return value;
+}
+
+// -------------------------------------------------------------- accessors
+
+/** Typed map lookup that names the field in its error, so failures are debuggable. */
+export function mapField(map: CborValue, key: string): CborValue {
+  if (!(map instanceof Map)) throw new CborError('expected a CBOR map');
+  const value = map.get(key);
+  if (value === undefined) throw new CborError(`missing field "${key}"`);
+  return value;
+}
+
+export function bytesField(map: CborValue, key: string): Uint8Array {
+  const value = mapField(map, key);
+  if (!(value instanceof Uint8Array)) throw new CborError(`field "${key}" is not a byte string`);
+  return value;
+}
+
+export function textField(map: CborValue, key: string): string {
+  const value = mapField(map, key);
+  if (typeof value !== 'string') throw new CborError(`field "${key}" is not text`);
+  return value;
+}

--- a/services/proxy/src/der.ts
+++ b/services/proxy/src/der.ts
@@ -1,0 +1,321 @@
+/**
+ * A tiny DER / X.509 reader — only what App Attest chain verification needs.
+ *
+ * Workers have no `X509Certificate` (that is `node:crypto`, and this worker
+ * runs without `nodejs_compat`), and Web Crypto will import an SPKI but will
+ * not parse a certificate. So the certificate walking is done by hand here and
+ * the actual cryptography is left entirely to Web Crypto. That division is
+ * deliberate: hand-rolled parsing is survivable, hand-rolled ECDSA is not.
+ *
+ * Same posture as the CBOR decoder — unknown or malformed input throws.
+ */
+
+export class DerError extends Error {}
+
+export interface Tlv {
+  /** The identifier octet. 0x30 SEQUENCE, 0x02 INTEGER, 0x03 BIT STRING, 0x04 OCTET STRING, 0x06 OID. */
+  tag: number;
+  /** Offset of the identifier octet, i.e. where the whole TLV starts. */
+  start: number;
+  /** Offset of the first content byte. */
+  contentStart: number;
+  /** Number of content bytes. */
+  length: number;
+  /** Offset one past the last content byte. */
+  end: number;
+}
+
+/**
+ * Bounds-checked byte read.
+ *
+ * Every caller has already length-checked; this turns `noUncheckedIndexedAccess`
+ * into a real runtime guard rather than a `!` that hides one.
+ */
+function byteAt(buf: Uint8Array, index: number): number {
+  const value = buf[index];
+  if (value === undefined) throw new DerError('read past the end of the buffer');
+  return value;
+}
+
+/** Asserts a structurally required element is present. */
+function required<T>(value: T | undefined, what: string): T {
+  if (value === undefined) throw new DerError(`missing ${what}`);
+  return value;
+}
+
+export function parseTlv(buf: Uint8Array, pos: number): Tlv {
+  if (pos + 2 > buf.length) throw new DerError('truncated TLV header');
+  const start = pos;
+  const tag = byteAt(buf, pos++);
+
+  // High-tag-number form (0x1f) never appears in the certificates Apple issues.
+  if ((tag & 0x1f) === 0x1f) throw new DerError('multi-byte tags are not supported');
+
+  const first = byteAt(buf, pos++);
+  let length: number;
+  if (first < 0x80) {
+    length = first;
+  } else {
+    const count = first & 0x7f;
+    // 0x80 is BER indefinite length — invalid in DER, and a classic way to
+    // desynchronise two parsers looking at the same bytes.
+    if (count === 0) throw new DerError('indefinite length is not valid DER');
+    // >4 length bytes means a value larger than any certificate we will ever
+    // see; refusing keeps `length` inside exact integer range.
+    if (count > 4) throw new DerError('length field too large');
+    if (pos + count > buf.length) throw new DerError('truncated length field');
+    length = 0;
+    for (let i = 0; i < count; i++) length = length * 256 + byteAt(buf, pos++);
+  }
+
+  const contentStart = pos;
+  const end = contentStart + length;
+  if (end > buf.length) throw new DerError('TLV content runs past the buffer');
+  return { tag, start, contentStart, length, end };
+}
+
+/** Every direct child of a constructed TLV. */
+export function children(buf: Uint8Array, parent: Tlv): Tlv[] {
+  const out: Tlv[] = [];
+  let pos = parent.contentStart;
+  while (pos < parent.end) {
+    const child = parseTlv(buf, pos);
+    out.push(child);
+    pos = child.end;
+  }
+  if (pos !== parent.end) throw new DerError('children do not tile the parent exactly');
+  return out;
+}
+
+export function content(buf: Uint8Array, tlv: Tlv): Uint8Array {
+  return buf.subarray(tlv.contentStart, tlv.end);
+}
+
+/** The complete TLV including its header — what a signature is computed over. */
+export function raw(buf: Uint8Array, tlv: Tlv): Uint8Array {
+  return buf.subarray(tlv.start, tlv.end);
+}
+
+/** Decodes an OBJECT IDENTIFIER's content octets to dotted-decimal form. */
+export function decodeOid(bytes: Uint8Array): string {
+  if (bytes.length === 0) throw new DerError('empty OID');
+  const parts: number[] = [];
+  // The first octet packs two arcs: 40*first + second.
+  const first = byteAt(bytes, 0);
+  parts.push(Math.floor(first / 40), first % 40);
+
+  let value = 0;
+  for (let i = 1; i < bytes.length; i++) {
+    const byte = byteAt(bytes, i);
+    value = value * 128 + (byte & 0x7f);
+    if ((byte & 0x80) === 0) {
+      parts.push(value);
+      value = 0;
+    }
+  }
+  if (value !== 0) throw new DerError('OID ends mid-arc');
+  return parts.join('.');
+}
+
+// ------------------------------------------------------------ certificates
+
+/** Named curve OIDs, mapped to the labels Web Crypto expects. */
+const CURVE_BY_OID: Record<string, string> = {
+  '1.2.840.10045.3.1.7': 'P-256',
+  '1.3.132.0.34': 'P-384',
+  '1.3.132.0.35': 'P-521',
+};
+
+/** ECDSA signature-algorithm OIDs, mapped to their digest. */
+const HASH_BY_SIG_OID: Record<string, string> = {
+  '1.2.840.10045.4.3.2': 'SHA-256',
+  '1.2.840.10045.4.3.3': 'SHA-384',
+  '1.2.840.10045.4.3.4': 'SHA-512',
+};
+
+export interface Certificate {
+  /** The exact `tbsCertificate` bytes, header included — the signed message. */
+  tbs: Uint8Array;
+  /** Digest named by the outer signatureAlgorithm, e.g. `SHA-256`. */
+  signatureHash: string;
+  /** Signature value, still in DER `SEQUENCE { r, s }` form. */
+  signature: Uint8Array;
+  /** The full SubjectPublicKeyInfo, ready to hand to `importKey('spki', …)`. */
+  spki: Uint8Array;
+  /** This certificate's own curve, e.g. `P-384`. */
+  curve: string;
+  /** The raw uncompressed EC point (`0x04 ‖ X ‖ Y`) — what App Attest hashes into a key id. */
+  publicKeyPoint: Uint8Array;
+  /** DER-encoded issuer and subject names, for chain linking. */
+  issuer: Uint8Array;
+  subject: Uint8Array;
+  notBefore: Date;
+  notAfter: Date;
+  /** Extensions by OID. Values are the extnValue OCTET STRING contents. */
+  extensions: Map<string, Uint8Array>;
+}
+
+/** ASN.1 UTCTime / GeneralizedTime → Date. */
+function parseTime(tag: number, text: string): Date {
+  const m =
+    tag === 0x17
+      ? /^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z$/.exec(text)
+      : /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z$/.exec(text);
+  if (!m) throw new DerError(`unparseable validity time "${text}"`);
+  let year = Number(m[1]);
+  // RFC 5280: two-digit years >= 50 are 19xx, below are 20xx.
+  if (tag === 0x17) year += year >= 50 ? 1900 : 2000;
+  return new Date(
+    Date.UTC(year, Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6]))
+  );
+}
+
+export function parseCertificate(der: Uint8Array): Certificate {
+  const cert = parseTlv(der, 0);
+  if (cert.tag !== 0x30) throw new DerError('certificate is not a SEQUENCE');
+  if (cert.end !== der.length) throw new DerError('trailing bytes after the certificate');
+
+  const [tbsTlv, sigAlgTlv, sigTlv] = children(der, cert);
+  if (!tbsTlv || !sigAlgTlv || !sigTlv) throw new DerError('certificate has too few fields');
+
+  // --- outer signature algorithm
+  const sigAlgOid = children(der, sigAlgTlv)[0];
+  if (!sigAlgOid || sigAlgOid.tag !== 0x06) throw new DerError('missing signature algorithm OID');
+  const sigOidText = decodeOid(content(der, sigAlgOid));
+  const signatureHash = HASH_BY_SIG_OID[sigOidText];
+  if (!signatureHash) {
+    // RSA-signed certificates would land here. App Attest is ECDSA end to end;
+    // silently accepting anything else would widen what we trust.
+    throw new DerError(`unsupported signature algorithm ${sigOidText}`);
+  }
+
+  // --- signature value (BIT STRING: first content byte is the unused-bit count)
+  if (sigTlv.tag !== 0x03) throw new DerError('signature is not a BIT STRING');
+  const sigBits = content(der, sigTlv);
+  if (sigBits.length < 1 || sigBits[0] !== 0) throw new DerError('signature has unused bits');
+  const signature = sigBits.subarray(1);
+
+  // --- tbsCertificate fields
+  const tbsFields = children(der, tbsTlv);
+  let i = 0;
+  // [0] EXPLICIT version, optional and always present in the v3 certs Apple issues.
+  if (tbsFields[i]?.tag === 0xa0) i++;
+  i++; // serialNumber
+  i++; // inner signature AlgorithmIdentifier
+  const issuerTlv = tbsFields[i++];
+  const validityTlv = tbsFields[i++];
+  const subjectTlv = tbsFields[i++];
+  const spkiTlv = tbsFields[i++];
+  if (!issuerTlv || !validityTlv || !subjectTlv || !spkiTlv) {
+    throw new DerError('tbsCertificate is missing required fields');
+  }
+
+  const validityParts = children(der, validityTlv);
+  const notBeforeTlv = required(validityParts[0], 'notBefore');
+  const notAfterTlv = required(validityParts[1], 'notAfter');
+  const decoder = new TextDecoder();
+  const notBefore = parseTime(notBeforeTlv.tag, decoder.decode(content(der, notBeforeTlv)));
+  const notAfter = parseTime(notAfterTlv.tag, decoder.decode(content(der, notAfterTlv)));
+
+  // --- public key
+  const spkiParts = children(der, spkiTlv);
+  const algTlv = required(spkiParts[0], 'public key algorithm');
+  const keyBitsTlv = required(spkiParts[1], 'public key bits');
+  const algParts = children(der, algTlv);
+  const algOid = decodeOid(content(der, required(algParts[0], 'algorithm OID')));
+  if (algOid !== '1.2.840.10045.2.1') throw new DerError(`public key is not EC (${algOid})`);
+  const curveParam = algParts[1];
+  const curveOid = curveParam ? decodeOid(content(der, curveParam)) : '';
+  const curve = CURVE_BY_OID[curveOid];
+  if (!curve) throw new DerError(`unsupported curve ${curveOid}`);
+
+  if (keyBitsTlv.tag !== 0x03) throw new DerError('public key is not a BIT STRING');
+  const keyBits = content(der, keyBitsTlv);
+  if (keyBits.length < 2 || keyBits[0] !== 0) throw new DerError('public key has unused bits');
+  const publicKeyPoint = keyBits.subarray(1);
+  if (byteAt(publicKeyPoint, 0) !== 0x04) {
+    // Compressed points would need decompression before hashing, and Apple
+    // does not issue them. Rejecting is safer than guessing.
+    throw new DerError('public key point is not in uncompressed form');
+  }
+
+  // --- extensions, under [3] EXPLICIT
+  const extensions = new Map<string, Uint8Array>();
+  for (let j = i; j < tbsFields.length; j++) {
+    const field = tbsFields[j];
+    if (!field || field.tag !== 0xa3) continue;
+    const seq = required(children(der, field)[0], 'extensions SEQUENCE');
+    for (const ext of children(der, seq)) {
+      const parts = children(der, ext);
+      const oid = decodeOid(content(der, required(parts[0], 'extension OID')));
+      // parts[1] may be the optional `critical` BOOLEAN; the value is the last.
+      const valueTlv = required(parts[parts.length - 1], 'extension value');
+      extensions.set(oid, content(der, valueTlv));
+    }
+  }
+
+  return {
+    tbs: raw(der, tbsTlv),
+    signatureHash,
+    signature,
+    spki: raw(der, spkiTlv),
+    curve,
+    publicKeyPoint,
+    issuer: raw(der, issuerTlv),
+    subject: raw(der, subjectTlv),
+    notBefore,
+    notAfter,
+    extensions,
+  };
+}
+
+/**
+ * Converts a DER `SEQUENCE { INTEGER r, INTEGER s }` signature into the fixed
+ * width `r ‖ s` that Web Crypto requires.
+ *
+ * DER INTEGERs are signed and minimally encoded, so `r` may carry a leading
+ * 0x00 (when its high bit is set) or be short (when it has leading zero bytes).
+ * Both have to be normalised to exactly `size` bytes or verification fails for
+ * roughly one signature in 256 — the kind of bug that looks like flaky
+ * hardware.
+ */
+export function ecdsaDerToRaw(derSig: Uint8Array, size: number): Uint8Array {
+  const seq = parseTlv(derSig, 0);
+  if (seq.tag !== 0x30) throw new DerError('ECDSA signature is not a SEQUENCE');
+  const [rTlv, sTlv] = children(derSig, seq);
+  if (!rTlv || !sTlv || rTlv.tag !== 0x02 || sTlv.tag !== 0x02) {
+    throw new DerError('ECDSA signature is not two INTEGERs');
+  }
+
+  const out = new Uint8Array(size * 2);
+  const place = (tlv: Tlv, offset: number) => {
+    let bytes = content(derSig, tlv);
+    let from = 0;
+    while (from < bytes.length - 1 && byteAt(bytes, from) === 0) from++;
+    bytes = bytes.subarray(from);
+    if (bytes.length > size) throw new DerError('ECDSA signature component is too large');
+    out.set(bytes, offset + size - bytes.length);
+  };
+  place(rTlv, 0);
+  place(sTlv, size);
+  return out;
+}
+
+/** Bytes per ECDSA signature component, by curve. */
+export function componentSize(curve: string): number {
+  if (curve === 'P-256') return 32;
+  if (curve === 'P-384') return 48;
+  if (curve === 'P-521') return 66;
+  throw new DerError(`unknown curve ${curve}`);
+}
+
+/** Decodes a PEM block (any label) to DER. */
+export function pemToDer(pem: string): Uint8Array {
+  const match = /-----BEGIN [^-]+-----([\s\S]*?)-----END [^-]+-----/.exec(pem);
+  if (!match) throw new DerError('no PEM block found');
+  const base64 = required(match[1], 'PEM body').replace(/\s+/g, '');
+  const binary = atob(base64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}

--- a/services/proxy/src/index.ts
+++ b/services/proxy/src/index.ts
@@ -15,6 +15,36 @@
 
 import { authenticate, type AuthFailure } from './auth';
 import { costUsd, type Usage } from './pricing';
+import {
+  AttestError,
+  CHALLENGE_TTL_SECONDS,
+  TOKEN_TTL_SECONDS,
+  claimChallenge,
+  fromBase64,
+  isPlausibleKeyId,
+  issueChallenge,
+  loadAttestedKey,
+  mintToken,
+  saveAttestedKey,
+  verifyAssertion,
+  verifyAttestation,
+  verifyToken,
+} from './attest';
+
+/**
+ * How hard attestation is enforced.
+ *
+ * `off`     — the credential's token, if any, is ignored entirely.
+ * `monitor` — tokens are verified and the outcome is logged, but a failure
+ *             never blocks a request.
+ * `enforce` — `/v1/messages` requires a valid token.
+ *
+ * Deployed as `off` and moved forward one notch at a time. Going straight to
+ * `enforce` would brick every already-installed build the moment it lands,
+ * including the testers' — attestation has to be observed working on real
+ * devices before it is allowed to say no.
+ */
+export type AttestMode = 'off' | 'monitor' | 'enforce';
 
 export interface Env {
   /** Secret. The real `sk-ant-…` key. Never leaves this worker. */
@@ -29,6 +59,15 @@ export interface Env {
   PER_INSTALL_DAILY_CAP_USD?: string;
   /** Override for tests / staging. Defaults to Anthropic. */
   UPSTREAM_BASE_URL?: string;
+
+  /** `off` | `monitor` | `enforce`. Anything unrecognised means `off`. */
+  ATTEST_MODE?: string;
+  /** `TEAMID.bundle.id`. Required once attestation is anything but `off`. */
+  APP_ATTEST_APP_ID?: string;
+  /** Apple's App Attest root CA, PEM. Public data, but configured not pinned. */
+  APP_ATTEST_ROOT_CA?: string;
+  /** `"true"` to also accept development attestations. Never in production. */
+  APP_ATTEST_ALLOW_DEVELOPMENT?: string;
 }
 
 const DEFAULT_DAILY_CAP_USD = 25;
@@ -87,6 +126,149 @@ async function addSpend(kv: KVNamespace, key: string, delta: number): Promise<vo
   await kv.put(key, String(current + delta), { expirationTtl: COUNTER_TTL_SECONDS });
 }
 
+// ------------------------------------------------------------- attestation
+
+export function attestMode(env: Env): AttestMode {
+  const raw = env.ATTEST_MODE?.trim().toLowerCase();
+  if (raw === 'monitor' || raw === 'enforce') return raw;
+  // Anything else — unset, a typo, an empty string — is `off`. A misspelled
+  // mode must not fail into rejecting every request in the field.
+  return 'off';
+}
+
+/**
+ * The attestation config, or `null` if it is incomplete.
+ *
+ * Incomplete config in `enforce` mode is a hard 500 at the call site rather
+ * than a silent downgrade: an operator who asked for enforcement and quietly
+ * got none is strictly worse off than one whose deploy visibly fails.
+ */
+function attestConfig(env: Env) {
+  if (!env.APP_ATTEST_APP_ID || !env.APP_ATTEST_ROOT_CA) return null;
+  return {
+    appId: env.APP_ATTEST_APP_ID,
+    rootCaPem: env.APP_ATTEST_ROOT_CA,
+    allowDevelopment: env.APP_ATTEST_ALLOW_DEVELOPMENT === 'true',
+  };
+}
+
+function json(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** Bodies here are tiny control-plane JSON — never walk content. See the header. */
+async function readJsonBody(request: Request): Promise<Record<string, unknown>> {
+  const text = await request.text();
+  if (text.length > 128 * 1024) throw new AttestError('body too large', 'too_large');
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object') throw new Error('not an object');
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new AttestError('body is not a JSON object', 'malformed_body');
+  }
+}
+
+function stringField(body: Record<string, unknown>, name: string): string {
+  const value = body[name];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new AttestError(`missing "${name}"`, 'missing_field');
+  }
+  return value;
+}
+
+async function handleAttestRoute(
+  path: string,
+  request: Request,
+  env: Env,
+  installId: string
+): Promise<Response> {
+  const config = attestConfig(env);
+  if (!config) {
+    return errorResponse(503, 'api_error', 'attestation is not configured on this deployment');
+  }
+
+  try {
+    if (path === '/v1/attest/challenge') {
+      const challenge = await issueChallenge(env.METER, installId);
+      return json(200, { challenge, expires_in: CHALLENGE_TTL_SECONDS });
+    }
+
+    const body = await readJsonBody(request);
+    const keyId = stringField(body, 'key_id');
+    const challenge = stringField(body, 'challenge');
+    if (!isPlausibleKeyId(keyId)) {
+      throw new AttestError('key id is not a base64 SHA-256', 'bad_key_id');
+    }
+
+    // Claimed BEFORE any expensive verification, so a flood of bogus
+    // attestations can't be used to burn CPU on a challenge that was never
+    // issued to this install.
+    if (!(await claimChallenge(env.METER, challenge, installId))) {
+      throw new AttestError('challenge is unknown, expired, or not yours', 'bad_challenge');
+    }
+    const challengeBytes = new TextEncoder().encode(challenge);
+
+    if (path === '/v1/attest/attest') {
+      const attestation = fromBase64(stringField(body, 'attestation'));
+      const verified = await verifyAttestation(
+        attestation,
+        fromBase64(keyId),
+        challengeBytes,
+        config
+      );
+      await saveAttestedKey(env.METER, keyId, {
+        spki: btoa(String.fromCharCode(...verified.spki)),
+        curve: verified.curve,
+        counter: 0,
+        installId,
+        attestedAt: Date.now(),
+      });
+      console.log(JSON.stringify({ event: 'attest_ok', installId, curve: verified.curve }));
+      return json(200, { ok: true });
+    }
+
+    if (path === '/v1/attest/assert') {
+      const stored = await loadAttestedKey(env.METER, keyId);
+      if (!stored) throw new AttestError('key has not been attested', 'unknown_key');
+      // A key belongs to the install that attested it. Without this, one
+      // attested device could mint tokens for every install id it likes and
+      // spread its spend across everyone else's caps.
+      if (stored.installId !== installId) {
+        throw new AttestError('key belongs to a different install', 'key_install_mismatch');
+      }
+
+      const assertion = fromBase64(stringField(body, 'assertion'));
+      const { counter } = await verifyAssertion(
+        assertion,
+        challengeBytes,
+        { spki: fromBase64(stored.spki), curve: stored.curve, counter: stored.counter },
+        config.appId
+      );
+      await saveAttestedKey(env.METER, keyId, { ...stored, counter });
+
+      const token = await mintToken(env.APP_SECRET, installId, keyId);
+      return json(200, { token, expires_in: TOKEN_TTL_SECONDS });
+    }
+
+    return errorResponse(404, 'not_found_error', 'unknown route');
+  } catch (error) {
+    if (error instanceof AttestError) {
+      // The code is a fixed enum, so this leaks nothing about the caller.
+      console.warn(JSON.stringify({ event: 'attest_failed', installId, code: error.code }));
+      return json(403, {
+        type: 'error',
+        error: { type: 'permission_error', message: error.message, code: error.code },
+      });
+    }
+    console.error(JSON.stringify({ event: 'attest_error', installId }));
+    return errorResponse(500, 'api_error', 'attestation check failed');
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
@@ -98,11 +280,15 @@ export default {
       });
     }
 
-    if (request.method !== 'POST' || url.pathname !== '/v1/messages') {
+    const isAttestRoute = url.pathname.startsWith('/v1/attest/');
+    if (request.method !== 'POST' || (url.pathname !== '/v1/messages' && !isAttestRoute)) {
       return errorResponse(404, 'not_found_error', 'unknown route');
     }
 
-    if (!env.ANTHROPIC_API_KEY || !env.APP_SECRET) {
+    // The attestation routes never call upstream, so they need the app secret
+    // but not the Anthropic key. Requiring both here would make attestation
+    // undeployable to a staging worker that has no key.
+    if (!env.APP_SECRET || (!isAttestRoute && !env.ANTHROPIC_API_KEY)) {
       // Misconfiguration must fail loudly and CLOSED. Forwarding without a key
       // would 401 confusingly; running without APP_SECRET would accept anyone.
       return errorResponse(500, 'api_error', 'proxy is not configured');
@@ -112,7 +298,43 @@ export default {
     if (!auth.ok) {
       return errorResponse(401, 'authentication_error', AUTH_FAILURE_MESSAGE[auth.reason]);
     }
-    const { installId } = auth.credential;
+    const { installId, attestToken } = auth.credential;
+
+    // Enrolment happens under Phase 1 auth alone — it has to, since a device
+    // cannot present an attestation token before it has attested.
+    if (isAttestRoute) {
+      return handleAttestRoute(url.pathname, request, env, installId);
+    }
+
+    const mode = attestMode(env);
+    if (mode !== 'off') {
+      if (!attestConfig(env)) {
+        // Asked to enforce, unable to. Fail closed and loudly rather than
+        // serving traffic an operator believes is being checked.
+        console.error(JSON.stringify({ event: 'attest_misconfigured', mode }));
+        return errorResponse(500, 'api_error', 'proxy is not configured');
+      }
+      const result = attestToken
+        ? await verifyToken(env.APP_SECRET, attestToken, installId)
+        : ({ ok: false, reason: 'malformed' } as const);
+
+      if (!result.ok) {
+        console.warn(
+          JSON.stringify({ event: 'attest_token_rejected', installId, mode, reason: result.reason }),
+        );
+        if (mode === 'enforce') {
+          // 401 rather than 403: the app's recovery is to re-attest and retry,
+          // which is what a client does with an authentication failure.
+          return errorResponse(
+            401,
+            'authentication_error',
+            'device attestation required; re-attest and retry',
+          );
+        }
+        // `monitor` — observed, counted, allowed through. This is the mode
+        // that tells us whether enforcement would have been safe.
+      }
+    }
 
     const today = dayKey(new Date());
     const globalKey = `spend:global:${today}`;

--- a/services/proxy/test/appattest-fixtures.ts
+++ b/services/proxy/test/appattest-fixtures.ts
@@ -1,0 +1,390 @@
+/**
+ * Builds synthetic App Attest material — a real certificate chain, real ECDSA
+ * signatures, real CBOR.
+ *
+ * ## Why this exists rather than a captured fixture
+ *
+ * A verifier you cannot make FAIL is not tested. A recorded attestation from a
+ * real device proves one happy path and nothing else: you cannot corrupt one
+ * field of it and re-sign, so every negative test degenerates into "garbage in,
+ * error out", which would also pass against a verifier that rejects everything.
+ *
+ * Holding the private keys means each test can change exactly one thing — the
+ * challenge, the counter, the aaguid, the signing CA — and assert that this
+ * specific check is what fires. That is the difference between testing the
+ * checks and testing that the parser doesn't crash.
+ *
+ * The cost is that these certificates are ours, not Apple's, so this cannot
+ * prove we accept a genuine Apple chain — only that we accept a well-formed
+ * one and reject the malformations. Rejecting Apple's real root is the residual
+ * risk, and it is the one thing that must be checked on a device.
+ */
+
+// ------------------------------------------------------------ DER encoding
+
+function encodeLength(n: number): Uint8Array {
+  if (n < 128) return Uint8Array.of(n);
+  const bytes: number[] = [];
+  let value = n;
+  while (value > 0) {
+    bytes.unshift(value & 0xff);
+    value = Math.floor(value / 256);
+  }
+  return Uint8Array.of(0x80 | bytes.length, ...bytes);
+}
+
+export function cat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+export function tlv(tag: number, body: Uint8Array): Uint8Array {
+  return cat(Uint8Array.of(tag), encodeLength(body.length), body);
+}
+
+const seq = (...parts: Uint8Array[]) => tlv(0x30, cat(...parts));
+const set = (...parts: Uint8Array[]) => tlv(0x31, cat(...parts));
+const octets = (body: Uint8Array) => tlv(0x04, body);
+const explicit = (n: number, body: Uint8Array) => tlv(0xa0 | n, body);
+
+/** DER INTEGER from a non-negative JS number. */
+function integer(value: number): Uint8Array {
+  const bytes: number[] = [];
+  let v = value;
+  do {
+    bytes.unshift(v & 0xff);
+    v = Math.floor(v / 256);
+  } while (v > 0);
+  // DER INTEGERs are signed; a leading high bit would read as negative.
+  if ((bytes[0] ?? 0) & 0x80) bytes.unshift(0);
+  return tlv(0x02, Uint8Array.from(bytes));
+}
+
+/** DER INTEGER from a big-endian magnitude, used for ECDSA r and s. */
+function integerFromBytes(magnitude: Uint8Array): Uint8Array {
+  let from = 0;
+  while (from < magnitude.length - 1 && magnitude[from] === 0) from++;
+  let bytes = Array.from(magnitude.subarray(from));
+  if ((bytes[0] ?? 0) & 0x80) bytes = [0, ...bytes];
+  return tlv(0x02, Uint8Array.from(bytes));
+}
+
+export function oid(dotted: string): Uint8Array {
+  const arcs = dotted.split('.').map(Number);
+  const bytes: number[] = [40 * (arcs[0] ?? 0) + (arcs[1] ?? 0)];
+  for (const arc of arcs.slice(2)) {
+    const chunk: number[] = [arc & 0x7f];
+    let v = Math.floor(arc / 128);
+    while (v > 0) {
+      chunk.unshift((v & 0x7f) | 0x80);
+      v = Math.floor(v / 128);
+    }
+    bytes.push(...chunk);
+  }
+  return tlv(0x06, Uint8Array.from(bytes));
+}
+
+function bitString(body: Uint8Array): Uint8Array {
+  return tlv(0x03, cat(Uint8Array.of(0), body));
+}
+
+function utcTime(date: Date): Uint8Array {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const text =
+    pad(date.getUTCFullYear() % 100) +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds()) +
+    'Z';
+  return tlv(0x17, new TextEncoder().encode(text));
+}
+
+/** `CN=<name>` as an RFC 5280 Name. */
+function name(common: string): Uint8Array {
+  return seq(set(seq(oid('2.5.4.3'), tlv(0x13, new TextEncoder().encode(common)))));
+}
+
+const ECDSA_SHA256 = seq(oid('1.2.840.10045.4.3.2'));
+const ECDSA_SHA384 = seq(oid('1.2.840.10045.4.3.3'));
+
+// -------------------------------------------------------------- signing
+
+function componentSize(curve: string): number {
+  return curve === 'P-384' ? 48 : 32;
+}
+
+/** Web Crypto emits `r ‖ s`; X.509 wants `SEQUENCE { INTEGER r, INTEGER s }`. */
+function rawSignatureToDer(raw: Uint8Array, curve: string): Uint8Array {
+  const size = componentSize(curve);
+  return seq(
+    integerFromBytes(raw.subarray(0, size)),
+    integerFromBytes(raw.subarray(size, size * 2))
+  );
+}
+
+export interface KeyPairInfo {
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
+  curve: string;
+  /** Full SubjectPublicKeyInfo DER. */
+  spki: Uint8Array;
+  /** Uncompressed EC point, `0x04 ‖ X ‖ Y`. */
+  point: Uint8Array;
+}
+
+export async function generateKeyPair(curve: 'P-256' | 'P-384'): Promise<KeyPairInfo> {
+  const pair = (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: curve }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  return {
+    publicKey: pair.publicKey,
+    privateKey: pair.privateKey,
+    curve,
+    // Cast: workers-types narrows exportKey's return by format, and the
+    // ArrayBuffer overloads aren't selected for these literals under `strict`.
+    spki: new Uint8Array((await crypto.subtle.exportKey('spki', pair.publicKey)) as ArrayBuffer),
+    point: new Uint8Array((await crypto.subtle.exportKey('raw', pair.publicKey)) as ArrayBuffer),
+  };
+}
+
+export interface CertOptions {
+  subject: string;
+  issuer: string;
+  subjectKey: KeyPairInfo;
+  issuerKey: KeyPairInfo;
+  /** Extra extensions as `[oid, extnValue content]`. */
+  extensions?: Array<[string, Uint8Array]>;
+  notBefore?: Date;
+  notAfter?: Date;
+  serial?: number;
+}
+
+export async function makeCertificate(options: CertOptions): Promise<Uint8Array> {
+  const hash = options.issuerKey.curve === 'P-384' ? 'SHA-384' : 'SHA-256';
+  const algorithm = hash === 'SHA-384' ? ECDSA_SHA384 : ECDSA_SHA256;
+
+  const extensionBlocks = (options.extensions ?? []).map(([extOid, value]) =>
+    seq(oid(extOid), octets(value))
+  );
+
+  const tbs = seq(
+    explicit(0, integer(2)), // v3
+    integer(options.serial ?? 1),
+    algorithm,
+    name(options.issuer),
+    seq(
+      utcTime(options.notBefore ?? new Date(Date.now() - 86_400_000)),
+      utcTime(options.notAfter ?? new Date(Date.now() + 86_400_000))
+    ),
+    name(options.subject),
+    options.subjectKey.spki,
+    ...(extensionBlocks.length ? [tlv(0xa3, seq(...extensionBlocks))] : [])
+  );
+
+  const raw = new Uint8Array(
+    await crypto.subtle.sign({ name: 'ECDSA', hash }, options.issuerKey.privateKey, tbs)
+  );
+  return seq(tbs, algorithm, bitString(rawSignatureToDer(raw, options.issuerKey.curve)));
+}
+
+export function toPem(der: Uint8Array): string {
+  let binary = '';
+  for (const byte of der) binary += String.fromCharCode(byte);
+  const base64 = btoa(binary).replace(/(.{64})/g, '$1\n');
+  return `-----BEGIN CERTIFICATE-----\n${base64}\n-----END CERTIFICATE-----\n`;
+}
+
+/** Apple wraps the attestation nonce in `SEQUENCE { [1] { OCTET STRING } }`. */
+export function nonceExtensionValue(nonce: Uint8Array): Uint8Array {
+  return seq(tlv(0xa1, octets(nonce)));
+}
+
+// ------------------------------------------------------------------ CBOR
+
+function cborHead(major: number, arg: number): Uint8Array {
+  if (arg < 24) return Uint8Array.of((major << 5) | arg);
+  if (arg < 0x100) return Uint8Array.of((major << 5) | 24, arg);
+  if (arg < 0x10000) return Uint8Array.of((major << 5) | 25, arg >> 8, arg & 0xff);
+  return Uint8Array.of(
+    (major << 5) | 26,
+    (arg >>> 24) & 0xff,
+    (arg >>> 16) & 0xff,
+    (arg >>> 8) & 0xff,
+    arg & 0xff
+  );
+}
+
+/** An interface, not a type alias — a `Record` inside the union is circular. */
+export interface CborMap {
+  [key: string]: CborInput;
+}
+export type CborInput = number | string | Uint8Array | CborInput[] | CborMap;
+
+export function encodeCbor(value: CborInput): Uint8Array {
+  if (typeof value === 'number') return cborHead(0, value);
+  if (value instanceof Uint8Array) return cat(cborHead(2, value.length), value);
+  if (typeof value === 'string') {
+    const bytes = new TextEncoder().encode(value);
+    return cat(cborHead(3, bytes.length), bytes);
+  }
+  if (Array.isArray(value)) {
+    return cat(cborHead(4, value.length), ...value.map(encodeCbor));
+  }
+  const entries = Object.entries(value);
+  return cat(
+    cborHead(5, entries.length),
+    ...entries.flatMap(([k, v]) => [encodeCbor(k), encodeCbor(v)])
+  );
+}
+
+// ------------------------------------------------------ authenticator data
+
+export function buildAuthData(options: {
+  rpIdHash: Uint8Array;
+  counter: number;
+  aaguid?: string;
+  credentialId?: Uint8Array;
+}): Uint8Array {
+  const header = new Uint8Array(37);
+  header.set(options.rpIdHash, 0);
+  header[32] = 0x40; // AT flag — attested credential data present
+  new DataView(header.buffer).setUint32(33, options.counter);
+  if (!options.aaguid || !options.credentialId) return header.subarray(0, 37);
+
+  const aaguid = new Uint8Array(16);
+  for (let i = 0; i < options.aaguid.length; i++) aaguid[i] = options.aaguid.charCodeAt(i);
+  const length = new Uint8Array(2);
+  new DataView(length.buffer).setUint16(0, options.credentialId.length);
+  return cat(header, aaguid, length, options.credentialId);
+}
+
+export async function sha256(...parts: Uint8Array[]): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', cat(...parts)));
+}
+
+// -------------------------------------------------------------- the world
+
+export const TEST_APP_ID = 'ABCDE12345.com.isaacwm.sitewalk';
+
+export interface AttestWorld {
+  rootPem: string;
+  /** The Secure Enclave key the device would hold. */
+  deviceKey: KeyPairInfo;
+  keyId: Uint8Array;
+  /** Builds an attestation object over `challenge`, with optional sabotage. */
+  attestationFor(
+    challenge: string,
+    overrides?: {
+      counter?: number;
+      aaguid?: string;
+      appId?: string;
+      credentialId?: Uint8Array;
+      /** Sign the leaf with a CA that does not chain to the pinned root. */
+      rogueIssuer?: boolean;
+      /** Put a different nonce in the certificate extension. */
+      nonce?: Uint8Array;
+      notAfter?: Date;
+    }
+  ): Promise<Uint8Array>;
+  /** Builds an assertion signed by the device key. */
+  assertionFor(
+    challenge: string,
+    counter: number,
+    overrides?: { appId?: string; wrongKey?: KeyPairInfo }
+  ): Promise<Uint8Array>;
+}
+
+export async function buildWorld(): Promise<AttestWorld> {
+  const root = await generateKeyPair('P-384');
+  const intermediate = await generateKeyPair('P-384');
+  const rogueRoot = await generateKeyPair('P-384');
+  const deviceKey = await generateKeyPair('P-256');
+  const keyId = await sha256(deviceKey.point);
+
+  const rootDer = await makeCertificate({
+    subject: 'Test App Attest Root',
+    issuer: 'Test App Attest Root',
+    subjectKey: root,
+    issuerKey: root,
+  });
+  const intermediateDer = await makeCertificate({
+    subject: 'Test App Attest CA 1',
+    issuer: 'Test App Attest Root',
+    subjectKey: intermediate,
+    issuerKey: root,
+  });
+  const rogueIntermediateDer = await makeCertificate({
+    subject: 'Test App Attest CA 1',
+    issuer: 'Test App Attest Root',
+    subjectKey: rogueRoot,
+    issuerKey: rogueRoot,
+  });
+
+  return {
+    rootPem: toPem(rootDer),
+    deviceKey,
+    keyId,
+
+    async attestationFor(challenge, overrides = {}) {
+      const rpIdHash = await sha256(
+        new TextEncoder().encode(overrides.appId ?? TEST_APP_ID)
+      );
+      const authData = buildAuthData({
+        rpIdHash,
+        counter: overrides.counter ?? 0,
+        aaguid: overrides.aaguid ?? 'appattest\0\0\0\0\0\0\0',
+        credentialId: overrides.credentialId ?? keyId,
+      });
+
+      const clientDataHash = await sha256(new TextEncoder().encode(challenge));
+      const nonce = overrides.nonce ?? (await sha256(authData, clientDataHash));
+
+      const signer = overrides.rogueIssuer ? rogueRoot : intermediate;
+      const leafDer = await makeCertificate({
+        subject: 'device',
+        issuer: 'Test App Attest CA 1',
+        subjectKey: deviceKey,
+        issuerKey: signer,
+        extensions: [['1.2.840.113635.100.8.2', nonceExtensionValue(nonce)]],
+        notAfter: overrides.notAfter,
+      });
+
+      return encodeCbor({
+        fmt: 'apple-appattest',
+        attStmt: {
+          x5c: [leafDer, overrides.rogueIssuer ? rogueIntermediateDer : intermediateDer],
+          receipt: new Uint8Array([1, 2, 3]),
+        },
+        authData,
+      });
+    },
+
+    async assertionFor(challenge, counter, overrides = {}) {
+      const rpIdHash = await sha256(
+        new TextEncoder().encode(overrides.appId ?? TEST_APP_ID)
+      );
+      const authData = buildAuthData({ rpIdHash, counter });
+      const clientDataHash = await sha256(new TextEncoder().encode(challenge));
+      const key = overrides.wrongKey ?? deviceKey;
+      const raw = new Uint8Array(
+        await crypto.subtle.sign(
+          { name: 'ECDSA', hash: 'SHA-256' },
+          key.privateKey,
+          cat(authData, clientDataHash)
+        )
+      );
+      return encodeCbor({
+        signature: rawSignatureToDer(raw, key.curve),
+        authenticatorData: authData,
+      });
+    },
+  };
+}

--- a/services/proxy/test/attest.test.ts
+++ b/services/proxy/test/attest.test.ts
@@ -1,0 +1,715 @@
+import { beforeAll, describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { authenticate } from '../src/auth';
+import { decodeCbor, CborError } from '../src/cbor';
+import { DerError, ecdsaDerToRaw, parseCertificate, pemToDer } from '../src/der';
+import {
+  AttestError,
+  claimChallenge,
+  isPlausibleKeyId,
+  issueChallenge,
+  mintToken,
+  parseAuthenticatorData,
+  toBase64Url,
+  verifyAssertion,
+  verifyAttestation,
+  verifyToken,
+} from '../src/attest';
+import worker, { attestMode, type Env } from '../src/index';
+import {
+  buildWorld,
+  encodeCbor,
+  generateKeyPair,
+  makeCertificate,
+  sha256,
+  TEST_APP_ID,
+  toPem,
+  type AttestWorld,
+} from './appattest-fixtures';
+
+const APP_SECRET = 'test-app-secret';
+const INSTALL = 'install-abc-123';
+
+let world: AttestWorld;
+beforeAll(async () => {
+  world = await buildWorld();
+}, 30_000);
+
+function config(overrides: Partial<{ appId: string; allowDevelopment: boolean }> = {}) {
+  return {
+    appId: overrides.appId ?? TEST_APP_ID,
+    rootCaPem: world.rootPem,
+    allowDevelopment: overrides.allowDevelopment ?? false,
+  };
+}
+
+const CHALLENGE = 'a-test-challenge-value';
+const challengeBytes = () => new TextEncoder().encode(CHALLENGE);
+
+/** Asserts the failure is ours and carries the code we expect, not a stray crash. */
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toThrow(AttestError);
+  await promise.catch((error: unknown) => {
+    expect((error as AttestError).code).toBe(code);
+  });
+}
+
+// ------------------------------------------------------------------- CBOR
+
+describe('cbor', () => {
+  it('round-trips the shapes App Attest actually uses', () => {
+    const encoded = encodeCbor({
+      fmt: 'apple-appattest',
+      attStmt: { x5c: [new Uint8Array([1, 2]), new Uint8Array([3])], n: 7 },
+      authData: new Uint8Array(300), // forces a 2-byte length header
+    });
+    const decoded = decodeCbor(encoded) as Map<string, unknown>;
+    expect(decoded.get('fmt')).toBe('apple-appattest');
+    expect((decoded.get('authData') as Uint8Array).length).toBe(300);
+    const attStmt = decoded.get('attStmt') as Map<string, unknown>;
+    expect((attStmt.get('x5c') as Uint8Array[])[0]).toEqual(new Uint8Array([1, 2]));
+    expect(attStmt.get('n')).toBe(7);
+  });
+
+  it('rejects trailing bytes, so a valid prefix cannot smuggle a second reading', () => {
+    const encoded = encodeCbor({ a: 1 });
+    const padded = new Uint8Array(encoded.length + 1);
+    padded.set(encoded);
+    expect(() => decodeCbor(padded)).toThrow(CborError);
+  });
+
+  it('rejects truncation rather than reading past the end', () => {
+    const encoded = encodeCbor({ authData: new Uint8Array(64) });
+    expect(() => decodeCbor(encoded.subarray(0, encoded.length - 10))).toThrow(CborError);
+  });
+
+  it('rejects duplicate map keys — a classic parser-differential trick', () => {
+    // {"a": 1, "a": 2} hand-encoded, since the encoder cannot produce it.
+    const blob = new Uint8Array([0xa2, 0x61, 0x61, 0x01, 0x61, 0x61, 0x02]);
+    expect(() => decodeCbor(blob)).toThrow(/duplicate/);
+  });
+
+  it('rejects indefinite-length items', () => {
+    expect(() => decodeCbor(new Uint8Array([0x5f, 0xff]))).toThrow(CborError);
+  });
+});
+
+// -------------------------------------------------------------------- DER
+
+describe('der', () => {
+  it('parses a certificate it just built, including the curve and extensions', async () => {
+    const ca = await generateKeyPair('P-384');
+    const leaf = await generateKeyPair('P-256');
+    const der = await makeCertificate({
+      subject: 'leaf',
+      issuer: 'ca',
+      subjectKey: leaf,
+      issuerKey: ca,
+      extensions: [['1.2.840.113635.100.8.2', new Uint8Array([0x30, 0x00])]],
+    });
+    const cert = parseCertificate(der);
+    expect(cert.curve).toBe('P-256');
+    expect(cert.signatureHash).toBe('SHA-384'); // named by the ISSUER's curve
+    expect(cert.extensions.has('1.2.840.113635.100.8.2')).toBe(true);
+    expect(cert.publicKeyPoint).toEqual(leaf.point);
+    expect(cert.notAfter.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('rejects trailing bytes after a certificate', async () => {
+    const ca = await generateKeyPair('P-256');
+    const der = await makeCertificate({ subject: 'a', issuer: 'a', subjectKey: ca, issuerKey: ca });
+    const padded = new Uint8Array(der.length + 1);
+    padded.set(der);
+    expect(() => parseCertificate(padded)).toThrow(DerError);
+  });
+
+  it('pads short ECDSA components to full width', () => {
+    // r = 0x01 (one byte), s = 0x00ff (leading zero stripped by DER rules).
+    const derSig = new Uint8Array([0x30, 0x08, 0x02, 0x01, 0x01, 0x02, 0x03, 0x00, 0xff, 0x00]);
+    // Rebuild cleanly: SEQUENCE { INTEGER 1, INTEGER 0x00ff }
+    const clean = new Uint8Array([0x30, 0x08, 0x02, 0x01, 0x01, 0x02, 0x03, 0x00, 0x00, 0xff]);
+    void derSig;
+    const raw = ecdsaDerToRaw(clean, 32);
+    expect(raw.length).toBe(64);
+    expect(raw[31]).toBe(1);
+    expect(raw.subarray(0, 31).every((b) => b === 0)).toBe(true);
+    expect(raw[63]).toBe(0xff);
+  });
+
+  it('round-trips PEM', async () => {
+    const ca = await generateKeyPair('P-256');
+    const der = await makeCertificate({ subject: 'a', issuer: 'a', subjectKey: ca, issuerKey: ca });
+    expect(pemToDer(toPem(der))).toEqual(der);
+  });
+});
+
+describe('authenticator data', () => {
+  it('rejects anything shorter than the fixed header', () => {
+    expect(() => parseAuthenticatorData(new Uint8Array(36))).toThrow(AttestError);
+  });
+
+  it('rejects a credential id length that runs past the buffer', () => {
+    const bytes = new Uint8Array(55);
+    new DataView(bytes.buffer).setUint16(53, 9999);
+    expect(() => parseAuthenticatorData(bytes)).toThrow(/past the buffer/);
+  });
+});
+
+// ------------------------------------------------------------- attestation
+
+describe('verifyAttestation', () => {
+  it('accepts a well-formed attestation over the right challenge', async () => {
+    const attestation = await world.attestationFor(CHALLENGE);
+    const result = await verifyAttestation(attestation, world.keyId, challengeBytes(), config());
+    expect(result.curve).toBe('P-256');
+    expect(result.spki).toEqual(world.deviceKey.spki);
+    expect(result.receipt).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it('rejects an attestation for a DIFFERENT challenge — the replay defence', async () => {
+    const attestation = await world.attestationFor('some-other-challenge');
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'nonce_mismatch'
+    );
+  });
+
+  it('rejects a nonce that does not cover authData', async () => {
+    // Right challenge, but the nonce is not SHA256(authData ‖ clientDataHash),
+    // so authData itself is unauthenticated — this is what lets an attacker
+    // swap the counter or aaguid if the check is missing.
+    const attestation = await world.attestationFor(CHALLENGE, {
+      nonce: await sha256(new TextEncoder().encode(CHALLENGE)),
+    });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'nonce_mismatch'
+    );
+  });
+
+  it('rejects a chain that does not reach the pinned root', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, { rogueIssuer: true });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'chain_signature_invalid'
+    );
+  });
+
+  it('rejects an expired certificate', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, {
+      notAfter: new Date(Date.now() - 60_000),
+    });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'cert_expired'
+    );
+  });
+
+  it('rejects an attestation for another app id', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, { appId: 'ZZZZZ99999.com.someone.else' });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'app_id_mismatch'
+    );
+  });
+
+  it('rejects a key that has already signed something', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, { counter: 5 });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'counter_not_zero'
+    );
+  });
+
+  it('rejects a development attestation in production', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, { aaguid: 'appattestdevelop' });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'bad_aaguid'
+    );
+  });
+
+  it('accepts a development attestation only when explicitly allowed', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, { aaguid: 'appattestdevelop' });
+    const result = await verifyAttestation(
+      attestation,
+      world.keyId,
+      challengeBytes(),
+      config({ allowDevelopment: true })
+    );
+    expect(result.curve).toBe('P-256');
+  });
+
+  it('rejects a key id that is not the hash of the attested key', async () => {
+    const attestation = await world.attestationFor(CHALLENGE);
+    await expectCode(
+      verifyAttestation(attestation, new Uint8Array(32), challengeBytes(), config()),
+      'key_id_mismatch'
+    );
+  });
+
+  it('rejects a credential id that disagrees with the key id', async () => {
+    const attestation = await world.attestationFor(CHALLENGE, {
+      credentialId: new Uint8Array(32).fill(7),
+    });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'credential_id_mismatch'
+    );
+  });
+
+  it('rejects a non-App-Attest format', async () => {
+    const blob = encodeCbor({
+      fmt: 'packed',
+      attStmt: { x5c: [new Uint8Array([1]), new Uint8Array([2])] },
+      authData: new Uint8Array(37),
+    });
+    await expectCode(verifyAttestation(blob, world.keyId, challengeBytes(), config()), 'bad_format');
+  });
+
+  it('rejects a chain with no intermediate', async () => {
+    const blob = encodeCbor({
+      fmt: 'apple-appattest',
+      attStmt: { x5c: [new Uint8Array([1])] },
+      authData: new Uint8Array(37),
+    });
+    await expectCode(verifyAttestation(blob, world.keyId, challengeBytes(), config()), 'no_chain');
+  });
+
+  it('refuses an implausibly large attestation before parsing it', async () => {
+    await expectCode(
+      verifyAttestation(new Uint8Array(70_000), world.keyId, challengeBytes(), config()),
+      'too_large'
+    );
+  });
+});
+
+// --------------------------------------------------------------- assertion
+
+describe('verifyAssertion', () => {
+  const stored = () => ({ spki: world.deviceKey.spki, curve: 'P-256', counter: 0 });
+
+  it('accepts an assertion signed by the attested key', async () => {
+    const assertion = await world.assertionFor(CHALLENGE, 1);
+    const { counter } = await verifyAssertion(assertion, challengeBytes(), stored(), TEST_APP_ID);
+    expect(counter).toBe(1);
+  });
+
+  it('rejects an assertion signed by a different key', async () => {
+    const other = await generateKeyPair('P-256');
+    const assertion = await world.assertionFor(CHALLENGE, 1, { wrongKey: other });
+    await expectCode(
+      verifyAssertion(assertion, challengeBytes(), stored(), TEST_APP_ID),
+      'assertion_invalid'
+    );
+  });
+
+  it('rejects an assertion over a different challenge', async () => {
+    const assertion = await world.assertionFor('another-challenge', 1);
+    await expectCode(
+      verifyAssertion(assertion, challengeBytes(), stored(), TEST_APP_ID),
+      'assertion_invalid'
+    );
+  });
+
+  it('rejects a replayed assertion whose counter did not advance', async () => {
+    const assertion = await world.assertionFor(CHALLENGE, 4);
+    const first = await verifyAssertion(assertion, challengeBytes(), stored(), TEST_APP_ID);
+    expect(first.counter).toBe(4);
+    // Same assertion again, now that the stored counter has caught up.
+    await expectCode(
+      verifyAssertion(assertion, challengeBytes(), { ...stored(), counter: 4 }, TEST_APP_ID),
+      'counter_replay'
+    );
+  });
+
+  it('rejects an assertion for a different app id', async () => {
+    const assertion = await world.assertionFor(CHALLENGE, 1, { appId: 'ZZZZZ99999.com.other' });
+    await expectCode(
+      verifyAssertion(assertion, challengeBytes(), stored(), TEST_APP_ID),
+      'app_id_mismatch'
+    );
+  });
+});
+
+// ------------------------------------------------------------------ token
+
+describe('attestation token', () => {
+  it('round-trips', async () => {
+    const token = await mintToken(APP_SECRET, INSTALL, 'key-1');
+    expect(await verifyToken(APP_SECRET, token, INSTALL)).toEqual({ ok: true, keyId: 'key-1' });
+  });
+
+  it('rejects a token minted under a different secret', async () => {
+    const token = await mintToken('some-other-secret', INSTALL, 'key-1');
+    expect(await verifyToken(APP_SECRET, token, INSTALL)).toEqual({
+      ok: false,
+      reason: 'bad_signature',
+    });
+  });
+
+  it('rejects a tampered payload', async () => {
+    const token = await mintToken(APP_SECRET, INSTALL, 'key-1');
+    const parts = token.split('.');
+    const forged = toBase64Url(
+      new TextEncoder().encode(JSON.stringify({ i: 'someone-else', k: 'x', e: 2 ** 40 }))
+    );
+    expect(await verifyToken(APP_SECRET, `jat.${forged}.${parts[2]}`, 'someone-else')).toEqual({
+      ok: false,
+      reason: 'bad_signature',
+    });
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await mintToken(APP_SECRET, INSTALL, 'key-1', new Date(Date.now() - 7200_000));
+    expect(await verifyToken(APP_SECRET, token, INSTALL)).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('refuses a valid token presented by another install', async () => {
+    // Without this, one attested device could mint tokens and hand them to
+    // every other install id, spreading its spend across everyone's caps.
+    const token = await mintToken(APP_SECRET, INSTALL, 'key-1');
+    expect(await verifyToken(APP_SECRET, token, 'different-install')).toEqual({
+      ok: false,
+      reason: 'wrong_install',
+    });
+  });
+
+  it('rejects structurally broken tokens without throwing', async () => {
+    for (const bad of ['', 'nope', 'jat.only-two', 'jat.a.b.c', 'xxx.a.b', 'jat.!!!.###']) {
+      const result = await verifyToken(APP_SECRET, bad, INSTALL);
+      expect(result.ok, bad).toBe(false);
+    }
+  });
+});
+
+describe('key ids', () => {
+  it('accepts base64 of a SHA-256 and rejects the rest', () => {
+    expect(isPlausibleKeyId(toBase64Url(new Uint8Array(32)))).toBe(true);
+    expect(isPlausibleKeyId('short')).toBe(false);
+    expect(isPlausibleKeyId('a'.repeat(500))).toBe(false);
+    expect(isPlausibleKeyId('has spaces and $')).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------- credentials
+
+describe('attested credential format', () => {
+  it('parses `jefeA.<install>.<token>~<secret>`', () => {
+    const raw = `jefeA.${INSTALL}.jat.abc.def~${APP_SECRET}`;
+    const result = authenticate(new Headers({ 'x-api-key': raw }), APP_SECRET);
+    expect(result).toEqual({
+      ok: true,
+      credential: { installId: INSTALL, attestToken: 'jat.abc.def' },
+    });
+  });
+
+  it('keeps accepting plain `jefe.` credentials', () => {
+    // Builds already in testers' hands predate attestation and must keep working.
+    const result = authenticate(
+      new Headers({ 'x-api-key': `jefe.${INSTALL}.${APP_SECRET}` }),
+      APP_SECRET
+    );
+    expect(result).toEqual({ ok: true, credential: { installId: INSTALL, attestToken: undefined } });
+  });
+
+  it('still checks the app secret on an attested credential', () => {
+    const raw = `jefeA.${INSTALL}.jat.abc.def~wrong-secret`;
+    expect(authenticate(new Headers({ 'x-api-key': raw }), APP_SECRET)).toEqual({
+      ok: false,
+      reason: 'bad_secret',
+    });
+  });
+
+  it('rejects an attested credential with no separator', () => {
+    const raw = `jefeA.${INSTALL}.${APP_SECRET}`;
+    expect(authenticate(new Headers({ 'x-api-key': raw }), APP_SECRET).ok).toBe(false);
+  });
+
+  it('rejects an oversized token before any crypto runs', () => {
+    const raw = `jefeA.${INSTALL}.${'a'.repeat(600)}~${APP_SECRET}`;
+    expect(authenticate(new Headers({ 'x-api-key': raw }), APP_SECRET).ok).toBe(false);
+  });
+});
+
+// --------------------------------------------------------------- the worker
+
+/** In-memory KV with the `delete` the challenge flow needs. */
+function fakeKv() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    put: vi.fn(async (k: string, v: string) => {
+      store.set(k, v);
+    }),
+    delete: vi.fn(async (k: string) => {
+      store.delete(k);
+    }),
+  } as unknown as KVNamespace & { store: Map<string, string> };
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ANTHROPIC_API_KEY: 'sk-ant-real',
+    APP_SECRET,
+    METER: fakeKv(),
+    UPSTREAM_BASE_URL: 'https://upstream.test',
+    APP_ATTEST_APP_ID: TEST_APP_ID,
+    APP_ATTEST_ROOT_CA: world.rootPem,
+    ...overrides,
+  } as Env;
+}
+
+const ctx = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+function messagesRequest(credential: string): Request {
+  return new Request('https://proxy.test/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': credential, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'claude-haiku-4-5', max_tokens: 8, messages: [] }),
+  });
+}
+
+function attestRequest(path: string, body: unknown, credential?: string): Request {
+  return new Request(`https://proxy.test${path}`, {
+    method: 'POST',
+    headers: {
+      'x-api-key': credential ?? `jefe.${INSTALL}.${APP_SECRET}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('attest mode parsing', () => {
+  it('treats anything unrecognised as off, so a typo cannot lock the fleet out', () => {
+    expect(attestMode({} as Env)).toBe('off');
+    expect(attestMode({ ATTEST_MODE: '' } as Env)).toBe('off');
+    expect(attestMode({ ATTEST_MODE: 'enfroce' } as Env)).toBe('off');
+    expect(attestMode({ ATTEST_MODE: ' Monitor ' } as Env)).toBe('monitor');
+    expect(attestMode({ ATTEST_MODE: 'enforce' } as Env)).toBe('enforce');
+  });
+});
+
+describe('worker attestation flow', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ usage: { input_tokens: 1, output_tokens: 1 } }), {
+            status: 200,
+          })
+      )
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** Walks challenge → attest → assert and returns the minted token. */
+  async function enrol(env: Env): Promise<string> {
+    const challengeRes = await worker.fetch(
+      attestRequest('/v1/attest/challenge', {}),
+      env,
+      ctx
+    );
+    expect(challengeRes.status).toBe(200);
+    const { challenge } = (await challengeRes.json()) as { challenge: string };
+
+    const keyId = toBase64Url(world.keyId);
+    const attestation = await world.attestationFor(challenge);
+    const attestRes = await worker.fetch(
+      attestRequest('/v1/attest/attest', {
+        key_id: keyId,
+        challenge,
+        attestation: toBase64Url(attestation),
+      }),
+      env,
+      ctx
+    );
+    expect(await attestRes.text()).toContain('"ok":true');
+
+    const second = await worker.fetch(attestRequest('/v1/attest/challenge', {}), env, ctx);
+    const { challenge: challenge2 } = (await second.json()) as { challenge: string };
+    const assertion = await world.assertionFor(challenge2, 1);
+    const assertRes = await worker.fetch(
+      attestRequest('/v1/attest/assert', {
+        key_id: keyId,
+        challenge: challenge2,
+        assertion: toBase64Url(assertion),
+      }),
+      env,
+      ctx
+    );
+    expect(assertRes.status).toBe(200);
+    const { token } = (await assertRes.json()) as { token: string };
+    return token;
+  }
+
+  it('runs the whole enrolment and then serves an enforced request', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'enforce' });
+    const token = await enrol(env);
+    const res = await worker.fetch(
+      messagesRequest(`jefeA.${INSTALL}.${token}~${APP_SECRET}`),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('turns away an unattested caller in enforce mode', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'enforce' });
+    const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain('attestation required');
+  });
+
+  it('lets an unattested caller through in monitor mode', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'monitor' });
+    const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('ignores attestation entirely when off — the deployed default', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('fails closed when asked to enforce without config', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'enforce', APP_ATTEST_ROOT_CA: undefined });
+    const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
+    expect(res.status).toBe(500);
+  });
+
+  it('refuses a token minted for a different install', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'enforce' });
+    const token = await enrol(env);
+    const res = await worker.fetch(
+      messagesRequest(`jefeA.someone-elses-install.${token}~${APP_SECRET}`),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('spends a challenge exactly once', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(attestRequest('/v1/attest/challenge', {}), env, ctx);
+    const { challenge } = (await res.json()) as { challenge: string };
+    const keyId = toBase64Url(world.keyId);
+    const attestation = toBase64Url(await world.attestationFor(challenge));
+
+    const first = await worker.fetch(
+      attestRequest('/v1/attest/attest', { key_id: keyId, challenge, attestation }),
+      env,
+      ctx
+    );
+    expect(first.status).toBe(200);
+
+    const replay = await worker.fetch(
+      attestRequest('/v1/attest/attest', { key_id: keyId, challenge, attestation }),
+      env,
+      ctx
+    );
+    expect(replay.status).toBe(403);
+    expect(await replay.text()).toContain('bad_challenge');
+  });
+
+  it('refuses a challenge issued to a different install', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(attestRequest('/v1/attest/challenge', {}), env, ctx);
+    const { challenge } = (await res.json()) as { challenge: string };
+
+    const stolen = await worker.fetch(
+      attestRequest(
+        '/v1/attest/attest',
+        {
+          key_id: toBase64Url(world.keyId),
+          challenge,
+          attestation: toBase64Url(await world.attestationFor(challenge)),
+        },
+        `jefe.other-install-99.${APP_SECRET}`
+      ),
+      env,
+      ctx
+    );
+    expect(stolen.status).toBe(403);
+  });
+
+  it('refuses to assert against a key another install attested', async () => {
+    const env = makeEnv();
+    await enrol(env);
+    const res = await worker.fetch(
+      attestRequest('/v1/attest/challenge', {}, `jefe.other-install-99.${APP_SECRET}`),
+      env,
+      ctx
+    );
+    const { challenge } = (await res.json()) as { challenge: string };
+    const hijack = await worker.fetch(
+      attestRequest(
+        '/v1/attest/assert',
+        {
+          key_id: toBase64Url(world.keyId),
+          challenge,
+          assertion: toBase64Url(await world.assertionFor(challenge, 9)),
+        },
+        `jefe.other-install-99.${APP_SECRET}`
+      ),
+      env,
+      ctx
+    );
+    expect(hijack.status).toBe(403);
+    expect(await hijack.text()).toContain('key_install_mismatch');
+  });
+
+  it('requires a credential on the attestation routes', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      new Request('https://proxy.test/v1/attest/challenge', { method: 'POST', body: '{}' }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('reports 503 rather than crashing when attestation is unconfigured', async () => {
+    const env = makeEnv({ APP_ATTEST_APP_ID: undefined });
+    const res = await worker.fetch(attestRequest('/v1/attest/challenge', {}), env, ctx);
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects a malformed body without a 500', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      new Request('https://proxy.test/v1/attest/attest', {
+        method: 'POST',
+        headers: { 'x-api-key': `jefe.${INSTALL}.${APP_SECRET}` },
+        body: 'not json',
+      }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('challenge storage', () => {
+  it('issues, claims once, and refuses a claim by the wrong install', async () => {
+    const kv = fakeKv();
+    const challenge = await issueChallenge(kv, INSTALL);
+    expect(await claimChallenge(kv, challenge, 'someone-else')).toBe(false);
+    expect(await claimChallenge(kv, challenge, INSTALL)).toBe(true);
+    expect(await claimChallenge(kv, challenge, INSTALL)).toBe(false);
+  });
+
+  it('issues distinct challenges', async () => {
+    const kv = fakeKv();
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) seen.add(await issueChallenge(kv, INSTALL));
+    expect(seen.size).toBe(50);
+  });
+});

--- a/services/proxy/wrangler.toml
+++ b/services/proxy/wrangler.toml
@@ -13,6 +13,29 @@ compatibility_date = "2026-07-25"
 DAILY_SPEND_CAP_USD = "25"
 PER_INSTALL_DAILY_CAP_USD = "2"
 
+# --- App Attest (Phase 2) --------------------------------------------------
+# `off` | `monitor` | `enforce`. Ships as `off`: the device half does not exist
+# yet, and even once it does, `enforce` before a `monitor` soak would lock out
+# every already-installed build. Anything unrecognised also means `off`.
+ATTEST_MODE = "off"
+
+# Required before ATTEST_MODE can leave `off`. Both are public values, so they
+# live here rather than in secrets — but the worker fails CLOSED without them.
+#
+# APP_ATTEST_APP_ID is "<TeamID>.<bundle id>". Note the real-core build uses
+# com.isaacwm.sitewalk; the demo project's id differs, and a mismatch shows up
+# as `app_id_mismatch` on every attestation.
+# APP_ATTEST_APP_ID = "TEAMID.com.isaacwm.sitewalk"
+#
+# APP_ATTEST_ROOT_CA is Apple's App Attest root, PEM. It is configured rather
+# than compiled in so it can be rotated without a code change:
+#   curl -O https://www.apple.com/certificateauthority/private/Apple_App_Attestation_Root_CA.pem
+#   wrangler secret put APP_ATTEST_ROOT_CA < Apple_App_Attestation_Root_CA.pem
+#
+# APP_ATTEST_ALLOW_DEVELOPMENT = "true" also accepts attestations from builds
+# signed with a development profile. Useful on a staging worker, never in
+# production — a development attestation is a far lower bar to clear.
+
 [[kv_namespaces]]
 binding = "METER"
 # Created 2026-07-26 via `wrangler kv namespace create METER`.


### PR DESCRIPTION
Implements §3.2 of `BEFORE-THE-MONTH-AWAY.md` — the half of App Attest that is mine. The device half stays dam's, and is filed separately.

## Why now

`src/auth.ts` has always been honest about what Phase 1 is: the app secret ships inside the IPA, so anyone willing to unzip a build can mint a valid credential. That is a fine trade while every install came from an invite we sent. It stops being fine the day the App Store listing goes public, because the binary becomes downloadable by anyone, and an open LLM proxy is a thing people actively scan for.

Right now the only thing standing between that and a bill is the $25/day cap.

## What this adds

Verification for `DCAppAttestService` output, plus the routes to enrol a device.

```
1.  app → POST /v1/attest/challenge        one-time, 5 minutes
2.  app → POST /v1/attest/attest           { key_id, challenge, attestation }
3.  app → POST /v1/attest/assert           { key_id, challenge, assertion } → token
4.  app → POST /v1/messages                credential carries the token
```

Steps 1–3 run **once an hour**, not per message. Asserting on every request would double the round trips on exactly the cellular link this app runs on — a contractor standing in a back yard.

Every check Apple documents is implemented, and each one is load-bearing:

| Check | What it stops |
|---|---|
| chain to Apple's pinned root | a self-signed key claiming to be Secure Enclave |
| nonce = `SHA256(authData ‖ SHA256(challenge))` | replaying an old attestation, **and** tampering with `authData` |
| `keyId == SHA256(publicKey)` | attesting one key, using another |
| `rpIdHash == SHA256(appId)` | an attestation harvested from a different app |
| `counter == 0` | presenting a key that has already been used |
| aaguid | a development-signed build passing as production |
| assertion counter strictly increases | replaying a captured assertion |
| token bound to `installId` | one attested device minting tokens for every install id and spreading its spend across everyone else's caps |

## It ships inert

`ATTEST_MODE` defaults to `off`, and the device half does not exist yet, so **nothing about the running service changes when this merges.** Rollout is `off` → `monitor` → `enforce`.

`monitor` is not skippable. It verifies and logs but never rejects, which is the only way to find out whether `enforce` is safe before it locks out every already-installed build — testers included. Watch `attest_token_rejected` fall toward zero as builds carrying the device half roll out.

A typo in `ATTEST_MODE` means `off`, so a fat finger cannot brick the fleet. But `monitor`/`enforce` with missing config is a hard 500 — asking for enforcement and quietly getting none is strictly worse than a deploy that visibly fails.

## Thinking

**Why hand-written CBOR and DER.** Workers have no `X509Certificate` (that is `node:crypto`, and we run without `nodejs_compat`) and no CBOR primitive. So the parsers are ours. The line I drew: **hand-rolled parsing is survivable, hand-rolled ECDSA is not.** Every signature, digest and MAC goes through Web Crypto. The hand-written code only walks bytes.

Both parsers are deliberately hostile to anything unexpected — indefinite lengths, trailing bytes, duplicate map keys, multi-byte tags, compressed EC points, RSA signature algorithms all throw rather than being tolerated. Trailing bytes and duplicate keys especially: "valid prefix, then junk" and "two verifiers disagree which value wins" are how parser differentials get exploited.

**Why a token instead of an assertion per request.** Partly latency, partly plumbing. The Rust provider sends `config.api_key` as the only caller-controlled header, so `/v1/messages` has nowhere to put a CBOR assertion. A compact token fits; `jefeA.<installId>.<token>~<appSecret>`. `jefe.` keeps working untouched — builds already on testers' phones must not stop being able to talk to the proxy.

The `~` is deliberate rather than another dot: the token is itself dotted, so a pure-dot format would force the credential parser to know the token's internal shape. And the app secret is **still checked** on attested credentials. Attestation adds a layer; it does not remove the one underneath.

**The honest limit of the tests.** They build a real certificate chain with real ECDSA keys rather than replaying a captured attestation. That is not gold-plating — a recorded blob proves one happy path and nothing else, because you cannot corrupt one field and re-sign it. Every negative test against a recording degenerates into "garbage in, error out", which a verifier that rejects *everything* would also pass.

Holding the private keys means each test changes exactly one thing and asserts that *that* check fires. I verified this is real by mutation — deleting the nonce check, the chain verification, the assertion counter check, or the token's install binding each breaks a test that names it, and restoring each one brings the suite back to green.

What this **cannot** prove is that we accept Apple's genuine root, because the sandbox had no network to fetch it and I was not willing to paste in a certificate I could not verify. So the root is configuration, not a compiled-in constant — which is better practice anyway, since it can rotate without a code change. **Accepting a real Apple chain is the one thing that has to be checked on a device**, and it is why the rollout starts in `monitor`.

**Not implemented on purpose.** The attestation `receipt` is parsed out but never sent to Apple for risk metrics or key refresh. Separate endpoint, separate auth, entirely optional — half-shipping it would be worse than not shipping it.

**KV honesty.** Challenge single-use is best-effort, not a hard guarantee, because KV is eventually consistent. Two requests racing the same challenge inside the replication window can both succeed. Acceptable: the challenge is a freshness bound, so winning that race gets an attacker a second copy of a token they already had. Durable Objects are the upgrade path, same as the spend counters.

## Verification

- 74 tests pass (57 new), `npm run typecheck` clean under `strict` + `noUncheckedIndexedAccess`
- Full enrolment walked end to end through `worker.fetch` — challenge → attest → assert → an enforced `/v1/messages` returning 200
- Backward compatibility pinned: a plain `jefe.` credential still authenticates
- All three modes pinned, including `off` as the deployed default and the fail-closed 500 on missing config
- Mutation-tested as described above

## What is still needed before this can be turned on

1. **The device half** (dam) — `DCAppAttestService` key generation, the enrolment calls, token caching, credential switch. Filed as #316.
2. `APP_ATTEST_APP_ID` = `<TeamID>.com.isaacwm.sitewalk` and Apple's root PEM configured.
3. A soak in `monitor` before anyone touches `enforce`.
