### PR TITLE
fix: spoken prices land on the work they describe — plus one walk's worth of field reports

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -296,6 +296,16 @@ final class AppModel {
     var document: DocumentModel?
     var editingRowID: UUID?
     var editText = ""
+    /// The line's description, edited alongside its amount. Isaac, 2026-08-09:
+    /// "the user should be able to edit the name of any of the lines, and also
+    /// delete or add a line should they choose." A transcript gets a word
+    /// wrong roughly as often as it gets a number wrong, and until now only
+    /// the number could be fixed on the paper.
+    var editTitle = ""
+    /// True while the row being edited was just added by ADD LINE and has
+    /// never had a description. Dismissing without typing one must leave no
+    /// blank line behind on the document.
+    var editingRowIsNew = false
     var shareURL: URL?
 
     // Not fully `private`: read from AppModel+Photos.swift (a same-module
@@ -827,9 +837,15 @@ final class AppModel {
             // Metered on OUTPUT, not on tapping START: the count moves only
             // once a walk has actually produced notes. Someone who starts a
             // walk, realizes they're at the wrong address, and discards it has
-            // received nothing and must not be charged for it. Pro is unmetered
-            // — no reason to keep a count nobody reads.
-            if metered && !self.entitlement.isPro {
+            // received nothing and must not be charged for it. The rest of the
+            // rule — Pro, practice, demo, and the `canSubscribe` clause that
+            // stops a whole TestFlight cohort burning its allowance against a
+            // product nobody can buy — is `WalkAllowance.shouldCount`.
+            if WalkAllowance.shouldCount(
+                isPro: self.entitlement.isPro,
+                canSubscribe: self.entitlement.canSubscribe,
+                isMeteredWalk: metered
+            ) {
                 WalkMeter.recordFinishedWalk()
             }
             // A FINISHED walk is a walk, whether or not a document was ever
@@ -1520,33 +1536,131 @@ final class AppModel {
 
     // MARK: Review interactions
 
+    /// Provenance for a line the operator added at review, kept off the walk's
+    /// own vocabulary ("NOT HEARD", "FILLED BY YOU") because it is a different
+    /// claim: this line was never spoken at all.
+    static let addedLineNote = "ADDED BY YOU"
+
     func beginEdit(_ row: DocRowFixture) {
         editingRowID = row.id
-        editText = row.amount.hasPrefix("$") ? String(row.amount.dropFirst()) : ""
+        editTitle = row.title
+        editingRowIsNew = false
+        // Grouping separator stripped: the field is a decimal pad, which has
+        // no comma key, so leaving one in gives the operator a value they
+        // cannot retype.
+        editText = row.amount.hasPrefix("$")
+            ? row.amount.dropFirst().replacingOccurrences(of: ",", with: "")
+            : ""
     }
 
+    /// Appends a blank line and opens it for editing.
+    ///
+    /// The line is added to the document immediately rather than on commit so
+    /// there is only ever one code path that writes a row — but it is marked
+    /// `editingRowIsNew`, so a sheet dismissed without a description takes the
+    /// blank row back out with it. An operator who taps ADD LINE and changes
+    /// their mind should not have to then delete something.
+    func addLine() {
+        guard var doc = document else { return }
+        let row = DocRowFixture(
+            title: "",
+            sub: Self.addedLineNote,
+            subWarn: false,
+            qty: "",
+            amount: doc.pricesShown ? "——" : "",
+            isGap: doc.pricesShown
+        )
+        doc.rows.append(row)
+        document = doc
+        editingRowID = row.id
+        editTitle = ""
+        editText = ""
+        editingRowIsNew = true
+    }
+
+    /// Removes the line being edited. Deliberately not a swipe: this screen is
+    /// read on a job site with gloves on, and a swipe that deletes a line off
+    /// an estimate is too easy to do by accident while scrolling.
+    func removeEditingLine() {
+        guard let id = editingRowID, var doc = document else { return }
+        doc.rows.removeAll { $0.id == id }
+        document = doc
+        editingRowID = nil
+        editingRowIsNew = false
+    }
+
+    /// Writes the sheet back onto the line.
+    ///
+    /// Both fields are optional edits, and each one's EMPTY case is a real
+    /// instruction rather than a no-op:
+    /// - An emptied description on an existing line keeps the old one (there
+    ///   is no such thing as an untitled line on a document); on a line just
+    ///   added it means "never mind", and the line goes.
+    /// - An emptied amount returns the line to an honest gap. Silently
+    ///   keeping the old number would be the one failure this screen exists
+    ///   to prevent — a price on a sent estimate that nobody agreed to.
     func commitEdit() {
         guard let id = editingRowID, var doc = document,
               let index = doc.rows.firstIndex(where: { $0.id == id }) else {
             editingRowID = nil
+            editingRowIsNew = false
             return
         }
-        let cleaned = editText.replacingOccurrences(of: ",", with: "").trimmingCharacters(in: .whitespaces)
-        if let value = Int(cleaned), value > 0 {
-            let old = doc.rows[index]
-            doc.rows[index] = DocRowFixture(
-                title: old.title,
-                sub: old.isGap ? "FILLED BY YOU" : old.sub,
-                subWarn: false,
-                hint: old.hint,
-                qty: old.qty,
-                amount: "$\(value)",
-                isEdit: false,
-                isGap: false
-            )
-            document = doc
+        let title = editTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if title.isEmpty && editingRowIsNew {
+            removeEditingLine()
+            return
         }
+        let old = doc.rows[index]
+        var row = old
+        row.title = title.isEmpty ? old.title : title
+        row.isEdit = false
+
+        // A document that carries no money keeps its amount column empty
+        // whatever is typed — a work order handed to a crew must not grow a
+        // price (the same rule `DemoWalkEngine.buildDocument` documents), so
+        // the sheet doesn't offer the field and this ignores it.
+        if doc.pricesShown {
+            let cleaned = editText
+                .replacingOccurrences(of: ",", with: "")
+                .replacingOccurrences(of: "$", with: "")
+                .trimmingCharacters(in: .whitespaces)
+            // A line the operator added themselves keeps saying so through
+            // every edit. "FILLED BY YOU" and "NOT HEARD" are both claims
+            // about what the WALK produced, and neither is true of a line the
+            // walk never produced.
+            let added = old.sub == Self.addedLineNote
+            // Parsed as a decimal, not an Int: a line that already carries
+            // cents ("$125.50") has to survive being opened and re-saved, and
+            // an Int parse silently refused it.
+            if let dollars = Double(cleaned), dollars > 0 {
+                row.amount = DocumentModel.money(cents: Int((dollars * 100).rounded()))
+                row.isGap = false
+                row.subWarn = false
+                if old.isGap && !added { row.sub = "FILLED BY YOU" }
+            } else if cleaned.isEmpty {
+                // Erased on purpose. Back to an honest gap — keeping the old
+                // number would be the one failure this screen exists to
+                // prevent, a price on a sent estimate nobody agreed to.
+                row.amount = "——"
+                row.isGap = true
+                if !added {
+                    row.sub = "NOT HEARD — TAP OR SAY IT"
+                    row.subWarn = true
+                }
+            }
+            // Anything else typed (letters, a stray symbol) leaves the amount
+            // exactly as it was: we cannot read it, so we do not act on it.
+        }
+
+        // `itemId` rides along on the copy. The old code rebuilt the row field
+        // by field and dropped it, which detached the row from the photos
+        // taken against that item mid-walk (`ReviewView.photos(for:)` joins on
+        // it) — so filling one gap quietly emptied that row's contact sheet.
+        doc.rows[index] = row
+        document = doc
         editingRowID = nil
+        editingRowIsNew = false
     }
 
     // MARK: Send

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -72,10 +72,12 @@ struct AppRoot: View {
                 licenseNumber: "44-1234", tradeKey: "landscape"
             ))
         }
-        // meter=N seeds the free-tier walk meter for the CURRENT month (parallel
-        // to autoprofile). The blocked-at-the-limit paywall is otherwise
-        // reachable only by finishing five real walks, which no headless
-        // screenshot run and no quick manual check can do. `meter=0` clears it.
+        // meter=N seeds the free-tier walk meter (parallel to autoprofile).
+        // The blocked-at-the-limit paywall is otherwise reachable only by
+        // finishing five real walks, which no headless screenshot run and no
+        // quick manual check can do. `meter=0` clears it — which is also the
+        // way to undo a lifetime allowance spent while testing, since the
+        // keychain survives delete-and-reinstall by design.
         if let arg = args.first(where: { $0.hasPrefix("meter=") }),
            let count = Int(arg.dropFirst("meter=".count)) {
             WalkMeter.save(WalkAllowance.Record(count: max(0, count)))
@@ -249,6 +251,21 @@ struct AppRoot: View {
                 if model.phase == .notes {
                     model.buildPrimaryDocument()
                     try? await Task.sleep(for: .seconds(2))
+                }
+            }
+            // editline=1 opens review's line editor on the first line (and
+            // editline=new on a freshly added one). Same reason as `newjob=1`:
+            // simctl cannot tap, and shipping an unseen UI surface is how the
+            // inline FILE chip ended up 130pt tall.
+            if autoflowRounds > 0, model.phase == .review,
+               let arg = ProcessInfo.processInfo.arguments.first(where: {
+                   $0.hasPrefix("editline=")
+               }) {
+                try? await Task.sleep(for: .seconds(1))
+                if arg == "editline=new" {
+                    model.addLine()
+                } else if let first = model.document?.rows.first {
+                    model.beginEdit(first)
                 }
             }
             // Screenshot-automation hook: render the PDF unattended.

--- a/apps/ios/Sources/App/WalkAllowance.swift
+++ b/apps/ios/Sources/App/WalkAllowance.swift
@@ -106,6 +106,32 @@ enum WalkAllowance {
         return .allowed(remaining: limit - used - 1)
     }
 
+    /// Whether a finished walk spends one of the free five.
+    ///
+    /// `canSubscribe` gates the COUNT for the same reason `decide` uses it to
+    /// gate the BLOCK: **an allowance we are not willing to enforce is not an
+    /// allowance we may spend.** Without that clause the meter runs through
+    /// the entire pre-launch window — every TestFlight tester silently burning
+    /// a lifetime allowance against a product that cannot be bought — and on
+    /// the day the App Store Connect product goes live they are all at zero,
+    /// having never had the free evaluation the tier exists to give them.
+    /// (Isaac, 2026-08-09, on his first walk after a reinstall: *"it said I
+    /// have 0 free walks left. I dont think this is correct."*)
+    ///
+    /// The other direction costs a handful of uncounted walks whenever
+    /// StoreKit is unreachable — the same fail-open trade `decide` makes, and
+    /// the cheaper one.
+    ///
+    /// `isMeteredWalk` carries `decide`'s two exemptions, restated at the
+    /// other end of the walk: a practice run is onboarding, and demo mode
+    /// makes no model calls at all, so neither costs anything the free tier
+    /// exists to bound. The caller computes it BEFORE the finish work, since
+    /// the exit paths clear the practice flag first.
+    static func shouldCount(isPro: Bool, canSubscribe: Bool, isMeteredWalk: Bool) -> Bool {
+        if isPro || !isMeteredWalk { return false }
+        return canSubscribe
+    }
+
     /// The record after a walk finishes.
     static func recordingFinish(in record: Record) -> Record {
         Record(count: max(0, record.count) + 1)

--- a/apps/ios/Sources/Components/Primitives.swift
+++ b/apps/ios/Sources/Components/Primitives.swift
@@ -53,6 +53,53 @@ struct SectionLabel: View {
     }
 }
 
+// MARK: - Empty panel (one idiom for "nothing here yet")
+
+/// The app's ONE way of saying a list is empty.
+///
+/// It had three. The board's walks list used a filled `paperDeep` slab, the
+/// jobs list directly beneath it used a white card with a hairline, and the
+/// document's photo well used a dashed outline — three answers to the same
+/// question, two of them stacked in the same scroll (Isaac's board shot,
+/// 2026-08-09: "the grey backdrop looks off when there are no walks"). Grey
+/// was the wrong one to keep: on a board whose section beds are also grey it
+/// stops reading as a card and starts reading as a hole in the layout.
+///
+/// A quiet white card with a hairline is what "nothing here yet" looks like
+/// in this app — the same sheet-on-paper grammar every real row uses, so an
+/// empty list reads as a list that is empty rather than as a different kind
+/// of surface. Dashed is deliberately NOT it: in app language dashed means
+/// disabled, and these lists are the opposite of disabled — they are waiting
+/// for the operator's first tap.
+///
+/// One documented exception: the photo well inside the rendered document
+/// (`ReviewView.photoGallery`) keeps its dashed outline, because this panel is
+/// sheet-white and the document it would sit on is too — an invisible card is
+/// not consistency. Dashed there also means what it says: a space waiting to
+/// be filled, on a page rather than in a list.
+struct EmptyPanel: View {
+    let text: String
+
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        Text(text)
+            .font(Theme.F.ui(14, .medium))
+            .foregroundStyle(Theme.C.ink60)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 22)
+            .background(Theme.C.sheet)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.S.radiusCard)
+                    .stroke(Theme.C.hairline, lineWidth: 1)
+            )
+    }
+}
+
 // MARK: - Metadata strip (provenance: site, sync, signal state)
 
 struct MetaStrip: View {

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -400,7 +400,8 @@ final class DemoWalkEngine: WalkEngine {
             staticTotal: priced ? trade.totalValue : "\(rows.count)",
             // The gap/price note only means anything on a priced document.
             note: priced ? trade.note : "",
-            send: "SEND \(DocKinds.label(for: kind).uppercased())"
+            send: "SEND \(DocKinds.label(for: kind).uppercased())",
+            pricesShown: priced
         )
     }
 

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -37,16 +37,13 @@ extension MurmurEngine {
         }
     }
 
