### PR TITLE
meta: tell dam the App Attest server half is on main and unreviewed

### DIFF
--- a/meta/dam/BEFORE-THE-MONTH-AWAY.md
+++ b/meta/dam/BEFORE-THE-MONTH-AWAY.md
@@ -191,7 +191,7 @@ becomes a sac-side feature that can ship in 1.1. Without them it waits a month.
 **This is the single highest-leverage hour of core work available.** If you
 think landing a capability with no consumer is wrong, say so on the issue.
 
-### 3.2 App Attest — server half DONE (#315), device half is yours (#316)
+### 3.2 App Attest — server half is ON MAIN and UNREVIEWED; device half is yours (#316)
 
 Hard prerequisite for a **public** listing. Not for TestFlight.
 
@@ -202,7 +202,20 @@ State the exposure accurately: the **global $25/day cap holds**, so this is
 ~$750/month worst case, not unbounded. The real risk is **availability** — an
 abuser burning the global cap denies service to paying subscribers mid-job.
 
-**Update 2026-08-08.** I wrote the server half — #315. Chain verification to
+**Update 2026-08-08 — read the correction below before the description.**
+
+The server half is **already on main**, in `26f8cca`, and **you never reviewed
+it**. I cut the paywall branch off the attestation branch instead of off `main`,
+so squash-merging #317 swept it along; the squash also destroyed the commit
+message that explained it. PR **#315 is closed** but its body is intact and is
+the review document — the diff is `git show 26f8cca -- services/proxy`.
+
+Isaac's call was to leave it rather than churn main, on the basis that it cannot
+run: `ATTEST_MODE = "off"`, missing config fails closed, and no workflow deploys
+or tests the proxy. All three verified. **The review is still owed, and the
+device work below is untouched by any of it.**
+
+I wrote the server half — originally #315. Chain verification to
 Apple's root, the nonce/keyId/rpId/counter/aaguid checks, assertion counter
 replay protection, and an hourly token so the app asserts once an hour rather
 than once per message. It ships **inert**: `ATTEST_MODE=off`, and nothing on

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -18,16 +18,45 @@ If you have one hour: **§2.1** (my core change — it replaced a named test of
 yours), **§3.1** (#263), **§4.1** (the ASC key, which has now blocked me twice),
 **§4.2** (do the certs outlive the trip?).
 
-**Since then (2026-08-08), two of your queued items now have code waiting:**
+**Since then (2026-08-08), two of your queued items have code waiting — and one
+of them is already on main by mistake. Read this before you touch the proxy.**
 
-- **#315 — App Attest server half** (§3.2). Verification is written and tested;
-  ships inert behind `ATTEST_MODE=off`. Device half is #316, and it is yours.
-  The residual risk is that the verifier has never seen a *genuine* Apple chain
-  — the sandbox had no network to fetch the real root, so the tests use a
-  synthetic one. That closes with one real attestation in `monitor` mode.
-- **#314 — the CI upload guard** (§3.6). **Deliberately left a DRAFT.**
-  `release.yml` strands everyone if it breaks while you are away, and this is a
-  convenience fix for a problem I caused. Merge, change, or reject — your call.
+### App Attest: the server half is ON MAIN, unreviewed (§3.2, and #316 is yours)
+
+I cut the paywall branch off my App Attest branch instead of off `main`, so
+squash-merging #317 carried the whole attestation server half with it. It landed
+in `26f8cca`, under a commit titled *"store: lifetime free allowance, an annual
+plan, and a paywall that can sell both"* — which says nothing about attestation,
+because the squash ate that message. **My mistake, and Isaac's call to leave it
+rather than churn main.**
+
+- **It cannot run.** `ATTEST_MODE = "off"` in `wrangler.toml`, missing config
+  fails closed, and no workflow deploys *or tests* the proxy (`release.yml`
+  mentions `services/proxy` only in a comment). Verified, not assumed.
+- **It was never reviewed.** That is the actual cost, and it is the thing I am
+  asking you to fix. The full thinking is preserved on **closed PR #315** — read
+  that as the review document. The diff is `git show 26f8cca -- services/proxy`,
+  byte-identical to what the PR would have shown you.
+- **The one thing that needs YOU, not a review.** The verifier has never seen a
+  *genuine* Apple chain. My sandbox had no network to fetch Apple's real root CA
+  and I would not paste in a certificate I could not verify, so the 57 tests
+  build a synthetic chain with real ECDSA keys. That proves every check fires on
+  every malformation I could construct — it does not prove we accept Apple.
+  Closing it needs a device: configure the worker, `ATTEST_MODE=monitor`, one
+  real attestation from a TestFlight build, confirm `attest_ok` in the logs and
+  not `chain_signature_invalid`. If it fails, the suspects are all in
+  `services/proxy/src/der.ts` and all have unit tests to extend.
+- **Then the device half — #316.** `DCAppAttestService`, the entitlement, token
+  caching, the `jefeA.` credential. Yours. Nothing is enforceable until it lands.
+
+Rollout is `off` → `monitor` → `enforce`, and `monitor` is not skippable —
+`enforce` before builds carry the device half locks out every install we have.
+
+### #314 — the CI upload guard (§3.6)
+
+**Deliberately left a DRAFT.** `release.yml` strands everyone if it breaks while
+you are away, and this is a convenience fix for a problem I caused. Merge,
+change, or reject — your call.
 
 The sections below are the older, longer-form context. The handover doc
 supersedes them where they disagree.


### PR DESCRIPTION
Docs only — `meta/` is in `release.yml`'s `paths-ignore`, so this burns no build number and no TestFlight slot.

## What happened

I cut `feat/sac/lifetime-free-tier-and-annual` off my App Attest branch instead of off `main`. Squash-merging #317 therefore carried the entire attestation server half onto main, in `26f8cca`, under a commit titled *"store: lifetime free allowance, an annual plan, and a paywall that can sell both"* — which mentions nothing about attestation, because the squash destroyed the message that did.

**dam never reviewed it.** That is the real cost, not the code being on main.

## Why it stays

Isaac's call, on the basis that it cannot run. Verified rather than assumed:

- `ATTEST_MODE = "off"` in `wrangler.toml`
- Missing config fails closed (a hard 500, not a silent downgrade)
- **No workflow deploys or even tests the proxy** — `release.yml` references `services/proxy` in a comment and nowhere else

Reverting would not create the review that didn't happen; it would only relocate the bytes. It would also cost a surgical partial revert (the squash also holds the paywall work Isaac is testing), a second PR to re-land, two more CI runs against the upload quota #314 exists to protect, and 4–6 weeks of branch rot while dam is away.

## What this PR changes

Both files dam's session actually reads now say so plainly.

**`meta/sac/STATE.md`** — read at session start per `CLAUDE.md`. Replaces the line claiming "#315 is waiting for you" (that PR is closed) with where the code actually is, that it is unreviewed, and what only he can do.

**`meta/dam/BEFORE-THE-MONTH-AWAY.md` §3.2** — heading and a correction ahead of the original description, so nobody reads the old framing first.

Both carry the same three points:

1. **It is on main, in `26f8cca`, and unreviewed.** Closed PR #315's body is intact and is the review document; `git show 26f8cca -- services/proxy` is byte-identical to the diff it would have shown.
2. **It cannot run**, with the three gates named so he can check them himself rather than take my word.
3. **The one thing tests could not cover.** The verifier has never seen a *genuine* Apple chain — my sandbox had no network to fetch Apple's real root and I would not paste in a certificate I could not verify, so the 57 tests build a synthetic chain with real ECDSA keys. That proves every check fires on every malformation I could construct; it does not prove we accept Apple. Closing it needs a device: `ATTEST_MODE=monitor`, one real attestation, confirm `attest_ok` and not `chain_signature_invalid`. Suspects on failure are all in `services/proxy/src/der.ts`.

Then #316, the device half, which is his and which nothing is enforceable without.