-    private static let centsFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-
+    /// Cents → "$285" / "$125.50". Shared with the total (`DocumentModel.money`)
+    /// so a line and the sum underneath it can never disagree about how money
+    /// is written — and so a price with cents renders both digits instead of
+    /// the "$125.5" a bare decimal formatter produces.
     static func amountString(_ cents: Int64?) -> String {
         guard let cents else { return "——" }
-        let dollars = Double(cents) / 100.0
-        return "$" + (centsFormatter.string(from: NSNumber(value: dollars)) ?? "\(dollars)")
+        return DocumentModel.money(cents: Int(cents))
     }
 
     private static let dateFormatter: DateFormatter = {
@@ -119,7 +116,14 @@ extension MurmurEngine {
             subWarn: line.isGap,
             hint: nil, // Deferred 4: price-book autofill hint
             qty: line.qty,
-            amount: amountString(line.amountCents),
+            // No amount and not a gap = this document has no money story for
+            // this line, so the column stays EMPTY rather than showing "——".
+            // A dash means "a number is missing here"; on a work order —
+            // which must never carry prices — nothing is missing, and a
+            // column of dashes read as a document that had failed to price
+            // itself. (The demo engine has always stripped these; the real
+            // one didn't, so the two engines disagreed on the same document.)
+            amount: line.amountCents.map(amountString) ?? (line.isGap ? "——" : ""),
             isEdit: false, // Deferred 4: pre-filled-from-history affordance
             isGap: line.isGap,
             itemId: line.itemId
@@ -132,12 +136,21 @@ extension MurmurEngine {
             totalKey: totalLabel(payload.totalLabelKey),
             staticTotal: payload.staticTotalCents.map(amountString) ?? "——",
             note: note(for: payload.docKind, queued: payload.queued),
-            send: sendLabel(for: payload.docKind)
+            send: sendLabel(for: payload.docKind),
+            // Built-in kinds answer directly; a custom schema (Plan 19) is
+            // priced iff core actually rendered money onto it — an amount or
+            // a gap on any line. Guessing from the kind name alone would tell
+            // an operator's own document type what it is allowed to be.
+            pricesShown: DocKinds.isPricingKind(payload.docKind)
+                || payload.lines.contains { $0.amountCents != nil || $0.isGap }
         )
     }
 
     static func emptyDocument() -> DocumentModel {
-        DocumentModel(rows: [], totalKey: "TOTAL", staticTotal: "——", note: "", send: "SEND")
+        DocumentModel(
+            rows: [], totalKey: "TOTAL", staticTotal: "——", note: "", send: "SEND",
+            pricesShown: false
+        )
     }
 
     // MARK: - Notes mapping (Plan 13 D2/D3; Plan 14 D2-14 grows it with buckets)

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -46,19 +46,47 @@ struct DocumentModel {
     var staticTotal: String   // used when rows carry no $ amounts (e.g. inspection)
     var note: String
     var send: String
+    /// Whether this document has an amount column at all.
+    ///
+    /// Set once, at build, from the kind — NOT inferred from the rows, which
+    /// would flip the wrong way the moment an operator cleared the last price
+    /// on an estimate. Review reads it to decide whether editing a line may
+    /// touch money: on a work order it may not, because a work order handed to
+    /// a crew with prices on it is the wrong document.
+    var pricesShown: Bool = true
 
     var gapCount: Int { rows.filter(\.isGap).count }
 
     /// Sum of $-parseable amounts; falls back to the template total.
+    ///
+    /// Summed in CENTS, from a `Double` parse. It used to parse each amount as
+    /// an `Int`, so any line carrying cents — "$125.50" — failed to parse and
+    /// was silently dropped from the total. A total that quietly omits a line
+    /// it is printed directly underneath is the worst kind of wrong on a
+    /// document someone signs, and it got likelier the moment spoken prices
+    /// started landing on lines verbatim.
     var totalValue: String {
-        let sum = rows.compactMap { row -> Int? in
+        let cents = rows.compactMap { row -> Int? in
             guard row.amount.hasPrefix("$") else { return nil }
-            return Int(row.amount.dropFirst().replacingOccurrences(of: ",", with: ""))
+            let digits = row.amount.dropFirst().replacingOccurrences(of: ",", with: "")
+            guard let dollars = Double(digits) else { return nil }
+            return Int((dollars * 100).rounded())
         }.reduce(0, +)
-        guard sum > 0 else { return staticTotal }
+        guard cents > 0 else { return staticTotal }
+        return DocumentModel.money(cents: cents)
+    }
+
+    /// Cents → "$1,210" / "$1,210.50". Whole dollars carry no decimals — a
+    /// trade document reads as money, not as a spreadsheet — and anything
+    /// with cents shows both digits, never the "$125.5" a plain decimal
+    /// formatter produces.
+    static func money(cents: Int) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        return "$" + (formatter.string(from: NSNumber(value: sum)) ?? "\(sum)")
+        formatter.minimumFractionDigits = cents % 100 == 0 ? 0 : 2
+        formatter.maximumFractionDigits = cents % 100 == 0 ? 0 : 2
+        let dollars = Double(cents) / 100
+        return "$" + (formatter.string(from: NSNumber(value: dollars)) ?? "\(dollars)")
     }
 }
 

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -46,7 +46,10 @@ struct CapturedFixture: Identifiable {
 
 struct DocRowFixture: Identifiable {
     let id = UUID()
-    let title: String
+    /// `var` so review can rename a line in place (#…, Isaac 2026-08-09).
+    /// Speech-to-text mishears a word about as often as it mishears a number,
+    /// and the description is what the client actually reads.
+    var title: String
     var sub: String
     var subWarn: Bool = false
     var hint: String? = nil

--- a/apps/ios/Sources/Flow/BoardView.swift
+++ b/apps/ios/Sources/Flow/BoardView.swift
@@ -175,19 +175,9 @@ struct BoardView: View {
                 if model.sessionWalks.isEmpty {
                     // Fresh board — no walks at all yet.
                     SectionHead(left: "TODAY", right: "0 WALKS", rightColor: Theme.C.amberInk)
-                    // Honest empty state, same dashed-box idiom as the
-                    // vocabulary editor's.
-                    Text("No walks yet. Tap Start walk and talk through the job.")
-                        .font(Theme.F.ui(14, .medium))
-                        .foregroundStyle(Theme.C.ink60)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 26)
-                        // Filled, not dashed. Dashed reads "disabled" in app
-                        // language; a quiet filled panel reads "nothing here
-                        // yet", which is what this actually is.
-                        .background(Theme.C.paperDeep)
-                        .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
+                    // One empty-state idiom, shared with JOBS directly below
+                    // — see `EmptyPanel`.
+                    EmptyPanel("No walks yet. Tap Start walk and talk through the job.")
                         .padding(.horizontal, Theme.S.screenPad)
                         .padding(.top, 16)
                 } else if model.looseWalks.isEmpty {
@@ -196,18 +186,7 @@ struct BoardView: View {
                     // "TODAY"; this is also filing's payoff ("it moved under the
                     // job").
                     SectionHead(left: "UNFILED", right: "0 WALKS", rightColor: Theme.C.amberInk)
-                    Text("Everything's filed under a job below.")
-                        .font(Theme.F.mono(8.5))
-                        .tracking(0.8)
-                        .foregroundStyle(Theme.C.ink45)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 22)
-                        // Filled, not dashed. Dashed reads "disabled" in app
-                        // language; a quiet filled panel reads "nothing here
-                        // yet", which is what this actually is.
-                        .background(Theme.C.paperDeep)
-                        .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
+                    EmptyPanel("Everything's filed under a job below.")
                         .padding(.horizontal, Theme.S.screenPad)
                         .padding(.top, 16)
                 } else {
@@ -484,26 +463,23 @@ extension BoardView {
             }
 
             if activeJobs.isEmpty {
-                Text("No jobs yet. Add one and your walks will file under it.")
-                    .font(Theme.F.ui(14, .medium))
-                    .foregroundStyle(Theme.C.ink60)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 22)
-                    .background(Theme.C.sheet)
-                    .clipShape(RoundedRectangle(cornerRadius: Theme.S.radiusCard))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Theme.S.radiusCard)
-                            .stroke(Theme.C.hairline, lineWidth: 1)
-                    )
+                EmptyPanel("No jobs yet. Add one and your walks will file under it.")
                     .padding(.horizontal, Theme.S.screenPad)
                     .padding(.top, 12)
+                    .padding(.bottom, 14)
             } else {
                 // Spaced, inset cards on a paperDeep bed — the container is
                 // what does the grouping now, so the cards need air between
                 // them and a darker ground to read as sheets ON something.
+                //
+                // The bed is on the CARDS, not on the section: without it,
+                // sheet-white cards on paper-white are invisible as
+                // containers and the grouping does nothing — but a bed under
+                // the header too made JOBS the one section head in the app
+                // sitting on grey while TODAY, two rows up, sat on paper, and
+                // when the list was empty it painted a grey slab grounding
+                // nothing (Isaac, 2026-08-09). The bed now appears exactly
+                // when there is something for it to ground.
                 VStack(spacing: 10) {
                     ForEach(activeJobs) { job in
                         OperatorJobCard(job: job, walks: walks(for: job.id)) { walk in
@@ -514,11 +490,10 @@ extension BoardView {
                 .padding(.horizontal, Theme.S.screenPad)
                 .padding(.top, 12)
                 .padding(.bottom, 14)
+                .frame(maxWidth: .infinity)
+                .background(Theme.C.paperDeep)
             }
         }
-        // The bed the cards sit on. Without it, sheet-white cards on paper-white
-        // are invisible as containers and the grouping does nothing.
-        .background(Theme.C.paperDeep)
         .onAppear(perform: loadJobs)
         // A SHEET, not an `.alert` (design review P1 #9). A TextField inside an
         // alert is a ~30pt target with no room for a real placeholder — the two

--- a/apps/ios/Sources/Flow/PaywallView.swift
+++ b/apps/ios/Sources/Flow/PaywallView.swift
@@ -150,6 +150,17 @@ struct PaywallView: View {
     }
 
     private var subtitle: String {
+        // With nothing purchasable, the gate declines to block and the meter
+        // declines to count (see `WalkAllowance.decide` and `AppModel`'s
+        // finish path), so ANY remaining-walks number here is a claim about a
+        // limit that is not in force. Isaac's TestFlight shot, 2026-08-09:
+        // "0 free walks left" sitting directly above this same sheet's "Your
+        // walks aren't limited while this is down." One of those was a lie,
+        // and it was this one. The board's plan chip already hides itself on
+        // exactly this condition — this is the second surface catching up.
+        guard entitlement.canSubscribe else {
+            return "Pro stops counting walks altogether."
+        }
         switch reason {
         case .blocked:
             // No "they reset on the 1st" any more — they don't. Saying plainly

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -7,6 +7,7 @@ import PhotosUI
 struct ReviewView: View {
     @Bindable var model: AppModel
     @FocusState private var amountFocused: Bool
+    @FocusState private var titleFocused: Bool
     // Photos (Plan 11) — functional-plain capture entry point + gallery.
     // sac: placement, layout, thumbnails, empty state are yours; this just
     // wires PhotosPicker → bytes → engine.attachPhoto.
@@ -65,7 +66,10 @@ struct ReviewView: View {
                             DocRowView(row: row)
                                 .contentShape(Rectangle())
                                 .onTapGesture { model.beginEdit(row) }
+                                .accessibilityElement(children: .combine)
+                                .accessibilityHint("Edit this line")
                         }
+                        addLineButton
                         TotalRow(key: doc.totalKey, value: doc.totalValue, gaps: doc.gapCount)
                             .padding(.top, 2)
                         // Empty note = no bar. An empty amber block reads as a
@@ -278,41 +282,109 @@ struct ReviewView: View {
         }
     }
 
-    private var editSheet: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            SectionLabel("SET AMOUNT")
-            HStack(spacing: 4) {
-                Text("$")
-                    .font(Theme.F.mono(24, .semibold))
-                    .foregroundStyle(Theme.C.ink60)
-                TextField("0", text: $model.editText)
-                    .font(Theme.F.mono(28, .semibold))
-                    .keyboardType(.numberPad)
-                    .focused($amountFocused)
+    /// Adding a line back, in the operator's own hand.
+    ///
+    /// Under the last line rather than beside the header: an estimate is read
+    /// top to bottom and the next line goes at the bottom, so the control sits
+    /// where the thing it makes will appear. Quiet by design — it is an
+    /// occasional correction, not the screen's job, and it must not compete
+    /// with SEND.
+    private var addLineButton: some View {
+        Button { model.addLine() } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .bold))
+                Text("ADD LINE")
+                    .font(Theme.F.mono(9, .semibold))
+                    .tracking(1.2)
             }
-            .padding(.bottom, 4)
-            .overlay(alignment: .bottom) { Theme.C.orangeDeep.frame(height: 2) }
+            .foregroundStyle(Theme.C.amberInk)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.S.radiusCard)
+                    .stroke(Theme.C.orangeDeep.opacity(0.45), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 10)
+        .accessibilityLabel("Add a line")
+    }
+
+    /// One sheet for everything a line can need: its words, its number, and
+    /// its removal.
+    ///
+    /// It used to be SET AMOUNT alone, which quietly said the only thing that
+    /// could be wrong on a document was a price. The description is what the
+    /// client actually reads, and speech-to-text mishears a word about as
+    /// often as it mishears a number (Isaac, 2026-08-09).
+    private var editSheet: some View {
+        let priced = model.document?.pricesShown ?? false
+        return VStack(alignment: .leading, spacing: 16) {
+            SectionLabel(model.editingRowIsNew ? "NEW LINE" : "EDIT LINE")
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text("DESCRIPTION")
+                    .font(Theme.F.mono(8, .semibold))
+                    .tracking(1.2)
+                    .foregroundStyle(Theme.C.ink60)
+                TextField("What the work is", text: $model.editTitle, axis: .vertical)
+                    .font(Theme.F.ui(17, .semibold))
+                    .lineLimit(1...3)
+                    .focused($titleFocused)
+                    .padding(.bottom, 4)
+                    .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1.5) }
+            }
+
+            if priced {
+                VStack(alignment: .leading, spacing: 5) {
+                    // "Leave it empty" belongs on the LABEL, not in the field:
+                    // as placeholder text it set at the field's own 24pt and
+                    // read as a value someone had typed.
+                    Text("AMOUNT · LEAVE EMPTY FOR A GAP")
+                        .font(Theme.F.mono(8, .semibold))
+                        .tracking(1.2)
+                        .foregroundStyle(Theme.C.ink60)
+                    HStack(spacing: 4) {
+                        Text("$")
+                            .font(Theme.F.mono(24, .semibold))
+                            .foregroundStyle(Theme.C.ink60)
+                        TextField("0", text: $model.editText)
+                            .font(Theme.F.mono(24, .semibold))
+                            // Decimal, not number: a line can carry cents, so
+                            // the keyboard has to be able to type them back.
+                            .keyboardType(.decimalPad)
+                            .focused($amountFocused)
+                    }
+                    .padding(.bottom, 4)
+                    .overlay(alignment: .bottom) { Theme.C.orangeDeep.frame(height: 2) }
+                }
+            }
 
             Button { model.commitEdit() } label: {
-                ZStack {
-                    RoundedRectangle(cornerRadius: Theme.S.radius)
-                        .fill(Theme.C.orangeDeep)
-                        .offset(y: 3)
-                    RoundedRectangle(cornerRadius: Theme.S.radius)
-                        .fill(Theme.C.orange)
-                    Text("SET")
-                        .font(Theme.F.ui(15, .bold))
-                        .tracking(1.4)
-                        .foregroundStyle(Theme.C.onOrange)
-                }
-                .frame(height: Theme.S.buttonHeight)
+                BlockLabel("SET")
             }
-            .buttonStyle(.plain)
+            .buttonStyle(RaisedBlockStyle(height: Theme.S.buttonHeight, leadingDot: false))
+
+            // Ink, not red, and last: it removes a line from an unsent draft
+            // that can be added straight back, so dressing it as destructive
+            // would overstate it — the same call DISCARD makes on this screen.
+            Button { model.removeEditingLine() } label: {
+                Text(model.editingRowIsNew ? "Cancel" : "Remove this line")
+                    .font(Theme.F.ui(13, .semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.wellChip)
         }
         .padding(Theme.S.screenPad)
-        .presentationDetents([.height(220)])
+        .presentationDetents([.height(priced ? 400 : 300)])
         .presentationBackground(Theme.C.paper)
-        .onAppear { amountFocused = true }
+        // A new line has nothing to say yet, so start in the words; an
+        // existing one is most often opened to fix its number.
+        .onAppear {
+            if model.editingRowIsNew || !priced { titleFocused = true } else { amountFocused = true }
+        }
     }
 }
 

--- a/apps/ios/Sources/Flow/VocabularyView.swift
+++ b/apps/ios/Sources/Flow/VocabularyView.swift
@@ -98,21 +98,15 @@ struct VocabularyView: View {
 
             // Terms
             if model.vocabulary.isEmpty {
-                Text("No terms yet. Add the words your crew actually says.\n\u{201C}boxwood\u{201D} · \u{201C}GFCI\u{201D} · \u{201C}Hollis\u{201D}")
-                    .font(Theme.F.mono(8.5))
-                    .tracking(0.6)
-                    .foregroundStyle(Theme.C.ink45)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(5)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 26)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Theme.S.radiusCard)
-                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-                            .foregroundStyle(Theme.C.ink45)
-                    )
-                    .padding(.horizontal, Theme.S.screenPad)
-                    .padding(.top, 16)
+                // The board's idiom, not a third one — see `EmptyPanel`. This
+                // was the dashed box the board's own comment used to cite as
+                // the house style while the board did something else.
+                EmptyPanel(
+                    "No terms yet. Add the words your crew actually says — "
+                        + "\u{201C}boxwood\u{201D}, \u{201C}GFCI\u{201D}, \u{201C}Hollis\u{201D}."
+                )
+                .padding(.horizontal, Theme.S.screenPad)
+                .padding(.top, 16)
             } else {
                 ScrollView {
                     VStack(spacing: 0) {

--- a/apps/ios/Tests/DocumentLineEditTests.swift
+++ b/apps/ios/Tests/DocumentLineEditTests.swift
@@ -1,0 +1,239 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on editing a document's lines at review time — rename, add, remove,
+/// and the amount rules that come with them.
+///
+/// Isaac, 2026-08-09: *"the user should be able to edit the name of any of the
+/// lines, and also delete or add a line should they choose."* Review used to
+/// offer exactly one edit, SET AMOUNT, which quietly said the only thing that
+/// could be wrong on a document was a price. Speech-to-text mishears a word
+/// about as often as it mishears a number, and the description is the part the
+/// client actually reads.
+///
+/// These are model-level on purpose: the rules that will be wrong are the empty
+/// cases (an emptied description, an emptied amount, a line added and
+/// abandoned) and the one-way doors (money on a document that must not carry
+/// it). None of those need a screen to be exercised, and all of them are
+/// invisible on one.
+@MainActor
+final class DocumentLineEditTests: XCTestCase {
+    private func model(pricesShown: Bool = true, rows: [DocRowFixture]? = nil) -> AppModel {
+        let model = AppModel(engine: DemoWalkEngine(), forcedMode: .demo)
+        model.document = DocumentModel(
+            rows: rows ?? [
+                DocRowFixture(title: "5 yards mulch", sub: "", qty: "", amount: "$200"),
+                DocRowFixture(
+                    title: "redo all garden beds", sub: "NOT HEARD — TAP OR SAY IT",
+                    subWarn: true, qty: "", amount: "——", isGap: true, itemId: "item-2"
+                ),
+            ],
+            totalKey: "TOTAL",
+            staticTotal: "——",
+            note: "",
+            send: "SEND ESTIMATE",
+            pricesShown: pricesShown
+        )
+        return model
+    }
+
+    // MARK: Renaming
+
+    func testALineCanBeRenamed() {
+        let model = model()
+        let row = model.document!.rows[0]
+        model.beginEdit(row)
+        XCTAssertEqual(model.editTitle, "5 yards mulch", "the sheet opens on the current words")
+        XCTAssertEqual(model.editText, "200", "and the current amount, without its $")
+
+        model.editTitle = "5 yards dark mulch, installed"
+        model.commitEdit()
+
+        XCTAssertEqual(model.document?.rows[0].title, "5 yards dark mulch, installed")
+        XCTAssertEqual(model.document?.rows[0].amount, "$200", "renaming left the money alone")
+    }
+
+    func testAnEmptiedDescriptionKeepsTheOldOne() {
+        let model = model()
+        model.beginEdit(model.document!.rows[0])
+        model.editTitle = "   "
+        model.commitEdit()
+
+        XCTAssertEqual(
+            model.document?.rows[0].title, "5 yards mulch",
+            "there is no such thing as an untitled line on a document"
+        )
+        XCTAssertEqual(model.document?.rows.count, 2, "and nothing was removed")
+    }
+
+    func testRenamingKeepsTheItemIdThePhotosJoinOn() {
+        let model = model()
+        model.beginEdit(model.document!.rows[1])
+        model.editTitle = "rebuild all garden beds"
+        model.editText = "500"
+        model.commitEdit()
+
+        XCTAssertEqual(
+            model.document?.rows[1].itemId, "item-2",
+            "dropping it detaches the row from the photos taken against that item"
+        )
+    }
+
+    // MARK: Amounts
+
+    func testFillingAGapMarksItFilledAndClearsTheWarning() {
+        let model = model()
+        model.beginEdit(model.document!.rows[1])
+        model.editText = "1,250"
+        model.commitEdit()
+
+        let row = model.document!.rows[1]
+        XCTAssertEqual(row.amount, "$1,250", "typed money is written the way core writes it")
+        XCTAssertFalse(row.isGap)
+        XCTAssertFalse(row.subWarn)
+        XCTAssertEqual(row.sub, "FILLED BY YOU")
+        XCTAssertEqual(model.document?.gapCount, 0)
+    }
+
+    func testAnEmptiedAmountGoesBackToAGapRatherThanKeepingTheOldPrice() {
+        let model = model()
+        model.beginEdit(model.document!.rows[0])
+        model.editText = ""
+        model.commitEdit()
+
+        let row = model.document!.rows[0]
+        XCTAssertEqual(row.amount, "——", "a price nobody agreed to is the failure this prevents")
+        XCTAssertTrue(row.isGap)
+        XCTAssertTrue(row.subWarn)
+        XCTAssertEqual(model.document?.gapCount, 2)
+    }
+
+    func testUnreadableTextLeavesTheAmountExactlyAsItWas() {
+        let model = model()
+        model.beginEdit(model.document!.rows[0])
+        model.editText = "about two hundred"
+        model.commitEdit()
+
+        XCTAssertEqual(
+            model.document?.rows[0].amount, "$200",
+            "we cannot read it, so we do not act on it — never zero, never a guess"
+        )
+        XCTAssertFalse(model.document!.rows[0].isGap)
+    }
+
+    func testADocumentThatCarriesNoMoneyNeverGrowsAPrice() {
+        let model = model(
+            pricesShown: false,
+            rows: [DocRowFixture(title: "haul the old bark away", sub: "", qty: "", amount: "")]
+        )
+        model.beginEdit(model.document!.rows[0])
+        model.editTitle = "haul the old bark away"
+        model.editText = "400"
+        model.commitEdit()
+
+        XCTAssertEqual(
+            model.document?.rows[0].amount, "",
+            "a work order handed to a crew with prices on it is the wrong document"
+        )
+        XCTAssertFalse(model.document!.rows[0].isGap)
+    }
+
+    // MARK: Adding and removing
+
+    func testAddLineAppendsAnOpenLineAndOpensIt() {
+        let model = model()
+        model.addLine()
+
+        XCTAssertEqual(model.document?.rows.count, 3)
+        XCTAssertTrue(model.editingRowIsNew)
+        XCTAssertEqual(model.editingRowID, model.document?.rows.last?.id)
+        XCTAssertEqual(model.editTitle, "")
+
+        model.editTitle = "haul-off and disposal"
+        model.editText = "150"
+        model.commitEdit()
+
+        let added = model.document!.rows[2]
+        XCTAssertEqual(added.title, "haul-off and disposal")
+        XCTAssertEqual(added.amount, "$150")
+        XCTAssertEqual(added.sub, "ADDED BY YOU", "the document says where the line came from")
+        XCTAssertFalse(model.editingRowIsNew)
+    }
+
+    func testANewLinePricedLaterStartsAsAnHonestGap() {
+        let model = model()
+        model.addLine()
+        model.editTitle = "haul-off"
+        model.commitEdit()
+
+        let added = model.document!.rows[2]
+        XCTAssertEqual(added.amount, "——")
+        XCTAssertTrue(added.isGap, "an unpriced line is a gap, whoever added it")
+    }
+
+    func testANewLineAbandonedWithoutWordsLeavesNothingBehind() {
+        let model = model()
+        model.addLine()
+        // The sheet is dismissed by dragging it down, which commits.
+        model.commitEdit()
+
+        XCTAssertEqual(model.document?.rows.count, 2, "no blank line on the estimate")
+        XCTAssertNil(model.editingRowID)
+        XCTAssertFalse(model.editingRowIsNew)
+    }
+
+    func testAnExistingLineCanBeRemoved() {
+        let model = model()
+        model.beginEdit(model.document!.rows[0])
+        model.removeEditingLine()
+
+        XCTAssertEqual(model.document?.rows.count, 1)
+        XCTAssertEqual(model.document?.rows.first?.title, "redo all garden beds")
+        XCTAssertNil(model.editingRowID, "the sheet closes with it")
+    }
+
+    // MARK: Money
+
+    func testALineWithCentsIsCountedInTheTotalAndKeepsBothDigits() {
+        // The defect: every amount was parsed as an Int, so "$125.50" failed
+        // to parse and was silently dropped from the total printed directly
+        // beneath it. Spoken prices landing on lines verbatim made it likelier.
+        let model = model(rows: [
+            DocRowFixture(title: "stone", sub: "", qty: "", amount: "$125.50"),
+            DocRowFixture(title: "labor", sub: "", qty: "", amount: "$500"),
+        ])
+        XCTAssertEqual(model.document?.totalValue, "$625.50")
+    }
+
+    func testWholeDollarsCarryNoDecimals() {
+        XCTAssertEqual(DocumentModel.money(cents: 28500), "$285")
+        XCTAssertEqual(DocumentModel.money(cents: 121000), "$1,210")
+        XCTAssertEqual(DocumentModel.money(cents: 12550), "$125.50", "not $125.5")
+        XCTAssertEqual(DocumentModel.money(cents: 12505), "$125.05")
+    }
+
+    func testAnAmountWithCentsSurvivesBeingOpenedAndSavedAgain() {
+        let model = model(rows: [
+            DocRowFixture(title: "stone", sub: "", qty: "", amount: "$125.50")
+        ])
+        model.beginEdit(model.document!.rows[0])
+        XCTAssertEqual(model.editText, "125.50")
+        model.commitEdit()
+        XCTAssertEqual(model.document?.rows[0].amount, "$125.50")
+    }
+
+    func testTheTotalFollowsEveryEdit() {
+        let model = model()
+        XCTAssertEqual(model.document?.totalValue, "$200")
+
+        model.beginEdit(model.document!.rows[1])
+        model.editText = "500"
+        model.commitEdit()
+        XCTAssertEqual(model.document?.totalValue, "$700")
+
+        model.beginEdit(model.document!.rows[0])
+        model.removeEditingLine()
+        XCTAssertEqual(model.document?.totalValue, "$500")
+    }
+}

--- a/apps/ios/Tests/WalkAllowanceTests.swift
+++ b/apps/ios/Tests/WalkAllowanceTests.swift
@@ -148,6 +148,54 @@ final class WalkAllowanceTests: XCTestCase {
         )
     }
 
+    // MARK: What a finished walk spends
+
+    func testAWalkIsNotCountedWhileThereIsNothingToSell() {
+        // The defect: the meter ran through the whole pre-launch window, so
+        // every TestFlight tester was silently burning a LIFETIME allowance
+        // against a product that could not be bought — and would have hit
+        // zero, having never had a free evaluation, the day the product went
+        // live. Isaac's first walk after a reinstall reported "0 free walks
+        // left" (2026-08-09) while the same sheet said walks weren't limited.
+        XCTAssertFalse(
+            WalkAllowance.shouldCount(isPro: false, canSubscribe: false, isMeteredWalk: true)
+        )
+    }
+
+    func testAWalkIsCountedOnceTheLimitIsRealAgain() {
+        // The counting half must be conditional, not off: the same walk counts
+        // the moment a product is purchasable, or the free tier is unbounded.
+        XCTAssertTrue(
+            WalkAllowance.shouldCount(isPro: false, canSubscribe: true, isMeteredWalk: true)
+        )
+    }
+
+    func testProAndUnmeteredWalksNeverCount() {
+        XCTAssertFalse(
+            WalkAllowance.shouldCount(isPro: true, canSubscribe: true, isMeteredWalk: true),
+            "Pro is unmetered — no reason to keep a count nobody reads"
+        )
+        XCTAssertFalse(
+            WalkAllowance.shouldCount(isPro: false, canSubscribe: true, isMeteredWalk: false),
+            "practice runs and demo mode cost nothing the free tier exists to bound"
+        )
+    }
+
+    /// The two halves agree: a walk is only spent under exactly the conditions
+    /// that would have refused it. Drift here is invisible — it shows up
+    /// months later as an allowance that ran out without ever being enforced.
+    func testCountingAndBlockingAgreeOnWhetherTheLimitIsInForce() {
+        for canSubscribe in [true, false] {
+            let counted = WalkAllowance.shouldCount(
+                isPro: false, canSubscribe: canSubscribe, isMeteredWalk: true
+            )
+            let enforced = WalkAllowance.decide(
+                isPro: false, record: record(5), limit: 5, canSubscribe: canSubscribe
+            ) == .blocked(used: 5, limit: 5)
+            XCTAssertEqual(counted, enforced, "canSubscribe=\(canSubscribe)")
+        }
+    }
+
     // MARK: Recording a finish
 
     func testFinishIncrements() {

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -14,6 +14,7 @@ use harness::{
 
 use crate::domain::{Artifact, CapturedItem, DocumentSchema, SchemaField, SessionStatus};
 use crate::error::CoreError;
+use crate::pipeline::spoken_price::{fold_spoken_prices, FoldedPrices};
 use crate::pipeline::{doc_kinds_for_template, is_pricing_kind};
 use crate::store::Store;
 
@@ -508,11 +509,30 @@ impl DocumentBuilder {
             .iter()
             .find(|s| s.kind == "line_items")
             .is_some_and(|s| s.priced);
-        let mut lines = render_lines(&items, GapPolicy::PerPricingKind, priced);
+
+        // Fold spoken prices onto the work they describe, BEFORE the render
+        // (Isaac's field report 2026-08-09 — "$200 mulch" was landing as its
+        // own line under "5 yards mulch"). Only for documents that HAVE an
+        // amount column: on an unpriced kind the amount lives nowhere but the
+        // title, so lifting it out would delete it. See `spoken_price`.
+        let folded =
+            if priced { fold_spoken_prices(&items) } else { FoldedPrices::unfolded(&items) };
+        let mut lines = render_lines(&folded.items, GapPolicy::PerPricingKind, priced);
+        // Spoken amounts land first and are never overwritten below: a price
+        // the operator said outranks a price the model inferred.
+        apply_prices(&folded.amounts, &mut lines);
         let mut usage = Usage::default();
         let mut queued = false;
 
-        if priced && !items.is_empty() {
+        // Only what is still unpriced goes to the model — it is cheaper, and
+        // it removes any chance of the pass contradicting the operator.
+        let unpriced: Vec<CapturedItem> = folded
+            .items
+            .iter()
+            .filter(|i| !folded.amounts.contains_key(&i.id))
+            .cloned()
+            .collect();
+        if priced && !unpriced.is_empty() {
             let hint = self.session_spoken_total(session_id)?;
             let memory_prompt = self
                 .memory
@@ -521,7 +541,7 @@ impl DocumentBuilder {
                 .to_prompt();
             match price_items(
                 &self.provider,
-                &items,
+                &unpriced,
                 hint,
                 &memory_prompt,
                 self.max_tokens,
@@ -854,6 +874,110 @@ mod tests {
             "exactly one 'document'-purpose row (the fixture's finish_session_processed \
              already logs its own 'processing' row separately)"
         );
+    }
+
+    /// Isaac's field report, 2026-08-09, end to end: the estimate came out
+    /// with six lines — three unpriced scope lines and three bare price lines
+    /// under them. The fold happens before the render, so the DOCUMENT is
+    /// four lines with the money in the amount column.
+    #[tokio::test]
+    async fn build_folds_spoken_prices_onto_the_work_they_describe() {
+        let (store, sid) = processed_session_with_items(&[
+            ("part", "5 yards mulch"),
+            ("part", "2 bags compost"),
+            ("todo", "redo all garden beds"),
+            ("price", "$500 labor"),
+            ("price", "$200 mulch"),
+            ("price", "$100 compost"),
+        ]);
+        let ids: Vec<String> =
+            store.list_items_for_session(&sid).unwrap().iter().map(|i| i.id.clone()).collect();
+        let store = Arc::new(Mutex::new(store));
+
+        // The model prices nothing extra — the beds stay an honest gap.
+        let provider =
+            Arc::new(MockProvider::new(vec![tool_use("price_items", serde_json::json!({"prices": []}))]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        let store_guard = store.lock().unwrap();
+        let art = store_guard.get_artifact(&outcome.document_artifact_id).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
+        let lines = v["lines"].as_array().unwrap();
+
+        let titles: Vec<&str> = lines.iter().map(|l| l["title"].as_str().unwrap()).collect();
+        assert_eq!(
+            titles,
+            vec!["5 yards mulch", "2 bags compost", "redo all garden beds", "Labor"],
+            "the two price statements that named work folded into it"
+        );
+        let amount = |item_id: &str| {
+            lines.iter().find(|l| l["item_id"] == item_id).unwrap()["amount_cents"].clone()
+        };
+        assert_eq!(amount(&ids[0]), serde_json::json!(20000), "mulch carries its spoken price");
+        assert_eq!(amount(&ids[1]), serde_json::json!(10000), "compost too");
+        assert_eq!(amount(&ids[2]), serde_json::Value::Null, "the beds were never priced");
+        assert_eq!(
+            lines.iter().find(|l| l["item_id"] == ids[2]).unwrap()["is_gap"],
+            true,
+            "and say so — an unheard price is a gap, never a guess (R4)"
+        );
+        assert_eq!(amount(&ids[3]), serde_json::json!(50000), "labor prices itself");
+
+        // Only the beds were still open, so only the beds were sent to be
+        // priced — the pass can neither cost tokens on settled lines nor
+        // contradict the operator.
+        let asked = &provider.requests()[0].messages[0].content;
+        let asked = format!("{asked:?}");
+        assert!(asked.contains("redo all garden beds"));
+        assert!(!asked.contains("$200 mulch"), "a spoken price is never re-priced");
+        assert!(!asked.contains("Labor"));
+    }
+
+    /// The same walk as an INSPECTION (no amount column). Lifting a price out
+    /// of a title would delete it from the only place it can appear, so the
+    /// fold sits out entirely.
+    #[tokio::test]
+    async fn an_unpriced_kind_keeps_every_line_and_every_dollar_in_its_title() {
+        let (store, sid) =
+            processed_session_with_items(&[("part", "5 yards mulch"), ("price", "$200 mulch")]);
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "work_order").await.unwrap();
+        let store = store.lock().unwrap();
+        let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
+        let titles: Vec<&str> =
+            v["lines"].as_array().unwrap().iter().map(|l| l["title"].as_str().unwrap()).collect();
+        assert_eq!(titles, vec!["5 yards mulch", "$200 mulch"]);
+        assert!(provider.requests().is_empty(), "still zero calls for a non-pricing kind");
+    }
+
+    /// A walk whose every item priced itself needs no model call at all.
+    #[tokio::test]
+    async fn a_fully_spoken_walk_skips_the_pricing_call() {
+        let (store, sid) = processed_session_with_items(&[
+            ("part", "5 yards mulch"),
+            ("price", "$200 mulch"),
+        ]);
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        assert!(!outcome.queued, "nothing to ask is not a degrade");
+        assert_eq!(outcome.usage, Usage::default());
+        assert!(provider.requests().is_empty(), "every line was priced by the operator");
+
+        let store = store.lock().unwrap();
+        let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
+        let lines = v["lines"].as_array().unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["amount_cents"], 20000);
+        assert_eq!(lines[0]["is_gap"], false);
     }
 
     #[tokio::test]

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -13,6 +13,8 @@ pub mod notes;
 
 pub(crate) mod prompts;
 
+pub(crate) mod spoken_price;
+
 use std::sync::{Arc, Mutex};
 
 use harness::{

--- a/crates/murmur-core/src/pipeline/spoken_price.rs
+++ b/crates/murmur-core/src/pipeline/spoken_price.rs
@@ -1,0 +1,545 @@
+//! Folding spoken prices onto the work they describe.
+//!
+//! An operator walks a job and talks the way people talk: the scope first,
+//! the money after. *"Five yards of mulch, two bags of compost, redo all the
+//! garden beds — five hundred for labor, two hundred mulch, a hundred
+//! compost."* The extractor faithfully records six items, because six things
+//! were said. The document render is one line per item, so the estimate came
+//! out with six lines: three unpriced scope lines marked NOT HEARD, and three
+//! bare price lines under them.
+//!
+//! That is wrong on the paper even though it is right in the store. A client
+//! reading it sees mulch twice and an estimate that appears to have missed
+//! three prices it was actually told. Isaac's field report, 2026-08-09:
+//! *"it made separate lines for labor, mulch, compost. It should have put
+//! those prices in the first three lines."*
+//!
+//! ## What this does
+//!
+//! One deterministic pass over the session's items, before the render:
+//!
+//! - An item that is **nothing but a price for something else** (`"$200
+//!   mulch"`) folds onto the earlier item it names (`"5 yards mulch"`) and
+//!   stops being a line of its own.
+//! - An item that **carries its own price** (`"5 yards mulch $200"`) keeps its
+//!   line and takes the amount into the amount column.
+//! - A price that **names nothing already on the board** (`"$500 labor"`)
+//!   keeps its own line — a labor line on an estimate is a real line, and
+//!   inventing a home for it would be a guess.
+//!
+//! ## Why it is deterministic, and why it is stingy
+//!
+//! Prices are the one thing R4/R6 will not let us guess: a wrong number in a
+//! sent estimate is the product's worst failure mode, and it is worse when it
+//! is wrong *quietly*. So this pass never invents an amount, never moves one
+//! onto an item it cannot name a shared word with, and folds at most one
+//! price onto any line. Everything it declines to fold stays visible as its
+//! own line, which is the same information the operator has today — the
+//! failure mode of this code is "no better than before", never "silently
+//! attached $500 to the wrong item".
+//!
+//! It also runs BEFORE the LLM pricing pass, and what it produces is
+//! authoritative over it: a price the operator actually said outranks a price
+//! the model inferred, and items already priced here are never sent to the
+//! model at all (cheaper, and it cannot contradict the operator).
+//!
+//! ## Why it is not in the extraction prompt
+//!
+//! Asking the extractor to attach prices to earlier items means asking a
+//! partial-transcript pass to hold and revise state it cannot see — the live
+//! pass sees only the newest slice, and the price usually arrives minutes
+//! after the scope. Text arithmetic on the finished item list is the pass
+//! that has all the information, and it is testable without a provider.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::domain::CapturedItem;
+
+/// Words that carry no identity when matching a price to its work. Kept
+/// deliberately short: every word removed here is a word that can no longer
+/// disagree, and a fold on a weak match is worse than no fold at all.
+const STOPWORDS: [&str; 24] = [
+    "the", "a", "an", "of", "for", "and", "to", "on", "in", "at", "all", "some", "any", "with",
+    "plus", "per", "each", "is", "it", "that", "this", "there", "was", "were",
+];
+
+/// The pass's output: the items to render, in order, and the amounts the
+/// operator actually spoke, keyed by the id of the item that should carry
+/// them.
+pub(crate) struct FoldedPrices {
+    /// Items to render. Same order as the input, minus the price statements
+    /// that found a home, with a rewritten `text` on any item whose amount
+    /// moved into the amount column (leaving "$200" in the title next to a
+    /// "$200" column reads as a mistake on the paper).
+    pub items: Vec<CapturedItem>,
+    /// `item_id` → cents, for prices that were SPOKEN. Authoritative over
+    /// anything the pricing pass infers.
+    pub amounts: HashMap<String, i64>,
+}
+
+impl FoldedPrices {
+    /// The identity result: every item kept, nothing priced. Used for
+    /// documents that have no amount column, where lifting a price out of a
+    /// title would delete it from the only place it appears.
+    pub fn unfolded(items: &[CapturedItem]) -> Self {
+        FoldedPrices { items: items.to_vec(), amounts: HashMap::new() }
+    }
+}
+
+/// How an item relates to money, once its text has been read.
+enum Reading {
+    /// No amount, or an amount we refuse to read (a rate, an ambiguous pair).
+    Plain,
+    /// Carries its own price: substantial text of its own, plus an amount.
+    SelfPriced { cents: i64, title: String },
+    /// A price for something else: an amount and a bare label, nothing more.
+    Statement { cents: i64, title: String, label_tokens: Vec<String> },
+}
+
+/// The pass. See the module docs for the rules; the short version is that a
+/// price only moves when the item it moves onto shares a real word with it.
+pub(crate) fn fold_spoken_prices(items: &[CapturedItem]) -> FoldedPrices {
+    let readings: Vec<Reading> = items.iter().map(|i| read(&i.text)).collect();
+
+    // Candidates are the items a price can land ON: work lines that don't
+    // already carry a price of their own. A price statement is never a target
+    // — folding "$200 mulch" onto "$100 compost" would be nonsense.
+    let mut amounts: HashMap<String, i64> = HashMap::new();
+    let mut titles: HashMap<String, String> = HashMap::new();
+    let mut folded_away: HashSet<String> = HashSet::new();
+    let mut claimed: HashSet<usize> = HashSet::new();
+
+    for (index, reading) in readings.iter().enumerate() {
+        match reading {
+            Reading::Plain => {}
+            Reading::SelfPriced { cents, title } => {
+                amounts.insert(items[index].id.clone(), *cents);
+                titles.insert(items[index].id.clone(), title.clone());
+            }
+            Reading::Statement { cents, title, label_tokens } => {
+                match target_for(label_tokens, items, &readings, &claimed) {
+                    Some(target) => {
+                        claimed.insert(target);
+                        amounts.insert(items[target].id.clone(), *cents);
+                        folded_away.insert(items[index].id.clone());
+                    }
+                    // Nothing on the board answers to this price. It stays a
+                    // line of its own — the operator said it, and dropping it
+                    // to keep the paper tidy would delete money from an
+                    // estimate.
+                    None => {
+                        amounts.insert(items[index].id.clone(), *cents);
+                        titles.insert(items[index].id.clone(), title.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let kept = items
+        .iter()
+        .filter(|i| !folded_away.contains(&i.id))
+        .map(|i| match titles.get(&i.id) {
+            Some(title) => CapturedItem { text: title.clone(), ..i.clone() },
+            None => i.clone(),
+        })
+        .collect();
+
+    FoldedPrices { items: kept, amounts }
+}
+
+/// The item a price statement belongs to: the FIRST unclaimed work line that
+/// shares a content word with the price's label.
+///
+/// First rather than best-scoring, on purpose. Items are in spoken order, and
+/// a tradesperson pricing a walk goes down the list in the order they walked
+/// it; when two lines both say "mulch", the earlier one is the one being
+/// priced. A similarity score would be more clever and less predictable, and
+/// the failure it buys — the price on the wrong mulch line — is invisible on
+/// the finished paper.
+fn target_for(
+    label_tokens: &[String],
+    items: &[CapturedItem],
+    readings: &[Reading],
+    claimed: &HashSet<usize>,
+) -> Option<usize> {
+    if label_tokens.is_empty() {
+        return None;
+    }
+    let wanted: HashSet<&str> = label_tokens.iter().map(String::as_str).collect();
+    items.iter().enumerate().position(|(index, item)| {
+        if claimed.contains(&index) || !matches!(readings[index], Reading::Plain) {
+            return false;
+        }
+        tokenize(&item.text).iter().any(|t| wanted.contains(t.as_str()))
+    })
+}
+
+/// Reads one item's text for money.
+fn read(text: &str) -> Reading {
+    let Some(found) = find_amount(text) else { return Reading::Plain };
+    let label = strip_amount(text, &found);
+    let title = if label.is_empty() { text.trim().to_string() } else { capitalized(&label) };
+    let tokens = tokenize(&label);
+
+    // The line between "a price for something else" and "a line item that
+    // happens to state its price" is whether the text describes work. Two
+    // signals, both cheap and both conservative: a quantity ("5 yards mulch
+    // $200") or enough words to be a description rather than a name.
+    let describes_work = tokens.len() > MAX_LABEL_WORDS || has_quantity(&label);
+    if describes_work {
+        Reading::SelfPriced { cents: found.cents, title }
+    } else {
+        Reading::Statement { cents: found.cents, title, label_tokens: tokens }
+    }
+}
+
+/// A label longer than this is a description of work, not the name of it.
+/// Three covers what people actually say when they price something they
+/// already described — "labor", "the mulch", "all garden beds" — without
+/// swallowing a real scope line.
+const MAX_LABEL_WORDS: usize = 3;
+
+struct Amount {
+    cents: i64,
+    /// Byte range of the whole money token in the source text.
+    span: (usize, usize),
+}
+
+/// The single money amount in `text`, if there is exactly one and we are
+/// willing to read it as a line total.
+///
+/// Refuses, in every case returning `None`:
+/// - **No amount.** Nothing to do.
+/// - **Two or more amounts** (`"$200 mulch and $100 compost"`). Which one is
+///   this line's? Guessing picks a number for a client's invoice by coin
+///   flip; the operator can see and fix one merged line, and cannot see a
+///   wrong split.
+/// - **A rate** (`"$95/yd"`, `"$40 per hour"`). A rate times an unknown
+///   quantity is not a total, and putting it in the total column would
+///   understate the bill — the one direction of error that costs the operator
+///   money rather than embarrassment.
+fn find_amount(text: &str) -> Option<Amount> {
+    let mut found: Option<Amount> = None;
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let start = i;
+        let dollar_first = bytes[i] == b'$';
+        let digits_at = if dollar_first { i + 1 } else { i };
+        // A number starts here only at a token boundary — "3x4" must not read
+        // as two amounts, and "EST-0047" must not read as one.
+        let boundary = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+        let Some((value, after)) = read_number(text, digits_at) else {
+            i += 1;
+            continue;
+        };
+        if !boundary || (!dollar_first && !has_currency_word(text, after)) {
+            i = after.max(i + 1);
+            continue;
+        }
+        let end = if dollar_first { after } else { end_of_currency_word(text, after) };
+        if is_rate(text, end) {
+            return None;
+        }
+        if found.is_some() {
+            return None; // two amounts — ambiguous, hands off
+        }
+        found = Some(Amount { cents: value, span: (start, end) });
+        i = end;
+    }
+    found
+}
+
+/// Parses `1,250`, `1250.50`, `250` at `at`, returning cents and the byte
+/// index just past the number.
+fn read_number(text: &str, at: usize) -> Option<(i64, usize)> {
+    let bytes = text.as_bytes();
+    let mut i = at;
+    let mut whole = String::new();
+    while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b',') {
+        if bytes[i].is_ascii_digit() {
+            whole.push(bytes[i] as char);
+        }
+        i += 1;
+    }
+    if whole.is_empty() {
+        return None;
+    }
+    let mut cents = whole.parse::<i64>().ok()?.checked_mul(100)?;
+    // Cents, only as exactly two digits — "$200.5" is far more likely a
+    // stray transcription than fifty cents, and reading it either way is a
+    // guess about money.
+    if i + 2 < bytes.len() && bytes[i] == b'.' && bytes[i + 1].is_ascii_digit() {
+        let two = i + 3 <= bytes.len() && bytes[i + 2].is_ascii_digit();
+        let ends = i + 3 >= bytes.len() || !bytes[i + 3].is_ascii_digit();
+        if two && ends {
+            let frac: i64 = text[i + 1..i + 3].parse().ok()?;
+            cents = cents.checked_add(frac)?;
+            i += 3;
+        }
+    }
+    Some((cents, i))
+}
+
+/// "500 dollars" / "500 bucks" — the bare-number forms speech-to-text
+/// produces when the speaker doesn't say a symbol.
+fn has_currency_word(text: &str, after: usize) -> bool {
+    let rest = text[after..].trim_start().to_ascii_lowercase();
+    rest.starts_with("dollar") || rest.starts_with("buck")
+}
+
+fn end_of_currency_word(text: &str, after: usize) -> usize {
+    let trimmed = text[after..].trim_start();
+    let offset = after + (text.len() - after - text[after..].trim_start().len());
+    let word_len = trimmed
+        .char_indices()
+        .find(|(_, c)| !c.is_alphabetic())
+        .map_or(trimmed.len(), |(i, _)| i);
+    offset + word_len
+}
+
+/// Whether the amount ending at `end` is a rate rather than a total.
+fn is_rate(text: &str, end: usize) -> bool {
+    let rest = text[end..].trim_start().to_ascii_lowercase();
+    rest.starts_with('/') || rest.starts_with("per ") || rest.starts_with("an hour")
+        || rest.starts_with("a yard") || rest.starts_with("each")
+}
+
+/// The text with the money token cut out and the joining words that are left
+/// dangling ("for", "at", "—") cleaned off both ends.
+fn strip_amount(text: &str, found: &Amount) -> String {
+    let mut label = String::with_capacity(text.len());
+    label.push_str(&text[..found.span.0]);
+    label.push(' ');
+    label.push_str(&text[found.span.1..]);
+    let trimmed: &[_] = &[' ', '\t', '-', '–', '—', ':', ',', '.', ';', '(', ')', '@'];
+    let mut label = label.trim_matches(trimmed).to_string();
+    for lead in ["for ", "at ", "on ", "of ", "is ", "was "] {
+        if label.to_ascii_lowercase().starts_with(lead) {
+            label = label[lead.len()..].to_string();
+        }
+    }
+    for tail in [" for", " at", " on", " of", " is", " was"] {
+        if label.to_ascii_lowercase().ends_with(tail) {
+            label.truncate(label.len() - tail.len());
+        }
+    }
+    label.trim_matches(trimmed).to_string()
+}
+
+/// Content words, lowercased, stopwords dropped, naive-singularized so
+/// "beds" matches "bed". Words shorter than three characters are dropped
+/// too — matching on "ft" or "yd" would fold a price onto whatever unit
+/// happened to appear first.
+fn tokenize(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(|w| w.to_ascii_lowercase())
+        .filter(|w| w.len() >= 3 && !STOPWORDS.contains(&w.as_str()) && !w.chars().all(|c| c.is_ascii_digit()))
+        .map(|w| singular(&w))
+        .collect()
+}
+
+fn singular(word: &str) -> String {
+    if word.len() > 3 && word.ends_with('s') && !word.ends_with("ss") {
+        word[..word.len() - 1].to_string()
+    } else {
+        word.to_string()
+    }
+}
+
+/// Whether a label states a quantity — the tell that it describes work
+/// rather than naming it.
+fn has_quantity(label: &str) -> bool {
+    label.split(|c: char| !c.is_alphanumeric()).any(|w| {
+        !w.is_empty() && (w.chars().all(|c| c.is_ascii_digit()) || w.chars().next().is_some_and(|c| c.is_ascii_digit()))
+    })
+}
+
+fn capitalized(label: &str) -> String {
+    let mut chars = label.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::ItemSource;
+
+    fn item(id: &str, kind: &str, text: &str) -> CapturedItem {
+        CapturedItem {
+            id: id.into(),
+            session_id: "s1".into(),
+            kind: kind.into(),
+            text: text.into(),
+            right: String::new(),
+            source: ItemSource::Authoritative,
+            done: false,
+            created_at: 0,
+            updated_at: 0,
+            device_id: "d".into(),
+        }
+    }
+
+    /// Isaac's field report, 2026-08-09, verbatim as an estimate.
+    #[test]
+    fn isaacs_walk_folds_the_prices_onto_the_work() {
+        let items = vec![
+            item("i1", "part", "5 yards mulch"),
+            item("i2", "part", "2 bags compost"),
+            item("i3", "todo", "redo all garden beds (5 beds)"),
+            item("i4", "price", "$500 labor"),
+            item("i5", "price", "$200 mulch"),
+            item("i6", "price", "$100 compost"),
+        ];
+        let folded = fold_spoken_prices(&items);
+
+        let titles: Vec<&str> = folded.items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(
+            titles,
+            vec!["5 yards mulch", "2 bags compost", "redo all garden beds (5 beds)", "Labor"],
+            "mulch and compost folded away; labor stayed as its own line, without its $ in the title"
+        );
+        assert_eq!(folded.amounts.get("i1"), Some(&20000), "$200 landed on the mulch line");
+        assert_eq!(folded.amounts.get("i2"), Some(&10000), "$100 landed on the compost line");
+        assert_eq!(folded.amounts.get("i4"), Some(&50000), "labor prices itself");
+        assert_eq!(folded.amounts.get("i3"), None, "the beds were never priced — still a gap");
+    }
+
+    #[test]
+    fn an_item_that_carries_its_own_price_keeps_its_line() {
+        let items = vec![item("i1", "part", "5 yards of mulch installed $450")];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.items.len(), 1);
+        assert_eq!(folded.items[0].text, "5 yards of mulch installed");
+        assert_eq!(folded.amounts.get("i1"), Some(&45000));
+    }
+
+    #[test]
+    fn a_price_naming_nothing_on_the_board_stays_its_own_line() {
+        let items = vec![item("i1", "todo", "fix the gate"), item("i2", "price", "$500 labor")];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.items.len(), 2, "nothing folded — no shared word");
+        assert_eq!(folded.amounts.get("i2"), Some(&50000));
+        assert_eq!(folded.amounts.get("i1"), None);
+    }
+
+    #[test]
+    fn one_price_per_line_never_two() {
+        let items = vec![
+            item("i1", "part", "5 yards mulch"),
+            item("i2", "price", "$200 mulch"),
+            item("i3", "price", "$300 mulch"),
+        ];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.amounts.get("i1"), Some(&20000), "first price wins the line");
+        assert_eq!(folded.amounts.get("i3"), Some(&30000), "the second stays visible, not lost");
+        assert_eq!(folded.items.len(), 2);
+    }
+
+    #[test]
+    fn earliest_matching_line_wins_in_spoken_order() {
+        let items = vec![
+            item("i1", "part", "front bed mulch"),
+            item("i2", "part", "back bed mulch"),
+            item("i3", "price", "$200 mulch"),
+        ];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.amounts.get("i1"), Some(&20000));
+        assert_eq!(folded.amounts.get("i2"), None);
+    }
+
+    #[test]
+    fn plural_and_singular_match() {
+        let items =
+            vec![item("i1", "todo", "rebuild 3 garden beds"), item("i2", "price", "$900 the bed")];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.amounts.get("i1"), Some(&90000));
+        assert_eq!(folded.items.len(), 1);
+    }
+
+    #[test]
+    fn spoken_dollars_without_a_symbol_are_read() {
+        let items =
+            vec![item("i1", "part", "cedar chips"), item("i2", "price", "500 dollars for chips")];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.amounts.get("i1"), Some(&50000));
+        assert_eq!(folded.items.len(), 1);
+    }
+
+    #[test]
+    fn commas_and_cents_parse() {
+        assert_eq!(find_amount("$1,250 stone").map(|a| a.cents), Some(125_000));
+        assert_eq!(find_amount("$1250.75 stone").map(|a| a.cents), Some(125_075));
+        assert_eq!(find_amount("$1250.5 stone").map(|a| a.cents), Some(125_000), "not two digits — read the dollars, never invent the cents");
+    }
+
+    #[test]
+    fn a_rate_is_never_read_as_a_total() {
+        for text in ["mulch $95/yd", "$40 per hour labor", "$40 an hour", "$95 each"] {
+            assert!(find_amount(text).is_none(), "{text} is a rate, not a line total");
+        }
+        let items = vec![item("i1", "part", "mulch"), item("i2", "price", "mulch $95/yd")];
+        let folded = fold_spoken_prices(&items);
+        assert!(folded.amounts.is_empty(), "a rate prices nothing");
+        assert_eq!(folded.items.len(), 2, "and the rate stays visible, in the operator's words");
+        assert_eq!(folded.items[1].text, "mulch $95/yd");
+    }
+
+    #[test]
+    fn two_amounts_in_one_item_are_left_alone() {
+        assert!(find_amount("$200 mulch and $100 compost").is_none());
+        let items = vec![item("i1", "price", "$200 mulch and $100 compost")];
+        let folded = fold_spoken_prices(&items);
+        assert!(folded.amounts.is_empty());
+        assert_eq!(folded.items[0].text, "$200 mulch and $100 compost", "untouched");
+    }
+
+    #[test]
+    fn bare_numbers_and_document_numbers_are_not_money() {
+        assert!(find_amount("5 yards mulch").is_none(), "a quantity is not a price");
+        assert!(find_amount("EST-0047 reissue").is_none());
+        assert!(find_amount("replace 3x4 post").is_none());
+    }
+
+    #[test]
+    fn items_without_money_pass_through_untouched() {
+        let items = vec![item("i1", "todo", "haul the old bark away"), item("i2", "safety", "loose railing")];
+        let folded = fold_spoken_prices(&items);
+        assert!(folded.amounts.is_empty());
+        assert_eq!(folded.items.len(), 2);
+        assert_eq!(folded.items[0].text, "haul the old bark away");
+    }
+
+    #[test]
+    fn a_price_statement_is_never_a_target_for_another_price() {
+        // "$100 compost" must not collect "$200 compost" — a price does not
+        // price a price.
+        let items = vec![item("i1", "price", "$100 compost"), item("i2", "price", "$200 compost")];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.items.len(), 2);
+        assert_eq!(folded.amounts.get("i1"), Some(&10000));
+        assert_eq!(folded.amounts.get("i2"), Some(&20000));
+    }
+
+    #[test]
+    fn a_bare_amount_with_no_label_keeps_the_operators_text() {
+        let items = vec![item("i1", "todo", "mulch the beds"), item("i2", "price", "$500")];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.items.len(), 2, "no label, nothing to match on");
+        assert_eq!(folded.items[1].text, "$500", "the title is all it said");
+        assert_eq!(folded.amounts.get("i2"), Some(&50000));
+    }
+
+    #[test]
+    fn unfolded_keeps_everything() {
+        let items = vec![item("i1", "price", "$200 mulch"), item("i2", "part", "mulch")];
+        let folded = FoldedPrices::unfolded(&items);
+        assert_eq!(folded.items.len(), 2);
+        assert!(folded.amounts.is_empty());
+    }
+}


### PR DESCRIPTION
Isaac walked a job on the TestFlight build (2026-08-09) and sent three screenshots. Everything here comes out of that one walk — three reported defects, a follow-up request, and three more found in the same code paths on the way through.

## Thinking

### Prices made their own lines

He talked the way people talk: the scope first, the money after. *"Five yards mulch, two bags compost, redo all the garden beds… five hundred labor, two hundred mulch, a hundred compost."* The extractor faithfully recorded six items, because six things were said, and the render is one line per item — so the estimate came out with **six lines**: three unpriced scope lines marked NOT HEARD, and three bare price lines underneath them.

That is right in the store and wrong on the paper. A client reading it sees mulch twice and an estimate that appears to have missed three prices it was actually told. Isaac: *"It should have put those prices in the first three lines."*

**Where the fix belongs.** Not in the extraction prompt. Attaching a price to an earlier item means asking a partial-transcript pass to hold and revise state it cannot see — the live pass sees only the newest slice, and the price usually arrives minutes after the scope. The finished item list is where all the information is, and text arithmetic on it is testable without a provider. So: one deterministic pass (`pipeline::spoken_price`) between the items and the render.

**Why it is stingy.** Prices are the one thing R4/R6 will not let us guess, and a wrong number is worse when it is wrong *quietly*. So it refuses more than it accepts:

- **A rate is never a total.** `"$95/yd"`, `"$40 per hour"` — a rate times an unknown quantity understates the bill, which is the one direction of error that costs the operator money rather than embarrassment.
- **Two amounts in one item is a coin flip**, so it does nothing. The operator can see and fix one merged line; they cannot see a wrong split.
- **A price only moves onto a line it shares a real word with.** No match, no fold — `"$500 labor"` stays its own line, because a labor line on an estimate is a real line and inventing a home for it would be a guess.
- **At most one price per line**, and a price statement is never itself a target.

The failure mode of the whole pass is therefore "no better than today", never "silently attached $500 to the wrong item".

**It also outranks the model.** Spoken amounts are applied first, and only the still-unpriced items are sent to `price_items` — cheaper, and the pass cannot contradict the operator. A fully-spoken walk now makes zero pricing calls. On unpriced kinds the fold sits out entirely: with no amount column, lifting a price out of a title would delete it from the only place it appears.

Isaac's walk, end to end: `5 yards mulch $200` · `2 bags compost $100` · `redo all garden beds ——` · `Labor $500`. Same total, four lines instead of six, and the beds stay an honest gap because nobody said what they cost.

### "0 free walks left" after a reinstall

Two defects behind one sentence, and the keychain is not one of them — surviving delete-and-reinstall is deliberate, and under a lifetime allowance it is the only thing between reinstall-looping and a permanently free tier.

**The meter counted walks it would never have refused.** `WalkAllowance.decide` declines to block when `canSubscribe` is false — we do not refuse someone's money and their work at the same time — but the finish path counted anyway. So every TestFlight tester has been burning a *lifetime* allowance against a product that cannot be bought, and on the day the ASC product goes live they would all be at zero, having never had the free evaluation the tier exists to give them. An allowance we are not willing to enforce is not an allowance we may spend. `shouldCount` now mirrors `decide`, and a test pins the two together — drift there is invisible for months and then shows up as an allowance that ran out without ever being enforced.

**And the sheet contradicted itself.** "0 free walks left" sat directly above this same sheet's "Your walks aren't limited while this is down." One of those was a lie, and it was the count. The board's plan chip already hid itself on exactly this condition; the paywall is the second surface catching up.

### The grey backdrop on an empty board

Three empty-state idioms — a grey slab for walks, a white card for jobs, a dashed box in the vocabulary editor that the board's own comment cited as the house style. Two of them stacked in the same scroll, which is what Isaac was looking at.

Grey was the wrong one to keep: on a board whose section beds are *also* grey, it stops reading as a card and starts reading as a hole in the layout. One `EmptyPanel` now. And the JOBS bed moved from the section to the **cards** — a bed exists to ground cards, so with no jobs it was painting a grey slab grounding nothing, and with jobs it made JOBS the one section head in the app sitting on grey while TODAY, two rows up, sat on paper.

One documented exception: the photo well inside the rendered document keeps its dashed outline, because `EmptyPanel` is sheet-white and so is the document — an invisible card is not consistency.

### Editable lines

Isaac, same day: *"the user should be able to edit the name of any of the lines, and also delete or add a line should they choose."*

Review offered exactly one edit, SET AMOUNT, which quietly said the only thing that could be wrong on a document was a price. Speech-to-text mishears a word about as often as it mishears a number, and the description is the part the client actually reads.

One EDIT LINE sheet — description, amount, remove — and ADD LINE under the last line, where the thing it makes will appear. The rules that will be wrong are the empty cases, so they are the ones under test:

- An emptied **description** keeps the old one (there is no untitled line on a document); on a line just added it means "never mind", and the line goes with the sheet.
- An emptied **amount** returns the line to an honest gap. Keeping the old number would be the one failure this screen exists to prevent.
- **A work order still cannot grow a price** — the sheet does not offer the field, and the model ignores it.
- Removal is a button in the sheet, not a swipe: this screen is read on a job site with gloves on.

These edits live on the document snapshot, like the amount edits always have — the notes screen remains where items themselves are edited.

## Three more, found in the same paths

- **`commitEdit` dropped `itemId`.** It rebuilt the row field by field, so filling one gap detached that row from the photos taken against that item mid-walk (`photos(for:)` joins on it) and quietly emptied its contact sheet.
- **The total dropped any line carrying cents.** Amounts were parsed as `Int`, so `"$125.50"` failed and vanished from the total printed directly beneath it. A total that silently omits a line it sits under is the worst kind of wrong on a document someone signs — and it got likelier the moment spoken prices started landing verbatim. Summed in cents now, and money is written one way everywhere (`DocumentModel.money`): `$125.50`, never `$125.5`.
- **The two engines disagreed about documents that carry no money.** The real engine rendered `——` in the amount column of a work order — a dash means "a number is missing here", so a crew's work order read as a document that had failed to price itself. The demo engine had always stripped it. Both now agree, driven per line rather than by a kind table, so a custom Plan 19 schema is not told what it is allowed to be.

## Testing

- `cargo test --workspace` green, `cargo clippy --workspace --all-targets -- -D warnings` clean. 15 unit tests on the fold (including Isaac's exact walk) plus three at `DocumentBuilder::build` level: the fold in the artifact, the unpriced-kind opt-out, and the zero-call fully-spoken walk.
- 132 iOS tests (13 new on line editing, 4 on the meter rule).
- Demo build (the CI path) and real-core both **BUILD SUCCEEDED**.
- Rendered on iPhone 17: the empty board, review with ADD LINE, both sheet states, and the paywall — which now reads "Pro stops counting walks altogether." above "Your walks aren't limited while this is down."

`editline=1` / `editline=new` open the line editor unattended, for the same reason `newjob=1` exists: simctl cannot tap, and shipping an unseen UI surface is how the inline FILE chip ended up 130pt tall.

## For dam

The core change is `crates/murmur-core/src/pipeline/spoken_price.rs` plus a ~15-line change to `DocumentBuilder::build`'s pricing block. It touches no FFI types and no schema. The judgement calls worth your eye are the three refusals (rate, ambiguous pair, no shared word) and the choice of **first** matching line rather than best-scoring — items are in spoken order, and a tradesperson pricing a walk goes down the list in the order they walked it; a similarity score would be cleverer, less predictable, and its failure (the price on the wrong mulch line) is invisible on the finished paper.
