### PR TITLE
feat: seven documents that read like the documents they are

### DIFF
--- a/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
+++ b/apps/ios/Packages/MurmurCoreFFI/Sources/MurmurCoreFFI/ffi.swift
@@ -2057,6 +2057,17 @@ public struct DocLine {
      * Additive; never derived by the FFI layer.
      */
     public var itemId: String?
+    /**
+     * Who is doing this line — `directive` documents (the work order) only,
+     * and only where the operator actually named someone.
+     *
+     * It rides in the column the amount would occupy, because a work order
+     * carries no money and that space is exactly where the crew looks.
+     * `None` everywhere else, including on a work order line nobody was
+     * named for: an unassigned task is a real state, and inventing an owner
+     * for it would put a person's name against work they never agreed to.
+     */
+    public var assignee: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -2069,7 +2080,17 @@ public struct DocLine {
          * The core item this row was built from (Plan 12). `None` for
          * total/rollup lines, or an old document body written before Plan 12.
          * Additive; never derived by the FFI layer.
-         */itemId: String?) {
+         */itemId: String?, 
+        /**
+         * Who is doing this line — `directive` documents (the work order) only,
+         * and only where the operator actually named someone.
+         *
+         * It rides in the column the amount would occupy, because a work order
+         * carries no money and that space is exactly where the crew looks.
+         * `None` everywhere else, including on a work order line nobody was
+         * named for: an unassigned task is a real state, and inventing an owner
+         * for it would put a person's name against work they never agreed to.
+         */assignee: String?) {
         self.id = id
         self.title = title
         self.detail = detail
@@ -2078,6 +2099,7 @@ public struct DocLine {
         self.section = section
         self.isGap = isGap
         self.itemId = itemId
+        self.assignee = assignee
     }
 }
 
@@ -2109,6 +2131,9 @@ extension DocLine: Equatable, Hashable {
         if lhs.itemId != rhs.itemId {
             return false
         }
+        if lhs.assignee != rhs.assignee {
+            return false
+        }
         return true
     }
 
@@ -2121,6 +2146,7 @@ extension DocLine: Equatable, Hashable {
         hasher.combine(section)
         hasher.combine(isGap)
         hasher.combine(itemId)
+        hasher.combine(assignee)
     }
 }
 
@@ -2139,7 +2165,8 @@ public struct FfiConverterTypeDocLine: FfiConverterRustBuffer {
                 amountCents: FfiConverterOptionInt64.read(from: &buf), 
                 section: FfiConverterOptionString.read(from: &buf), 
                 isGap: FfiConverterBool.read(from: &buf), 
-                itemId: FfiConverterOptionString.read(from: &buf)
+                itemId: FfiConverterOptionString.read(from: &buf), 
+                assignee: FfiConverterOptionString.read(from: &buf)
         )
     }
 
@@ -2152,6 +2179,7 @@ public struct FfiConverterTypeDocLine: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.section, into: &buf)
         FfiConverterBool.write(value.isGap, into: &buf)
         FfiConverterOptionString.write(value.itemId, into: &buf)
+        FfiConverterOptionString.write(value.assignee, into: &buf)
     }
 }
 
@@ -3173,15 +3201,27 @@ public struct SchemaField {
     public var label: String
     public var fill: String
     public var staticValue: String?
+    /**
+     * What the field should contain, in the model's terms — carried across
+     * the boundary so an operator authoring their own document type can
+     * teach the compose pass what they mean by it.
+     */
+    public var hint: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(key: String, kind: String, label: String, fill: String, staticValue: String?) {
+    public init(key: String, kind: String, label: String, fill: String, staticValue: String?, 
+        /**
+         * What the field should contain, in the model's terms — carried across
+         * the boundary so an operator authoring their own document type can
+         * teach the compose pass what they mean by it.
+         */hint: String?) {
         self.key = key
         self.kind = kind
         self.label = label
         self.fill = fill
         self.staticValue = staticValue
+        self.hint = hint
     }
 }
 
@@ -3204,6 +3244,9 @@ extension SchemaField: Equatable, Hashable {
         if lhs.staticValue != rhs.staticValue {
             return false
         }
+        if lhs.hint != rhs.hint {
+            return false
+        }
         return true
     }
 
@@ -3213,6 +3256,7 @@ extension SchemaField: Equatable, Hashable {
         hasher.combine(label)
         hasher.combine(fill)
         hasher.combine(staticValue)
+        hasher.combine(hint)
     }
 }
 
@@ -3228,7 +3272,8 @@ public struct FfiConverterTypeSchemaField: FfiConverterRustBuffer {
                 kind: FfiConverterString.read(from: &buf), 
                 label: FfiConverterString.read(from: &buf), 
                 fill: FfiConverterString.read(from: &buf), 
-                staticValue: FfiConverterOptionString.read(from: &buf)
+                staticValue: FfiConverterOptionString.read(from: &buf), 
+                hint: FfiConverterOptionString.read(from: &buf)
         )
     }
 
@@ -3238,6 +3283,7 @@ public struct FfiConverterTypeSchemaField: FfiConverterRustBuffer {
         FfiConverterString.write(value.label, into: &buf)
         FfiConverterString.write(value.fill, into: &buf)
         FfiConverterOptionString.write(value.staticValue, into: &buf)
+        FfiConverterOptionString.write(value.hint, into: &buf)
     }
 }
 
@@ -3265,15 +3311,25 @@ public struct SchemaSection {
     public var kind: String
     public var label: String
     public var priced: Bool
+    /**
+     * `line_items` only: "" | "inclusion" | "directive" | "observation" —
+     * who the second line under each item is written for.
+     */
+    public var lineDetail: String
     public var fields: [SchemaField]
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(key: String, kind: String, label: String, priced: Bool, fields: [SchemaField]) {
+    public init(key: String, kind: String, label: String, priced: Bool, 
+        /**
+         * `line_items` only: "" | "inclusion" | "directive" | "observation" —
+         * who the second line under each item is written for.
+         */lineDetail: String, fields: [SchemaField]) {
         self.key = key
         self.kind = kind
         self.label = label
         self.priced = priced
+        self.lineDetail = lineDetail
         self.fields = fields
     }
 }
@@ -3294,6 +3350,9 @@ extension SchemaSection: Equatable, Hashable {
         if lhs.priced != rhs.priced {
             return false
         }
+        if lhs.lineDetail != rhs.lineDetail {
+            return false
+        }
         if lhs.fields != rhs.fields {
             return false
         }
@@ -3305,6 +3364,7 @@ extension SchemaSection: Equatable, Hashable {
         hasher.combine(kind)
         hasher.combine(label)
         hasher.combine(priced)
+        hasher.combine(lineDetail)
         hasher.combine(fields)
     }
 }
@@ -3321,6 +3381,7 @@ public struct FfiConverterTypeSchemaSection: FfiConverterRustBuffer {
                 kind: FfiConverterString.read(from: &buf), 
                 label: FfiConverterString.read(from: &buf), 
                 priced: FfiConverterBool.read(from: &buf), 
+                lineDetail: FfiConverterString.read(from: &buf), 
                 fields: FfiConverterSequenceTypeSchemaField.read(from: &buf)
         )
     }
@@ -3330,6 +3391,7 @@ public struct FfiConverterTypeSchemaSection: FfiConverterRustBuffer {
         FfiConverterString.write(value.kind, into: &buf)
         FfiConverterString.write(value.label, into: &buf)
         FfiConverterBool.write(value.priced, into: &buf)
+        FfiConverterString.write(value.lineDetail, into: &buf)
         FfiConverterSequenceTypeSchemaField.write(value.fields, into: &buf)
     }
 }

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1539,7 +1539,46 @@ final class AppModel {
     /// Provenance for a line the operator added at review, kept off the walk's
     /// own vocabulary ("NOT HEARD", "FILLED BY YOU") because it is a different
     /// claim: this line was never spoken at all.
-    static let addedLineNote = "ADDED BY YOU"
+    static let addedLineNote = OperatorNote.added
+
+    /// The authored field being edited, as (section key, field key). Separate
+    /// from `editingRowID` because a field is not a line: it has no amount, no
+    /// quantity and nothing to remove — the sheet has to know which it is.
+    var editingField: (section: String, key: String)?
+
+    /// Opens an authored field (a work order's ACCESS note, an estimate's
+    /// SCOPE OF WORK) for editing.
+    ///
+    /// The same reasoning as tap-to-edit on a line, and the same seam: these
+    /// are the fields the walk was thin on, so the gap is a prompt to finish
+    /// the document rather than a defect. An operator who is about to send a
+    /// work order with a blank SAFETY block should be able to type the one
+    /// sentence they know without regenerating the whole thing.
+    func beginFieldEdit(section: DocSectionFixture, field: DocFieldFixture) {
+        editingField = (section: section.key, key: field.key)
+        editTitle = field.value ?? ""
+        editText = ""
+        editingRowID = nil
+        editingRowIsNew = false
+    }
+
+    /// Writes the field back. An emptied value returns it to a truthful gap —
+    /// the same rule as an emptied amount, for the same reason.
+    func commitFieldEdit() {
+        guard let target = editingField, var doc = document,
+              let sectionIndex = doc.sections.firstIndex(where: { $0.key == target.section }),
+              let fieldIndex = doc.sections[sectionIndex].fields
+                  .firstIndex(where: { $0.key == target.key })
+        else {
+            editingField = nil
+            return
+        }
+        let value = editTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        doc.sections[sectionIndex].fields[fieldIndex].value = value.isEmpty ? nil : value
+        doc.sections[sectionIndex].fields[fieldIndex].isGap = value.isEmpty
+        document = doc
+        editingField = nil
+    }
 
     func beginEdit(_ row: DocRowFixture) {
         editingRowID = row.id
@@ -1637,7 +1676,7 @@ final class AppModel {
                 row.amount = DocumentModel.money(cents: Int((dollars * 100).rounded()))
                 row.isGap = false
                 row.subWarn = false
-                if old.isGap && !added { row.sub = "FILLED BY YOU" }
+                if old.isGap && !added { row.sub = OperatorNote.filled }
             } else if cleaned.isEmpty {
                 // Erased on purpose. Back to an honest gap — keeping the old
                 // number would be the one failure this screen exists to
@@ -1645,7 +1684,7 @@ final class AppModel {
                 row.amount = "——"
                 row.isGap = true
                 if !added {
-                    row.sub = "NOT HEARD — TAP OR SAY IT"
+                    row.sub = OperatorNote.gap
                     row.subWarn = true
                 }
             }

--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1582,6 +1582,11 @@ final class AppModel {
 
     func beginEdit(_ row: DocRowFixture) {
         editingRowID = row.id
+        // Mutually exclusive with the field editor, in BOTH directions: the
+        // two sheets are bound to these two properties independently, so
+        // leaving the other set would present them on top of each other.
+        // `beginFieldEdit` already clears this one.
+        editingField = nil
         editTitle = row.title
         editingRowIsNew = false
         // Grouping separator stripped: the field is a decimal pad, which has

--- a/apps/ios/Sources/App/GalleryApp.swift
+++ b/apps/ios/Sources/App/GalleryApp.swift
@@ -249,7 +249,17 @@ struct AppRoot: View {
                 // reaches ReviewView for the existing PDF/send screenshot
                 // hooks below.
                 if model.phase == .notes {
-                    model.buildPrimaryDocument()
+                    // doc=<kind> builds a specific document instead of the
+                    // template's lead one. Seven kinds now have seven
+                    // genuinely different shapes, and simctl cannot tap the
+                    // button that picks them — so without this, six of them
+                    // can only be seen by a person with a device in hand.
+                    if let arg = ProcessInfo.processInfo.arguments
+                        .first(where: { $0.hasPrefix("doc=") }) {
+                        model.buildDocument(kind: String(arg.dropFirst("doc=".count)))
+                    } else {
+                        model.buildPrimaryDocument()
+                    }
                     try? await Task.sleep(for: .seconds(2))
                 }
             }

--- a/apps/ios/Sources/Components/Document.swift
+++ b/apps/ios/Sources/Components/Document.swift
@@ -74,10 +74,18 @@ struct DocRowView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(row.title)
                     .font(Theme.F.cond(12.5, .semibold))
-                Text(row.sub)
-                    .font(Theme.F.mono(8, row.subWarn ? .semibold : .regular))
-                    .tracking(0.3)
-                    .foregroundStyle(row.subWarn ? Theme.C.yellowTag : Theme.C.ink60)
+                // The second line: what the line covers, what the crew must
+                // do, or what was observed. It sets as SENTENCES, not as a
+                // stamp — a directive like "strip the old bark first, watch
+                // the irrigation heads" is read, not scanned, and 8pt mono
+                // all-caps is unreadable at two paragraphs.
+                if !row.sub.isEmpty {
+                    Text(row.sub)
+                        .font(row.subWarn ? Theme.F.mono(8, .semibold) : Theme.F.ui(11, .medium))
+                        .tracking(row.subWarn ? 0.3 : 0)
+                        .foregroundStyle(row.subWarn ? Theme.C.yellowTag : Theme.C.ink60)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 if let hint = row.hint {
                     Text(hint)
                         .font(Theme.F.mono(8))
@@ -99,7 +107,20 @@ struct DocRowView: View {
 
     @ViewBuilder
     private var amount: some View {
-        if row.isEdit {
+        // A work order carries no money, so the column the price would
+        // occupy is where the crew's name goes — the exact spot a foreman's
+        // eye already travels to on every other document they read.
+        if let assignee = row.assignee, !assignee.isEmpty {
+            Text(assignee.uppercased())
+                .font(Theme.F.mono(9, .semibold))
+                .tracking(0.8)
+                .foregroundStyle(Theme.C.amberInk)
+                .padding(.horizontal, 6)
+                .padding(.top, 3)
+                .padding(.bottom, 2)
+                .background(Theme.C.orangeTint)
+                .lineLimit(1)
+        } else if row.isEdit {
             HStack(spacing: 1) {
                 Text(row.amount)
                     .font(Theme.F.mono(12, .semibold))
@@ -117,6 +138,99 @@ struct DocRowView: View {
             Text(row.amount)
                 .font(Theme.F.mono(12, .semibold))
                 .foregroundStyle(Theme.C.ink)
+        }
+    }
+}
+
+// MARK: - Authored section (the prose blocks a trade document is expected to carry)
+
+/// One authored block — ASSIGNMENT, SITE NOTES, SCOPE OF WORK, SUMMARY.
+///
+/// This is what makes each document type recognizable as itself rather than
+/// as the same list under a different heading. A crew reads ASSIGNMENT and
+/// SITE NOTES before they read a single line item; a client reads SCOPE OF
+/// WORK and may never read the lines at all.
+///
+/// Gaps show rather than hide. An operator scanning before sending needs to
+/// see that nothing was said about safety, in the place the safety note would
+/// have been — a silently absent field is indistinguishable from a field that
+/// was never on the document, and the whole point is that they can fill it.
+struct DocSectionView: View {
+    let section: DocSectionFixture
+    /// Tapping a field opens it for editing, like a line.
+    var onEdit: ((DocFieldFixture) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(section.label)
+                .font(Theme.F.mono(8, .semibold))
+                .tracking(1.6)
+                .foregroundStyle(Theme.C.ink60)
+                .padding(.bottom, 1)
+                .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1) }
+
+            ForEach(section.fields) { field in
+                fieldView(field)
+                    .contentShape(Rectangle())
+                    .onTapGesture { onEdit?(field) }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityHint("Edit \(field.label)")
+            }
+        }
+        .padding(.top, 14)
+    }
+
+    /// A section holding ONE paragraph is already named by its own heading —
+    /// SCOPE OF WORK over a field labelled "Scope of work" is the heading
+    /// said twice. Sections with more than one field keep their labels,
+    /// because there the labels are what tell Access apart from Safety.
+    private var labelsAreRedundant: Bool {
+        section.fields.count == 1 && section.fields[0].isParagraph
+    }
+
+    @ViewBuilder
+    private func fieldView(_ field: DocFieldFixture) -> some View {
+        if field.isParagraph {
+            VStack(alignment: .leading, spacing: 3) {
+                if !labelsAreRedundant {
+                    Text(field.label.uppercased())
+                        .font(Theme.F.mono(7.5, .semibold))
+                        .tracking(1.2)
+                        .foregroundStyle(Theme.C.ink45)
+                }
+                valueText(field)
+            }
+        } else {
+            // Short fields sit inline — "ASSIGNED TO   Jose, Michael" reads
+            // as a form field, which is exactly what it is.
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(field.label.uppercased())
+                    .font(Theme.F.mono(7.5, .semibold))
+                    .tracking(1.2)
+                    .foregroundStyle(Theme.C.ink45)
+                    // Wide enough for "ASSIGNED TO" on one line — a wrapped
+                    // two-word label reads as a layout accident.
+                    .frame(width: 104, alignment: .leading)
+                valueText(field)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func valueText(_ field: DocFieldFixture) -> some View {
+        if let value = field.value, !field.isGap {
+            Text(value)
+                .font(Theme.F.ui(12, .medium))
+                .foregroundStyle(Theme.C.ink)
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Text(OperatorNote.gap)
+                .font(Theme.F.mono(8, .semibold))
+                .tracking(0.3)
+                .foregroundStyle(Theme.C.yellowTag)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -395,14 +395,125 @@ final class DemoWalkEngine: WalkEngine {
         // "findings") shape for an inspection.
         let counted = kind == "inspection"
         return DocumentModel(
-            rows: rows,
-            totalKey: priced ? trade.totalKey : (counted ? "FINDINGS" : "ITEMS"),
+            rows: kind == "work_order" ? Self.assigned(rows) : rows,
+            totalKey: DocKinds.totalLabel(for: kind),
             staticTotal: priced ? trade.totalValue : "\(rows.count)",
             // The gap/price note only means anything on a priced document.
             note: priced ? trade.note : "",
             send: "SEND \(DocKinds.label(for: kind).uppercased())",
+            sections: Self.demoSections(for: kind),
+            // The demo mints a matching per-kind number so a demo work order
+            // does not go out unnumbered while the real one does.
+            docNumber: Self.demoDocNumber(for: kind, fallback: trade.docNo),
+            docKindLabel: DocKinds.label(for: kind).uppercased(),
             pricesShown: priced
         )
+    }
+
+    /// The demo's per-kind document number. The fixture number ("EST-0047")
+    /// only fits the trade's lead kind; the others keep its digits and take
+    /// their own prefix, so a demo work order is WO-0047 rather than blank.
+    private static func demoDocNumber(for kind: String, fallback: String) -> String {
+        let digits = fallback.split(separator: "-").last.map(String.init) ?? "0001"
+        let prefix: String
+        switch kind {
+        case "estimate": prefix = "EST"
+        case "invoice": prefix = "INV"
+        case "work_order": prefix = "WO"
+        case "inspection": prefix = "IR"
+        case "condition": prefix = "COND"
+        case "move_out": prefix = "MO"
+        default: prefix = "DOC"
+        }
+        return "\(prefix)-\(digits)"
+    }
+
+    /// The demo's crew names, so a demo work order shows the column a real one
+    /// has. Round-robin rather than random: a screenshot run must produce the
+    /// same document twice.
+    private static func assigned(_ rows: [DocRowFixture]) -> [DocRowFixture] {
+        let crew = ["Jose", "Michael"]
+        return rows.enumerated().map { index, row in
+            var out = row
+            out.assignee = crew[index % crew.count]
+            return out
+        }
+    }
+
+    /// The authored blocks each kind carries in the REAL pipeline, written out
+    /// for the demo.
+    ///
+    /// The demo has to show what the product does, not less: the fixtures are
+    /// what onboarding teaches from and what an App Store reviewer sees, and
+    /// a demo estimate with no SCOPE OF WORK would be advertising the version
+    /// of this product that existed yesterday. (The reverse of that mismatch —
+    /// a demo promising a deposit total the real move-out report could not
+    /// produce — is what prompted this whole pass.)
+    private static func demoSections(for kind: String) -> [DocSectionFixture] {
+        func para(_ key: String, _ label: String, _ value: String) -> DocFieldFixture {
+            DocFieldFixture(key: key, label: label, value: value, isGap: false, isParagraph: true)
+        }
+        func line(_ key: String, _ label: String, _ value: String?) -> DocFieldFixture {
+            DocFieldFixture(
+                key: key, label: label, value: value, isGap: value == nil, isParagraph: false
+            )
+        }
+        switch kind {
+        case "estimate":
+            return [DocSectionFixture(key: "scope", label: "SCOPE OF WORK", fields: [para(
+                "scope_summary", "Scope of work",
+                "Refresh the front beds and walkway line: three yards of premium bark mulch "
+                    + "delivered and installed, boxwood trimmed and clippings hauled, sixty feet "
+                    + "of bed edging re-cut, and the zone 2 irrigation head replaced."
+            )])]
+        case "invoice":
+            return [DocSectionFixture(key: "work", label: "WORK PERFORMED", fields: [para(
+                "work_summary", "Work performed",
+                "Installed three yards of premium bark mulch across the front beds, trimmed the "
+                    + "boxwood along the walkway and hauled the clippings, re-cut sixty feet of "
+                    + "bed edging, and replaced the zone 2 irrigation head."
+            )])]
+        case "work_order":
+            return [
+                DocSectionFixture(key: "assignment", label: "ASSIGNMENT", fields: [
+                    line("crew", "Assigned to", "Jose, Michael"),
+                    line("schedule", "Scheduled", "Thursday, first thing"),
+                ]),
+                DocSectionFixture(key: "site", label: "SITE NOTES", fields: [
+                    para(
+                        "access", "Access",
+                        "Gate code 4412 on the side yard. Park on the street — the driveway is "
+                            + "being sealed. Dog is in the back until eight."
+                    ),
+                    para(
+                        "safety", "Safety",
+                        "Irrigation lines run shallow along the walkway bed — hand-dig within a "
+                            + "foot of the heads."
+                    ),
+                ]),
+            ]
+        case "condition", "move_out":
+            return [DocSectionFixture(key: "summary", label: "SUMMARY", fields: [para(
+                "summary", "Summary",
+                "Unit 12, walked at move-out. Overall condition is good with normal wear to the "
+                    + "walls throughout. Two items fall outside normal wear and are itemized "
+                    + "below; the water heater serial was logged for the file."
+            )])]
+        case "inspection":
+            return [DocSectionFixture(key: "summary", label: "SUMMARY", fields: [para(
+                "summary", "Summary",
+                "Pre-purchase inspection of a 2001 single-family home. One safety item: the hall "
+                    + "bathroom GFCI does not trip on test. Three repair items follow, including "
+                    + "three lifted shingles on the south slope and grading that falls toward the "
+                    + "foundation at the northeast corner."
+            )])]
+        default:
+            return [DocSectionFixture(key: "summary", label: "SUMMARY", fields: [para(
+                "summary", "Summary",
+                "Site visit write-up. The items below are what was walked and agreed, in the "
+                    + "order they were covered on site."
+            )])]
+        }
     }
 
     // MARK: Document schemas (Plan 19) — in-memory demo conformance.

--- a/apps/ios/Sources/Engine/DocumentSchemaModel.swift
+++ b/apps/ios/Sources/Engine/DocumentSchemaModel.swift
@@ -37,6 +37,10 @@ struct SchemaFieldModel: Identifiable, Hashable {
     var fill: String
     /// The authored constant when `fill == "static"`; nil otherwise.
     var staticValue: String?
+    /// What this field should contain, in the model's terms. Not editable in
+    /// v1 — carried so a round-trip through the editor cannot silently strip
+    /// it off a built-in and leave the compose pass writing one-word answers.
+    var hint: String?
 
     init(
         id: UUID = UUID(),
@@ -44,7 +48,8 @@ struct SchemaFieldModel: Identifiable, Hashable {
         kind: String,
         label: String,
         fill: String,
-        staticValue: String? = nil
+        staticValue: String? = nil,
+        hint: String? = nil
     ) {
         self.id = id
         self.key = key
@@ -52,6 +57,7 @@ struct SchemaFieldModel: Identifiable, Hashable {
         self.label = label
         self.fill = fill
         self.staticValue = staticValue
+        self.hint = hint
     }
 }
 
@@ -63,6 +69,9 @@ struct SchemaSectionModel: Identifiable, Hashable {
     var label: String
     /// Whether the captured-items table carries amounts.
     var priced: Bool
+    /// `line_items` only: "" | "inclusion" | "directive" | "observation".
+    /// Not editable in v1 — carried for the same reason as `hint`.
+    var lineDetail: String
     var fields: [SchemaFieldModel]
 
     init(
@@ -71,6 +80,7 @@ struct SchemaSectionModel: Identifiable, Hashable {
         kind: String,
         label: String,
         priced: Bool,
+        lineDetail: String = "",
         fields: [SchemaFieldModel]
     ) {
         self.id = id
@@ -78,6 +88,7 @@ struct SchemaSectionModel: Identifiable, Hashable {
         self.kind = kind
         self.label = label
         self.priced = priced
+        self.lineDetail = lineDetail
         self.fields = fields
     }
 }

--- a/apps/ios/Sources/Engine/MurmurEngine.swift
+++ b/apps/ios/Sources/Engine/MurmurEngine.swift
@@ -438,13 +438,15 @@ final class MurmurEngine: WalkEngine {
                     kind: section.kind,
                     label: section.label,
                     priced: section.priced,
+                    lineDetail: section.lineDetail,
                     fields: section.fields.map { field in
                         SchemaFieldModel(
                             key: field.key,
                             kind: field.kind,
                             label: field.label,
                             fill: field.fill,
-                            staticValue: field.staticValue
+                            staticValue: field.staticValue,
+                            hint: field.hint
                         )
                     }
                 )
@@ -476,13 +478,15 @@ final class MurmurEngine: WalkEngine {
                     kind: section.kind,
                     label: section.label,
                     priced: section.priced,
+                    lineDetail: section.lineDetail,
                     fields: section.fields.map { field in
                         MurmurCoreFFI.SchemaField(
                             key: field.key,
                             kind: field.kind,
                             label: field.label,
                             fill: field.fill,
-                            staticValue: field.staticValue
+                            staticValue: field.staticValue,
+                            hint: field.hint
                         )
                     }
                 )

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -57,16 +57,27 @@ extension MurmurEngine {
         dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(unixSeconds))).uppercased()
     }
 
-    static func docNumberLabel(docKind: String, docNumber: UInt64) -> String {
+    /// "EST-0047". `numberPrefix` is the resolved schema row's, so an
+    /// operator's own document type numbers itself correctly; the switch is
+    /// the fallback for a pre-Plan-19 body that carries no prefix.
+    static func docNumberLabel(
+        docKind: String,
+        docNumber: UInt64,
+        numberPrefix: String? = nil
+    ) -> String {
         let prefix: String
-        switch docKind {
-        case "estimate": prefix = "EST"
-        case "invoice": prefix = "INV"
-        case "work_order": prefix = "WO"
-        case "inspection": prefix = "IR"
-        case "condition": prefix = "COND"
-        case "move_out": prefix = "MO"
-        default: prefix = "DOC"
+        if let numberPrefix, !numberPrefix.isEmpty {
+            prefix = numberPrefix
+        } else {
+            switch docKind {
+            case "estimate": prefix = "EST"
+            case "invoice": prefix = "INV"
+            case "work_order": prefix = "WO"
+            case "inspection": prefix = "IR"
+            case "condition": prefix = "COND"
+            case "move_out": prefix = "MO"
+            default: prefix = "DOC"
+            }
         }
         return "\(prefix)-\(String(format: "%04d", docNumber))"
     }
@@ -83,6 +94,10 @@ extension MurmurEngine {
         switch key {
         case "deposit_deduction": return "DEPOSIT DEDUCTION"
         case "findings": return "FINDINGS"
+        // What the sum MEANS differs, and this label is the only place a
+        // reader learns it: an estimate totals an offer, an invoice states a
+        // debt that is now owed.
+        case "amount_due": return "AMOUNT DUE"
         default: return "TOTAL"
         }
     }
@@ -112,7 +127,7 @@ extension MurmurEngine {
     static func row(_ line: FFIDocLine) -> DocRowFixture {
         DocRowFixture(
             title: line.title,
-            sub: line.isGap ? "NOT HEARD — TAP OR SAY IT" : line.detail,
+            sub: line.isGap ? OperatorNote.gap : line.detail,
             subWarn: line.isGap,
             hint: nil, // Deferred 4: price-book autofill hint
             qty: line.qty,
@@ -126,8 +141,56 @@ extension MurmurEngine {
             amount: line.amountCents.map(amountString) ?? (line.isGap ? "——" : ""),
             isEdit: false, // Deferred 4: pre-filled-from-history affordance
             isGap: line.isGap,
-            itemId: line.itemId
+            itemId: line.itemId,
+            assignee: line.assignee
         )
+    }
+
+    static func totalLabelText(_ key: String) -> String { totalLabel(key) }
+
+    /// The authored sections, grouped from the flat `fields` array the
+    /// payload carries. Order is preserved — core emits fields in schema
+    /// order, and the schema order IS the reading order of the document.
+    static func sections(_ payload: FFIDocumentPayload) -> [DocSectionFixture] {
+        var order: [String] = []
+        var grouped: [String: [DocFieldFixture]] = [:]
+        for field in payload.fields {
+            if grouped[field.sectionKey] == nil {
+                order.append(field.sectionKey)
+                grouped[field.sectionKey] = []
+            }
+            grouped[field.sectionKey]?.append(DocFieldFixture(
+                key: field.key,
+                label: field.label,
+                value: field.value,
+                isGap: field.isGap,
+                isParagraph: field.kind == "long_text"
+            ))
+        }
+        return order.map { key in
+            DocSectionFixture(
+                key: key,
+                // Core sends the field labels but not the section's own; the
+                // section key is authored lowercase and stable, so it is the
+                // honest source for the stamp above the block.
+                label: sectionLabel(key),
+                fields: grouped[key] ?? []
+            )
+        }
+    }
+
+    /// Display copy for an authored section. Unknown (operator-authored)
+    /// keys fall back to the key itself, title-cased — better a plain stamp
+    /// than a section with no heading at all.
+    static func sectionLabel(_ key: String) -> String {
+        switch key {
+        case "scope": return "SCOPE OF WORK"
+        case "work": return "WORK PERFORMED"
+        case "assignment": return "ASSIGNMENT"
+        case "site": return "SITE NOTES"
+        case "summary": return "SUMMARY"
+        default: return key.replacingOccurrences(of: "_", with: " ").uppercased()
+        }
     }
 
     static func document(_ payload: FFIDocumentPayload) -> DocumentModel {
@@ -137,6 +200,13 @@ extension MurmurEngine {
             staticTotal: payload.staticTotalCents.map(amountString) ?? "——",
             note: note(for: payload.docKind, queued: payload.queued),
             send: sendLabel(for: payload.docKind),
+            sections: sections(payload),
+            docNumber: docNumberLabel(
+                docKind: payload.docKind,
+                docNumber: payload.docNumber,
+                numberPrefix: payload.numberPrefix
+            ),
+            docKindLabel: DocKinds.label(for: payload.docKind).uppercased(),
             // Built-in kinds answer directly; a custom schema (Plan 19) is
             // priced iff core actually rendered money onto it — an amount or
             // a gap on any line. Guessing from the kind name alone would tell

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -40,12 +40,61 @@ struct PhotoModel: Identifiable, Equatable {
     var capturedAt: UInt64
 }
 
+/// One authored section of a document — the block of prose above or below
+/// the lines that turns a list into a document a trade reader recognizes.
+///
+/// A work order's ASSIGNMENT and SITE NOTES, an estimate's SCOPE OF WORK, a
+/// report's SUMMARY. Rendered from the schema, so an operator's own document
+/// type gets its own sections with no app change.
+struct DocSectionFixture: Identifiable {
+    let id = UUID()
+    let key: String
+    let label: String
+    var fields: [DocFieldFixture]
+
+    /// A section with nothing written in it at all is not rendered — an
+    /// all-gap block is a heading over an empty box, which reads as a broken
+    /// screen rather than as an honest blank.
+    var hasContent: Bool { fields.contains { !$0.isGap } }
+}
+
+struct DocFieldFixture: Identifiable {
+    let id = UUID()
+    let key: String
+    let label: String
+    /// `nil` = a truthful gap: nothing about this was said on the walk.
+    var value: String?
+    var isGap: Bool
+    /// `long_text` sets its own paragraph; `text` sits inline beside its label.
+    var isParagraph: Bool
+}
+
 struct DocumentModel {
     var rows: [DocRowFixture]
     var totalKey: String
     var staticTotal: String   // used when rows carry no $ amounts (e.g. inspection)
     var note: String
     var send: String
+    /// Authored sections, in schema order. Empty for the demo engine's
+    /// fixtures and any pre-Plan-19 document body.
+    var sections: [DocSectionFixture] = []
+    /// The document's own number — "EST-0047", "INV-0003", "WO-0012".
+    ///
+    /// Core has minted a real, per-kind, monotonic number on every build
+    /// since Plan 13, and the app was throwing it away: the letterhead read
+    /// the FIXTURE number for a trade's lead kind and printed nothing at all
+    /// for the other six. So every real estimate went out as EST-0047
+    /// whatever core had minted, and every real invoice went out with no
+    /// invoice number — which is not a document a bookkeeper can accept, and
+    /// in most places not one a client is obliged to pay against.
+    var docNumber: String = ""
+    /// "WORK ORDER", "INVOICE" — the stamp at the top right.
+    ///
+    /// Same defect as `docNumber` and the same fix: the PDF was passing the
+    /// TRADE fixture's kind, so an exported work order was headed ESTIMATE.
+    /// One value, read by the screen and the export, because a document that
+    /// disagrees with itself about what it is has no business being sent.
+    var docKindLabel: String = ""
     /// Whether this document has an amount column at all.
     ///
     /// Set once, at build, from the kind — NOT inferred from the rows, which

--- a/apps/ios/Sources/Fixtures/Fixtures.swift
+++ b/apps/ios/Sources/Fixtures/Fixtures.swift
@@ -44,6 +44,37 @@ struct CapturedFixture: Identifiable {
     }
 }
 
+/// Marks the app writes onto a document to talk to the OPERATOR — never to
+/// whoever receives it.
+///
+/// "NOT HEARD — TAP OR SAY IT" is an instruction to the person holding the
+/// phone. "ADDED BY YOU" and "FILLED BY YOU" are provenance, useful while
+/// reviewing and faintly damaging on a client's copy: they advertise which
+/// parts of the estimate the software got wrong. Isaac, 2026-08-09: *"when
+/// the user hits send... little tag lines like 'added by you' are not
+/// included. Overall these should be clean and professional looking."*
+///
+/// They live here, in one place, because the failure mode is silent: a new
+/// marker added at a call site would simply start printing on customers'
+/// paperwork, and nobody would find out from the app. `DocumentPDF` strips
+/// everything in `all`, so a marker that is not registered here is a bug that
+/// ships. Add new ones HERE, not as string literals.
+enum OperatorNote {
+    static let added = "ADDED BY YOU"
+    static let filled = "FILLED BY YOU"
+    static let gap = "NOT HEARD — TAP OR SAY IT"
+
+    static let all: Set<String> = [added, filled, gap]
+
+    /// True for any operator-facing mark, including the demo fixtures' older
+    /// comma-spelled variants ("NOT HEARD, TAP OR SAY IT").
+    static func isOperatorFacing(_ text: String) -> Bool {
+        let upper = text.uppercased()
+        return all.contains(text) || upper.hasPrefix("NOT HEARD") || upper.hasPrefix("NOT ACCESSED")
+            || upper.hasSuffix("BY YOU")
+    }
+}
+
 struct DocRowFixture: Identifiable {
     let id = UUID()
     /// `var` so review can rename a line in place (#…, Isaac 2026-08-09).
@@ -53,7 +84,9 @@ struct DocRowFixture: Identifiable {
     var sub: String
     var subWarn: Bool = false
     var hint: String? = nil
-    let qty: String
+    /// `var` so the print path can blank a gap's "——" — a dash is warning
+    /// styling for the operator, not information for the client.
+    var qty: String
     /// `var` so a non-pricing document can blank it without rebuilding the row
     /// field by field (#222) — a work order must not carry prices.
     var amount: String
@@ -63,6 +96,9 @@ struct DocRowFixture: Identifiable {
     /// fixture rows (no core ids), total/rollup lines, or rows built before
     /// Plan 12 landed. // sac: a demo could wire a stub id to preview grouping.
     var itemId: String?
+    /// Who is doing this line — work orders only, where the money column is
+    /// empty by design and that space belongs to the crew.
+    var assignee: String?
 }
 
 struct TradeFixture {
@@ -149,13 +185,34 @@ enum DocKinds {
         case "work_order": return "CREW"
         case "condition": return "REPORT"
         case "move_out": return "DEPOSIT"
-        case "inspection": return "TREC REPORT"
+        // NOT "TREC REPORT". TREC is the Texas Real Estate Commission's
+        // mandatory inspection form, which a licensed Texas inspector is
+        // required to deliver on — and this app produces a findings list, not
+        // that form. There is no TREC section mapping anywhere in the
+        // codebase. An inspector reading that stamp would reasonably expect
+        // the form and discover otherwise after the walk, which is the worst
+        // possible moment.
+        case "inspection": return "FINDINGS"
         default: return "EXPORT"
         }
     }
 
+    /// Mirrors core's `is_pricing_kind`. `move_out` joined on 2026-08-09: the
+    /// deduction total IS the move-out report, and the unpriced version could
+    /// not do the one job it has.
     static func isPricingKind(_ kind: String) -> Bool {
-        kind == "estimate" || kind == "invoice"
+        kind == "estimate" || kind == "invoice" || kind == "move_out"
+    }
+
+    /// Mirrors core's `total_shape` label key → the demo's display copy, so a
+    /// demo invoice says AMOUNT DUE exactly like the real one.
+    static func totalLabel(for kind: String) -> String {
+        switch kind {
+        case "invoice": return "AMOUNT DUE"
+        case "move_out": return "DEPOSIT DEDUCTION"
+        case "inspection": return "FINDINGS"
+        default: return isPricingKind(kind) ? "TOTAL" : "ITEMS"
+        }
     }
 }
 
@@ -190,12 +247,12 @@ enum Fixtures {
         docNo: "EST-0047",
         docDate: "JUL 01 2026",
         rows: [
-            DocRowFixture(title: "Premium bark mulch, front beds", sub: "DELIVERED + INSTALLED", qty: "3 CU YD", amount: "$285"),
-            DocRowFixture(title: "Boxwood trim, walkway line", sub: "SHAPE + HAUL CLIPPINGS", qty: "× 4", amount: "$140"),
-            DocRowFixture(title: "Irrigation head, zone 2", sub: "PARTS + LABOR", hint: "↺ LAST 3: $110 · $120 · $125", qty: "× 1", amount: "$120", isEdit: true),
-            DocRowFixture(title: "Bed edging, front beds", sub: "SPADE EDGE, RE-CUT", qty: "60 LF", amount: "$310"),
+            DocRowFixture(title: "Premium bark mulch, front beds", sub: "Delivered and installed", qty: "3 CU YD", amount: "$285"),
+            DocRowFixture(title: "Boxwood trim, walkway line", sub: "Shaped, clippings hauled", qty: "× 4", amount: "$140"),
+            DocRowFixture(title: "Irrigation head, zone 2", sub: "Parts and labor", hint: "↺ LAST 3: $110 · $120 · $125", qty: "× 1", amount: "$120", isEdit: true),
+            DocRowFixture(title: "Bed edging, front beds", sub: "Spade edge, re-cut", qty: "60 LF", amount: "$310"),
             DocRowFixture(title: "Haul & disposal", sub: "NOT HEARD, TAP OR SAY IT", subWarn: true, qty: "× 1", amount: "——", isGap: true),
-            DocRowFixture(title: "Crew labor", sub: "2-MAN CREW · HALF DAY", qty: "4 HR", amount: "$355"),
+            DocRowFixture(title: "Crew labor", sub: "Two-man crew · half day", qty: "4 HR", amount: "$355"),
         ],
         totalKey: "TOTAL",
         totalValue: "$1,210",
@@ -232,10 +289,10 @@ enum Fixtures {
         docNo: "MO-0112",
         docDate: "JUL 01 2026",
         rows: [
-            DocRowFixture(title: "Carpet, bedroom 1", sub: "STAIN NEAR WINDOW · PHOTO ×2", hint: "↺ SCHEDULE: CARPET CLEAN $140", qty: "DEDUCT", amount: "$140", isEdit: true),
-            DocRowFixture(title: "Blinds, kitchen", sub: "2 SLATS MISSING · PHOTO ×1", qty: "DEDUCT", amount: "$45"),
-            DocRowFixture(title: "Walls, all rooms", sub: "NORMAL WEAR AND TEAR", qty: "OK", amount: "—"),
-            DocRowFixture(title: "Water heater", sub: "MFG 2019 · SERIAL LOGGED", qty: "NOTE", amount: "—"),
+            DocRowFixture(title: "Carpet, bedroom 1", sub: "Stain near the window · photo ×2", hint: "↺ SCHEDULE: CARPET CLEAN $140", qty: "DEDUCT", amount: "$140", isEdit: true),
+            DocRowFixture(title: "Blinds, kitchen", sub: "Two slats missing · photo ×1", qty: "DEDUCT", amount: "$45"),
+            DocRowFixture(title: "Walls, all rooms", sub: "Normal wear and tear", qty: "OK", amount: "—"),
+            DocRowFixture(title: "Water heater", sub: "Mfg 2019 · serial logged", qty: "NOTE", amount: "—"),
             DocRowFixture(title: "Garage remote", sub: "NOT HEARD, RETURNED? SAY IT", subWarn: true, qty: "DEDUCT", amount: "——", isGap: true),
         ],
         totalKey: "DEPOSIT DEDUCTION",
@@ -273,15 +330,18 @@ enum Fixtures {
         docNo: "IR-0389",
         docDate: "JUL 01 2026",
         rows: [
-            DocRowFixture(title: "Roof covering, south slope", sub: "3 LIFTED SHINGLES · PHOTO ×3", qty: "REPAIR", amount: "§ 2.1"),
-            DocRowFixture(title: "GFCI, hall bathroom", sub: "FAILS TO TRIP ON TEST", hint: "↺ AUTO-FILED FROM YOUR LAST 12 REPORTS", qty: "SAFETY", amount: "§ 6.4", isEdit: true),
-            DocRowFixture(title: "Attic ventilation", sub: "RIDGE + SOFFIT, ADEQUATE", qty: "OK", amount: "§ 3.2"),
-            DocRowFixture(title: "Furnace filter", sub: "REPLACEMENT OVERDUE", qty: "MAINT", amount: "§ 5.1"),
+            DocRowFixture(title: "Roof covering, south slope", sub: "Three lifted shingles · photo ×3", qty: "REPAIR", amount: "§ 2.1"),
+            DocRowFixture(title: "GFCI, hall bathroom", sub: "Fails to trip on test", hint: "↺ AUTO-FILED FROM YOUR LAST 12 REPORTS", qty: "SAFETY", amount: "§ 6.4", isEdit: true),
+            DocRowFixture(title: "Attic ventilation", sub: "Ridge and soffit, adequate", qty: "OK", amount: "§ 3.2"),
+            DocRowFixture(title: "Furnace filter", sub: "Replacement overdue", qty: "MAINT", amount: "§ 5.1"),
             DocRowFixture(title: "Water heater TPR valve", sub: "NOT ACCESSED, VERIFY OR EXCLUDE", subWarn: true, qty: "——", amount: "§ 5.3", isGap: true),
         ],
         totalKey: "FINDINGS",
         totalValue: "1 SAFETY · 3 REPAIR",
-        note: "FINDINGS FILE INTO TREC SECTIONS AUTOMATICALLY: REORDER BY DRAG",
+        // Was "FINDINGS FILE INTO TREC SECTIONS AUTOMATICALLY" — see
+        // `DocKinds.stamp`: there is no TREC mapping in the product, and this
+        // demo is what an inspector decides on.
+        note: "FINDINGS ARE GROUPED BY SEVERITY: SAFETY FIRST",
         send: "SEND REPORT"
     )
 

--- a/apps/ios/Sources/Flow/DocumentPDF.swift
+++ b/apps/ios/Sources/Flow/DocumentPDF.swift
@@ -7,6 +7,52 @@ import UIKit
 
 enum DocumentPDF {
 
+    /// The section with its unfilled fields dropped. See the call site: a gap
+    /// is a message to the operator, and the operator is not who reads this.
+    static func printableSection(_ section: DocSectionFixture) -> DocSectionFixture {
+        var out = section
+        out.fields = section.fields.filter { !$0.isGap }
+        return out
+    }
+
+    /// The line as a CLIENT should receive it.
+    ///
+    /// Everything the app was saying to the operator comes off (Isaac,
+    /// 2026-08-09: *"little tag lines like 'added by you' are not
+    /// included"*). Concretely:
+    ///
+    /// - **Provenance and prompts** ("ADDED BY YOU", "NOT HEARD — TAP OR SAY
+    ///   IT") go. They advertise which parts of the document the software got
+    ///   wrong, which is nobody's business but the operator's — and "added by
+    ///   you" on a line the client is being charged for actively invites the
+    ///   question "so what did the app get wrong?"
+    /// - **The price-book hint** ("↺ LAST 3: $110 · $120 · $125") goes. It is
+    ///   what this operator charged their LAST THREE customers. Printing that
+    ///   on a quote is a pricing leak.
+    /// - **An unfilled amount prints blank**, not as a yellow dashed "——".
+    ///   The operator chose to send it; the dash is warning styling, and a
+    ///   client reading a warning colour on their own estimate learns only
+    ///   that something is wrong.
+    ///
+    /// What SURVIVES is everything written for the reader: the title, the
+    /// composed detail line, the quantity, real amounts, and the assignee —
+    /// a work order's crew names are the whole point of the document.
+    static func printableRow(_ row: DocRowFixture) -> DocRowFixture {
+        var out = row
+        if row.subWarn || OperatorNote.isOperatorFacing(row.sub) {
+            out.sub = ""
+        }
+        out.subWarn = false
+        out.hint = nil
+        out.isEdit = false
+        if row.isGap {
+            out.amount = row.amount == "——" ? "" : row.amount
+            out.qty = row.qty == "——" ? "" : row.qty
+        }
+        out.isGap = false
+        return out
+    }
+
     /// `biz`/`bizSub`/`docDate` default to the trade fixture — callers with a
     /// BusinessProfile pass the operator's letterhead (AppModel.makePDF); the
     /// gallery/demo path keeps rendering fixture paperwork unchanged.
@@ -31,8 +77,12 @@ enum DocumentPDF {
         renderer.scale = 3
         guard let image = renderer.uiImage else { return nil }
 
+        // The document's own number names the file. It used to be the trade
+        // FIXTURE's number, so every export — invoice, work order, report —
+        // arrived in the client's inbox as "EST-0047.pdf".
+        let fileName = document.docNumber.isEmpty ? trade.docNo : document.docNumber
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(trade.docNo).pdf")
+            .appendingPathComponent("\(fileName).pdf")
         let pdf = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: pageSize))
         do {
             try pdf.writePDF(to: url) { ctx in
@@ -61,15 +111,33 @@ private struct PDFPageView: View {
             Letterhead(
                 biz: biz,
                 bizSub: bizSub,
-                docKind: trade.docKind,
-                docNo: trade.docNo,
+                docKind: document.docKindLabel.isEmpty ? trade.docKind : document.docKindLabel,
+                // The minted number, same as the preview — an exported PDF
+                // that disagreed with the screen about its own document
+                // number would be the worst possible place to disagree.
+                docNo: document.docNumber.isEmpty ? trade.docNo : document.docNumber,
                 docDate: docDate,
                 branding: branding
             )
-            ForEach(document.rows) { row in
-                DocRowView(row: row)
+            // The authored blocks, above the lines — the same order as the
+            // review screen, because "pixel-identical to the preview" is the
+            // promise the whole review screen rests on.
+            //
+            // Gaps are the one deliberate difference: on screen an unfilled
+            // field shows as "NOT HEARD — TAP OR SAY IT" so the operator can
+            // fix it; in the exported PDF that sentence would be addressed to
+            // the CLIENT, telling them the contractor's software missed
+            // something. A block with nothing written in it is simply omitted.
+            ForEach(document.sections.filter(\.hasContent)) { section in
+                DocSectionView(section: DocumentPDF.printableSection(section))
             }
-            TotalRow(key: document.totalKey, value: document.totalValue, gaps: document.gapCount)
+            ForEach(document.rows) { row in
+                DocRowView(row: DocumentPDF.printableRow(row))
+            }
+            // `gaps: 0` — the "+3 GAP" badge is the app nudging the operator
+            // before they send. Once they have sent, it is a note to the
+            // client that the estimate is incomplete.
+            TotalRow(key: document.totalKey, value: document.totalValue, gaps: 0)
                 .padding(.top, 2)
             // Structure basics (DocumentLayout): operator terms + signature line.
             if !layout.termsText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -93,7 +161,9 @@ private struct PDFPageView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.white)
     }
+
 }
+
 
 // MARK: - Share sheet wrapper
 

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -54,14 +54,28 @@ struct ReviewView: View {
                             // outside the fixture estimate rather than invented:
                             // core mints real numbers, and a fake one on a real
                             // document would be worse than none.
-                            docKind: model.reviewKind.map { DocKinds.label(for: $0).uppercased() }
-                                ?? model.trade.docKind,
-                            docNo: model.reviewKind == nil
-                                || model.reviewKind == DocKinds.primaryKind(for: model.trade.key)
-                                ? model.trade.docNo : "",
+                            docKind: doc.docKindLabel.isEmpty
+                                ? model.trade.docKind : doc.docKindLabel,
+                            // The number core actually minted for THIS build.
+                            // It used to fall back to the fixture's EST-0047
+                            // for a trade's lead kind and to nothing at all
+                            // for the other six — so every real invoice went
+                            // out unnumbered. See `DocumentModel.docNumber`.
+                            docNo: doc.docNumber.isEmpty ? model.trade.docNo : doc.docNumber,
                             docDate: model.letterheadDate,
                             branding: model.branding
                         )
+                        // The authored blocks, above the itemized body — the
+                        // order every trade document on paper uses (who and
+                        // what this is about, then the lines, then the total).
+                        ForEach(doc.sections) { section in
+                            DocSectionView(section: section) { field in
+                                model.beginFieldEdit(section: section, field: field)
+                            }
+                        }
+                        if !doc.sections.isEmpty {
+                            Spacer(minLength: 14)
+                        }
                         ForEach(doc.rows) { row in
                             DocRowView(row: row)
                                 .contentShape(Rectangle())
@@ -156,6 +170,12 @@ struct ReviewView: View {
             set: { if !$0 { model.commitEdit() } }
         )) {
             editSheet
+        }
+        .sheet(isPresented: Binding(
+            get: { model.editingField != nil },
+            set: { if !$0 { model.commitFieldEdit() } }
+        )) {
+            fieldSheet
         }
         .sheet(isPresented: Binding(
             get: { model.shareURL != nil },
@@ -310,6 +330,39 @@ struct ReviewView: View {
         .buttonStyle(.plain)
         .padding(.top, 10)
         .accessibilityLabel("Add a line")
+    }
+
+    /// The authored-field editor. Deliberately plainer than the line sheet:
+    /// a field has no amount, no quantity and nothing to remove — it is one
+    /// block of words — so offering those controls would be offering three
+    /// dead buttons.
+    private var fieldSheet: some View {
+        let label = model.document?.sections
+            .first { $0.key == model.editingField?.section }?
+            .fields.first { $0.key == model.editingField?.key }?
+            .label ?? "Field"
+        return VStack(alignment: .leading, spacing: 16) {
+            SectionLabel(label)
+            TextField("What was said", text: $model.editTitle, axis: .vertical)
+                .font(Theme.F.ui(16, .medium))
+                .lineLimit(3...8)
+                .focused($titleFocused)
+                .padding(.bottom, 4)
+                .overlay(alignment: .bottom) { Theme.C.hairline.frame(height: 1.5) }
+            Text("LEAVE EMPTY TO PUT IT BACK TO A GAP")
+                .font(Theme.F.mono(8, .semibold))
+                .tracking(1.2)
+                .foregroundStyle(Theme.C.ink45)
+            Button { model.commitFieldEdit() } label: {
+                BlockLabel("SET")
+            }
+            .buttonStyle(RaisedBlockStyle(height: Theme.S.buttonHeight, leadingDot: false))
+            Spacer(minLength: 0)
+        }
+        .padding(Theme.S.screenPad)
+        .presentationDetents([.height(360)])
+        .presentationBackground(Theme.C.paper)
+        .onAppear { titleFocused = true }
     }
 
     /// One sheet for everything a line can need: its words, its number, and

--- a/apps/ios/Tests/DocumentIdentityTests.swift
+++ b/apps/ios/Tests/DocumentIdentityTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on a document knowing what it is.
+///
+/// Core has minted a real per-kind number on every build since Plan 13, and
+/// the app was discarding it: the letterhead read the trade FIXTURE's number
+/// for a trade's lead kind, and printed nothing at all for the other six. The
+/// exported file was named after the fixture too. So a real invoice went out
+/// headed ESTIMATE, numbered EST-0047 or not numbered at all, as
+/// `EST-0047.pdf` — three separate ways of telling a client this is a
+/// different document than it is.
+///
+/// An invoice without its own number is not a document a bookkeeper can
+/// accept, so this is pinned per kind rather than spot-checked.
+@MainActor
+final class DocumentIdentityTests: XCTestCase {
+    private func build(_ kind: String) async throws -> DocumentModel {
+        let engine = DemoWalkEngine()
+        _ = engine.begin(trade: Fixtures.landscape)
+        engine.append(transcript: "mulch and boxwood")
+        _ = await engine.finish()
+        return try await engine.buildDocument(sessionId: "demo-session", kind: kind)
+    }
+
+    func testEveryKindCarriesItsOwnNumberAndHeading() async throws {
+        let expected: [(kind: String, number: String, heading: String)] = [
+            ("estimate", "EST-0047", "ESTIMATE"),
+            ("invoice", "INV-0047", "INVOICE"),
+            ("work_order", "WO-0047", "WORK ORDER"),
+            ("report", "DOC-0047", "REPORT"),
+        ]
+        for row in expected {
+            let doc = try await build(row.kind)
+            XCTAssertEqual(doc.docNumber, row.number, "\(row.kind) number")
+            XCTAssertEqual(doc.docKindLabel, row.heading, "\(row.kind) heading")
+        }
+    }
+
+    /// What the sum MEANS differs per kind, and the label is the only place a
+    /// reader learns it.
+    func testTheTotalIsLabelledByWhatItMeans() async throws {
+        let doc = try await build("invoice")
+        XCTAssertEqual(doc.totalKey, "AMOUNT DUE", "an invoice states a debt, not an offer")
+
+        let estimate = try await build("estimate")
+        XCTAssertEqual(estimate.totalKey, "TOTAL")
+
+        let workOrder = try await build("work_order")
+        XCTAssertEqual(workOrder.totalKey, "ITEMS", "a work order counts tasks; it has no money")
+    }
+
+    /// The move-out report is a money document — the deduction total is the
+    /// entire reason it exists. It was seeded unpriced while the demo screen
+    /// the product is sold on showed "DEPOSIT DEDUCTION $185".
+    func testTheMoveOutReportIsAMoneyDocument() {
+        XCTAssertTrue(DocKinds.isPricingKind("move_out"))
+        XCTAssertEqual(DocKinds.totalLabel(for: "move_out"), "DEPOSIT DEDUCTION")
+        XCTAssertFalse(DocKinds.isPricingKind("condition"), "a move-in record tallies nothing")
+        XCTAssertFalse(
+            DocKinds.isPricingKind("work_order"),
+            "a crew's copy with prices on it is the wrong document"
+        )
+    }
+
+    /// TREC is the Texas Real Estate Commission's mandatory inspection form,
+    /// which this app does not produce — there is no TREC mapping in the
+    /// codebase. Claiming it on the button an inspector taps is a promise
+    /// discovered to be false only after the walk.
+    func testTheInspectionButtonDoesNotClaimATrecForm() {
+        XCTAssertEqual(DocKinds.stamp(for: "inspection"), "FINDINGS")
+        for kind in DocKinds.legalKinds(for: "inspection") {
+            XCTAssertFalse(
+                DocKinds.stamp(for: kind).contains("TREC"),
+                "\(kind) claims a regulated form the app does not produce"
+            )
+        }
+    }
+
+    /// A work order carries the crew, an estimate never does — an assignee in
+    /// the price column would be a rendering bug wearing a data bug's clothes.
+    func testOnlyTheWorkOrderCarriesCrewNames() async throws {
+        let workOrder = try await build("work_order")
+        XCTAssertTrue(
+            workOrder.rows.allSatisfy { $0.assignee != nil },
+            "the crew column is the work order's reason for existing"
+        )
+        XCTAssertTrue(workOrder.rows.allSatisfy { $0.amount.isEmpty }, "and it carries no money")
+
+        let estimate = try await build("estimate")
+        XCTAssertTrue(estimate.rows.allSatisfy { $0.assignee == nil })
+    }
+
+    /// Each kind carries the authored blocks a trade reader expects, and they
+    /// differ — an invoice's block is past tense, a work order's is the
+    /// assignment. A document whose sections all said the same thing would be
+    /// the old "every document looks like an estimate" bug wearing a hat.
+    func testEachKindCarriesItsOwnAuthoredBlocks() async throws {
+        let cases: [(kind: String, sections: [String])] = [
+            ("estimate", ["scope"]),
+            ("invoice", ["work"]),
+            ("work_order", ["assignment", "site"]),
+            ("report", ["summary"]),
+        ]
+        for row in cases {
+            let doc = try await build(row.kind)
+            XCTAssertEqual(doc.sections.map(\.key), row.sections, "\(row.kind) sections")
+            XCTAssertTrue(
+                doc.sections.allSatisfy(\.hasContent),
+                "\(row.kind): a heading over an empty box reads as a broken document"
+            )
+        }
+    }
+}

--- a/apps/ios/Tests/PrintableDocumentTests.swift
+++ b/apps/ios/Tests/PrintableDocumentTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on what leaves the phone.
+///
+/// The review screen and the exported PDF render the same document from the
+/// same model, and that is the point — "the PDF is pixel-identical to the
+/// preview" is the promise the whole review screen rests on. But a handful of
+/// marks on that screen are the app talking to the OPERATOR: gap prompts,
+/// provenance, the price-book hint, the +N GAP badge. Isaac, 2026-08-09:
+/// *"when the user hits send... little tag lines like 'added by you' are not
+/// included. Overall these should be clean and professional looking."*
+///
+/// The failure mode is silent and outward-facing: nobody finds out from the
+/// app that a client received "ADDED BY YOU" on their estimate. So the marks
+/// live in one enum and these tests pin the filter over it — including a
+/// sweep that fails if a NEW marker is ever added without being registered.
+final class PrintableDocumentTests: XCTestCase {
+    private func printable(_ row: DocRowFixture) -> DocRowFixture {
+        DocumentPDF.printableRow(row)
+    }
+
+    // MARK: Provenance never prints
+
+    func testProvenanceAndPromptsAreStripped() {
+        for note in OperatorNote.all {
+            let row = DocRowFixture(
+                title: "5 yards mulch", sub: note, subWarn: note == OperatorNote.gap,
+                qty: "3 CU YD", amount: "$200"
+            )
+            XCTAssertEqual(printable(row).sub, "", "\(note) reached the client's copy")
+            XCTAssertFalse(printable(row).subWarn)
+        }
+    }
+
+    /// The sweep: every operator-facing string the app can put in a `sub` has
+    /// to be recognized. A new one added at a call site without registering
+    /// it in `OperatorNote` would otherwise print on customers' paperwork.
+    func testEveryKnownOperatorMarkerIsRecognized() {
+        let marks = [
+            OperatorNote.added, OperatorNote.filled, OperatorNote.gap,
+            "NOT HEARD, TAP OR SAY IT",           // demo fixtures' older spelling
+            "NOT HEARD, RETURNED? SAY IT",        // move-out fixture
+            "NOT ACCESSED, VERIFY OR EXCLUDE",    // inspection fixture
+        ]
+        for mark in marks {
+            XCTAssertTrue(
+                OperatorNote.isOperatorFacing(mark),
+                "\(mark) is not recognized as operator-facing — it will print"
+            )
+        }
+    }
+
+    func testTheComposedDetailLineSurvives() {
+        // The one thing on that line written FOR the reader.
+        let row = DocRowFixture(
+            title: "Mulch the front beds",
+            sub: "Strip the old bark first. Watch the irrigation heads.",
+            qty: "", amount: ""
+        )
+        XCTAssertEqual(
+            printable(row).sub, "Strip the old bark first. Watch the irrigation heads.",
+            "the directive IS the work order"
+        )
+    }
+
+    // MARK: The pricing leak
+
+    func testThePriceBookHintNeverPrints() {
+        // "LAST 3: $110 · $120 · $125" is what this operator charged their
+        // last three customers. On a quote, that is a pricing leak.
+        let row = DocRowFixture(
+            title: "Irrigation head", sub: "", hint: "↺ LAST 3: $110 · $120 · $125",
+            qty: "× 1", amount: "$120"
+        )
+        XCTAssertNil(printable(row).hint)
+    }
+
+    // MARK: Gaps
+
+    func testAnUnfilledAmountPrintsBlankNotAWarningDash() {
+        let row = DocRowFixture(
+            title: "Haul & disposal", sub: OperatorNote.gap, subWarn: true,
+            qty: "——", amount: "——", isGap: true
+        )
+        let out = printable(row)
+        XCTAssertEqual(out.amount, "", "a yellow dashed —— is warning styling, not information")
+        XCTAssertEqual(out.qty, "")
+        XCTAssertFalse(out.isGap, "and it renders in plain ink, not in the gap treatment")
+    }
+
+    func testARealAmountOnAGapLineIsKept() {
+        // An inspection's amount column carries section refs ("§ 5.3"), not
+        // money — a gap there must not blank a value that was actually set.
+        let row = DocRowFixture(
+            title: "Water heater TPR valve", sub: "NOT ACCESSED, VERIFY OR EXCLUDE",
+            subWarn: true, qty: "——", amount: "§ 5.3", isGap: true
+        )
+        XCTAssertEqual(printable(row).amount, "§ 5.3")
+    }
+
+    // MARK: What the reader is owed
+
+    func testTheCrewNameSurvivesOnAWorkOrder() {
+        let row = DocRowFixture(
+            title: "Rebuild the fence panel", sub: "Match the existing pickets.",
+            qty: "", amount: "", assignee: "Michael"
+        )
+        XCTAssertEqual(printable(row).assignee, "Michael", "the crew names ARE the work order")
+    }
+
+    func testUnwrittenSectionsAndFieldsAreDroppedFromThePrintedCopy() {
+        let section = DocSectionFixture(
+            key: "site",
+            label: "SITE NOTES",
+            fields: [
+                DocFieldFixture(
+                    key: "access", label: "Access", value: "Gate code 4412.",
+                    isGap: false, isParagraph: true
+                ),
+                DocFieldFixture(
+                    key: "safety", label: "Safety", value: nil, isGap: true, isParagraph: true
+                ),
+            ]
+        )
+        let out = DocumentPDF.printableSection(section)
+        XCTAssertEqual(out.fields.count, 1, "a gap is a message to the operator")
+        XCTAssertEqual(out.fields.first?.key, "access")
+        XCTAssertTrue(section.hasContent)
+
+        let allGaps = DocSectionFixture(
+            key: "assignment",
+            label: "ASSIGNMENT",
+            fields: [DocFieldFixture(
+                key: "crew", label: "Assigned to", value: nil, isGap: true, isParagraph: false
+            )]
+        )
+        XCTAssertFalse(
+            allGaps.hasContent,
+            "a heading over an empty box reads as a broken document, so the block is omitted"
+        )
+    }
+}

--- a/crates/evals/tests/document_fill_quality.rs
+++ b/crates/evals/tests/document_fill_quality.rs
@@ -56,6 +56,7 @@ fn unit_turn_schema() -> DocumentSchema {
                 kind: "line_items".into(),
                 label: "Items".into(),
                 priced: false,
+                line_detail: String::new(),
                 fields: vec![],
             },
             SchemaSection {
@@ -63,6 +64,7 @@ fn unit_turn_schema() -> DocumentSchema {
                 kind: "filled".into(),
                 label: "Approvals".into(),
                 priced: false,
+                line_detail: String::new(),
                 fields: vec![
                     SchemaField {
                         key: "hoa_no".into(),
@@ -70,6 +72,7 @@ fn unit_turn_schema() -> DocumentSchema {
                         label: "HOA approval #".into(),
                         fill: "walk".into(),
                         static_value: None,
+                        hint: None,
                     },
                     SchemaField {
                         key: "unit".into(),
@@ -77,6 +80,7 @@ fn unit_turn_schema() -> DocumentSchema {
                         label: "Unit".into(),
                         fill: "walk".into(),
                         static_value: None,
+                        hint: None,
                     },
                 ],
             },
@@ -148,7 +152,7 @@ fn build_fields(
 #[test]
 fn custom_field_absent_from_the_transcript_renders_as_a_gap() {
     let (fields, queued) = build_fields(vec![tool_use(
-        "fill_fields",
+        "compose_document",
         serde_json::json!({"fields": [{"key": "unit", "value": "12"}]}),
     )]);
     assert_eq!(fields[0]["key"], "hoa_no");
@@ -162,7 +166,7 @@ fn custom_field_absent_from_the_transcript_renders_as_a_gap() {
 #[test]
 fn custom_field_stated_in_the_transcript_is_filled() {
     let (fields, queued) = build_fields(vec![tool_use(
-        "fill_fields",
+        "compose_document",
         serde_json::json!({"fields": [{"key": "unit", "value": "12"}]}),
     )]);
     assert_eq!(fields[1]["key"], "unit");

--- a/crates/ffi/src/convert.rs
+++ b/crates/ffi/src/convert.rs
@@ -67,6 +67,7 @@ pub fn document_payload(artifact: &Artifact) -> Result<DocumentPayload, ConvertE
                     section: line.get("section").and_then(|x| x.as_str()).map(str::to_string),
                     is_gap: line.get("is_gap").and_then(|x| x.as_bool()).unwrap_or(false),
                     item_id: line.get("item_id").and_then(|x| x.as_str()).map(str::to_string),
+                    assignee: line.get("assignee").and_then(|x| x.as_str()).map(str::to_string),
                 })
                 .collect()
         })

--- a/crates/ffi/src/document.rs
+++ b/crates/ffi/src/document.rs
@@ -18,6 +18,15 @@ pub struct DocLine {
     /// total/rollup lines, or an old document body written before Plan 12.
     /// Additive; never derived by the FFI layer.
     pub item_id: Option<String>,
+    /// Who is doing this line — `directive` documents (the work order) only,
+    /// and only where the operator actually named someone.
+    ///
+    /// It rides in the column the amount would occupy, because a work order
+    /// carries no money and that space is exactly where the crew looks.
+    /// `None` everywhere else, including on a work order line nobody was
+    /// named for: an unassigned task is a real state, and inventing an owner
+    /// for it would put a person's name against work they never agreed to.
+    pub assignee: Option<String>,
 }
 
 /// One authored `filled`/`static` schema field of a built document (Plan 19

--- a/crates/ffi/src/document_build.rs
+++ b/crates/ffi/src/document_build.rs
@@ -121,15 +121,43 @@ mod tests {
         (engine, sid)
     }
 
+    /// A work order comes back with no money and WITH its assignment block —
+    /// the whole point of the document. The field keys validate (they are
+    /// authored, so the response can pre-know them); the per-line write
+    /// cannot, since item ids are minted at runtime (the Plan 12 C2 pattern),
+    /// and dropping it is exactly the echo-validation working.
     #[tokio::test]
-    async fn build_document_non_pricing_kind_returns_the_structure_only_document() {
-        let (engine, sid) = processed_landscape_session(vec![]).await;
+    async fn build_document_work_order_carries_its_assignment_and_no_money() {
+        let (engine, sid) = processed_landscape_session(vec![tool_use(
+            "compose_document",
+            serde_json::json!({
+                "fields": [
+                    {"key": "crew", "value": "Jose, Michael"},
+                    {"key": "access", "value": "Gate code 4412; park on the street."}
+                ],
+                "lines": [{"item_id": "placeholder", "detail": "Pick up from the yard first.",
+                           "assignee": "Jose"}]
+            }),
+        )])
+        .await;
 
         let payload = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
         assert_eq!(payload.doc_kind, "work_order");
         assert_eq!(payload.doc_number, 1, "a fresh mint for this build_document call");
         assert_eq!(payload.lines.len(), 1, "the one authoritative item survives finish()'s swap");
         assert_eq!(payload.lines[0].title, "order lumber");
+        assert_eq!(payload.lines[0].amount_cents, None, "a work order carries no money");
+        assert_eq!(
+            payload.lines[0].assignee, None,
+            "the placeholder id degrades — a name is never attached to a line we cannot match"
+        );
+        let crew = payload.fields.iter().find(|f| f.key == "crew").expect("crew field");
+        assert_eq!(crew.value.as_deref(), Some("Jose, Michael"));
+        assert!(!crew.is_gap);
+        let access = payload.fields.iter().find(|f| f.key == "access").expect("access field");
+        assert_eq!(access.value.as_deref(), Some("Gate code 4412; park on the street."));
+        let safety = payload.fields.iter().find(|f| f.key == "safety").expect("safety field");
+        assert!(safety.is_gap, "nothing was said about hazards — a truthful gap, not filler");
         assert!(!payload.queued);
 
         // Exactly one document artifact for the session: phase B is gone, so
@@ -195,16 +223,28 @@ mod tests {
         // (Plan 12's C2 pattern), so it echoes a placeholder that will fail
         // echo-validation — proving the wiring (a price_items request was
         // made, fed the real id) without needing to pre-script it.
-        let (engine, sid) = processed_landscape_session(vec![tool_use(
-            "price_items",
-            serde_json::json!({"prices": [{"item_id": "placeholder", "amount_cents": 28500}]}),
-        )])
+        let (engine, sid) = processed_landscape_session(vec![
+            tool_use(
+                "price_items",
+                serde_json::json!({"prices": [{"item_id": "placeholder", "amount_cents": 28500}]}),
+            ),
+            // Pricing first, then the prose — an estimate now writes its scope
+            // paragraph in a second, separate call.
+            tool_use(
+                "compose_document",
+                serde_json::json!({"fields": [
+                    {"key": "scope_summary", "value": "Deck lumber ordered and delivered."}
+                ]}),
+            ),
+        ])
         .await;
 
         let payload = engine.build_document(sid, "estimate".into()).await.unwrap();
         assert_eq!(payload.doc_kind, "estimate");
         assert_eq!(payload.lines.len(), 1);
         assert_eq!(payload.lines[0].amount_cents, None, "placeholder id degrades, never crashes");
+        let scope = payload.fields.iter().find(|f| f.key == "scope_summary").expect("scope field");
+        assert_eq!(scope.value.as_deref(), Some("Deck lumber ordered and delivered."));
         assert!(!payload.queued, "the pricing call itself succeeded (a validation miss, not R7)");
     }
 }

--- a/crates/ffi/src/schemas.rs
+++ b/crates/ffi/src/schemas.rs
@@ -21,6 +21,10 @@ pub struct SchemaField {
     pub label: String,
     pub fill: String,
     pub static_value: Option<String>,
+    /// What the field should contain, in the model's terms — carried across
+    /// the boundary so an operator authoring their own document type can
+    /// teach the compose pass what they mean by it.
+    pub hint: Option<String>,
 }
 
 /// FFI mirror of `murmur_core::SchemaSection`.
@@ -30,6 +34,9 @@ pub struct SchemaSection {
     pub kind: String,
     pub label: String,
     pub priced: bool,
+    /// `line_items` only: "" | "inclusion" | "directive" | "observation" —
+    /// who the second line under each item is written for.
+    pub line_detail: String,
     pub fields: Vec<SchemaField>,
 }
 
@@ -59,6 +66,7 @@ fn field_to_core(f: &SchemaField) -> murmur_core::SchemaField {
         label: f.label.clone(),
         fill: f.fill.clone(),
         static_value: f.static_value.clone(),
+        hint: f.hint.clone(),
     }
 }
 
@@ -68,6 +76,7 @@ fn section_to_core(s: &SchemaSection) -> murmur_core::SchemaSection {
         kind: s.kind.clone(),
         label: s.label.clone(),
         priced: s.priced,
+        line_detail: s.line_detail.clone(),
         fields: s.fields.iter().map(field_to_core).collect(),
     }
 }
@@ -106,6 +115,7 @@ fn schema_from_core(d: murmur_core::DocumentSchema) -> DocumentSchema {
                 kind: s.kind,
                 label: s.label,
                 priced: s.priced,
+                line_detail: s.line_detail,
                 fields: s
                     .fields
                     .into_iter()
@@ -115,6 +125,7 @@ fn schema_from_core(d: murmur_core::DocumentSchema) -> DocumentSchema {
                         label: f.label,
                         fill: f.fill,
                         static_value: f.static_value,
+                        hint: f.hint,
                     })
                     .collect(),
             })
@@ -238,6 +249,7 @@ mod tests {
                 kind: "line_items".into(),
                 label: "Items".into(),
                 priced: false,
+                line_detail: String::new(),
                 fields: vec![],
             }],
             schema_version: 1,
@@ -264,12 +276,14 @@ mod tests {
             kind: "filled".into(),
             label: "Approvals".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![SchemaField {
                 key: "hoa_no".into(),
                 kind: "text".into(),
                 label: "HOA approval #".into(),
                 fill: "walk".into(),
                 static_value: None,
+                hint: None,
             }],
         });
         let saved = e.save_document_schema(schema).unwrap();
@@ -301,12 +315,14 @@ mod tests {
             kind: "filled".into(),
             label: "S2".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![SchemaField {
                 key: "b".into(),
                 kind: "barcode".into(),
                 label: "B".into(),
                 fill: "walk".into(),
                 static_value: None,
+                hint: None,
             }],
         });
         let err = e.save_document_schema(bad).unwrap_err();
@@ -332,6 +348,7 @@ mod tests {
             kind: "gallery".into(),
             label: "Gallery".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![],
         });
         assert!(matches!(
@@ -341,15 +358,19 @@ mod tests {
         assert_eq!(e.list_document_schemas(None).unwrap().len(), before);
     }
 
-    /// Payload parity THROUGH the FFI: a built-in build is unchanged on
-    /// every pre-Plan-19 field, plus the additive `fields: []` and today's
-    /// prefix.
+    /// Payload parity THROUGH the FFI: a built-in build keeps every
+    /// pre-Plan-19 field exactly, and carries its authored fields and today's
+    /// prefix on top.
     #[tokio::test]
     async fn ffi_build_document_unchanged_for_builtins() {
         let e = engine_with(vec![
             tool_use("add_item", serde_json::json!({"kind": "todo", "text": "order lumber"})),
             end_turn("done"),
             tool_use("write_notes", serde_json::json!({"summary": "Lumber ordered."})),
+            tool_use(
+                "compose_document",
+                serde_json::json!({"fields": [{"key": "crew", "value": "Jose"}]}),
+            ),
         ]);
         let session = e.clone().begin_walk(None, "landscape".into()).unwrap();
         session.clone().append_transcript("order twelve two by tens".into());
@@ -367,8 +388,16 @@ mod tests {
         assert_eq!(payload.lines[0].title, "order lumber");
         assert_eq!(payload.lines[0].section, None);
         assert!(!payload.lines[0].is_gap);
-        // The Plan 19 additive surface, inert for built-ins:
-        assert!(payload.fields.is_empty(), "built-ins carry zero authored fields");
+        // The Plan 19 additive surface, now carrying the work order's own
+        // structure: the crew it was assigned to, and truthful gaps for what
+        // this short walk never mentioned.
+        assert_eq!(
+            payload.fields.iter().map(|f| f.key.as_str()).collect::<Vec<_>>(),
+            vec!["crew", "schedule", "access", "safety"],
+            "the assignment block, in schema order"
+        );
+        assert_eq!(payload.fields[0].value.as_deref(), Some("Jose"));
+        assert!(payload.fields[1].is_gap, "no schedule was stated — a gap, not an invented date");
         assert_eq!(payload.number_prefix.as_deref(), Some("WO"), "today's prefix, from the row");
     }
 }

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -239,6 +239,20 @@ pub const VALID_FIELD_KINDS: [&str; 7] =
 /// completes at review (always a gap in v1), `static` = authored constant.
 pub const VALID_FILL_KINDS: [&str; 3] = ["walk", "manual", "static"];
 
+/// The allowlist for a `line_items` section's `line_detail` — what the second
+/// line under each item is FOR. Three, because a document is written for
+/// exactly one of three readers:
+///
+/// - `inclusion` — the CLIENT, deciding. What that line covers, so the number
+///   next to it is defensible: "delivered and installed, 3 cu yd".
+/// - `directive` — the CREW, executing. How to do it and what to watch for,
+///   plus who is doing it (`DocLine.assignee`).
+/// - `observation` — the RECORD, later. What was seen, in enough detail to
+///   stand up months from now in a deposit dispute or a re-inspection.
+///
+/// `""` means no second line, and is the default for every pre-existing row.
+pub const VALID_LINE_DETAILS: [&str; 4] = ["", "inclusion", "directive", "observation"];
+
 /// Fixed built-in schema ids (Plan 19 §3): UUIDv7-shaped constants (version
 /// nibble 7, variant 8) so they sort FIRST in any UUIDv7-ordered list and
 /// read as built-in. Identical on every device — together with the sentinel
@@ -271,6 +285,16 @@ pub struct SchemaField {
     /// The authored constant for `fill == "static"` fields; `None` otherwise.
     #[serde(default)]
     pub static_value: Option<String>,
+    /// What this field should contain, in the model's terms — sent with the
+    /// label on the compose pass.
+    ///
+    /// A label alone is too thin to fill well: "Access" produces one word,
+    /// while "how the crew gets in and what they must know before starting —
+    /// gate codes, parking, dogs" produces the paragraph a foreman actually
+    /// needs. Additive and defaulted, so every authored and pre-existing row
+    /// parses unchanged.
+    #[serde(default)]
+    pub hint: Option<String>,
 }
 
 /// One ordered section of a document schema (Plan 19 §3).
@@ -283,6 +307,17 @@ pub struct SchemaSection {
     /// `line_items` sections only: whether the build runs the pricing pass.
     #[serde(default)]
     pub priced: bool,
+    /// `line_items` sections only: what the second line under each item says.
+    /// One of `VALID_LINE_DETAILS`; `""` (the default, and every pre-existing
+    /// row) means no second line and no compose pass.
+    ///
+    /// This is the difference between a list and a document. "Mulch, front
+    /// beds" is a note to self; "Mulch, front beds / delivered and installed,
+    /// 3 cu yd" is a line on an estimate a client can agree to, and "JOSE —
+    /// strip the old bark before laying, watch the irrigation heads" is a
+    /// line on a work order a crew can execute from.
+    #[serde(default)]
+    pub line_detail: String,
     #[serde(default)]
     pub fields: Vec<SchemaField>,
 }
@@ -315,6 +350,31 @@ pub struct DocumentSchema {
     pub device_id: String,
 }
 
+/// One `filled` section of authored fields, in render order.
+fn filled(key: &str, label: &str, fields: Vec<SchemaField>) -> SchemaSection {
+    SchemaSection {
+        key: key.into(),
+        kind: "filled".into(),
+        label: label.into(),
+        priced: false,
+        line_detail: String::new(),
+        fields,
+    }
+}
+
+/// One walk-filled field: the model writes it, or it stays a truthful gap.
+fn walk_field(key: &str, kind: &str, label: &str, hint: &str) -> SchemaField {
+    SchemaField {
+        key: key.into(),
+        kind: kind.into(),
+        label: label.into(),
+        fill: "walk".into(),
+        static_value: None,
+        hint: Some(hint.into()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn builtin_schema(
     id: &str,
     kind: &str,
@@ -323,7 +383,22 @@ fn builtin_schema(
     trade_key: Option<&str>,
     priced: bool,
     (total_kind, total_label_key): (&str, &str),
+    line_detail: &str,
+    mut sections: Vec<SchemaSection>,
 ) -> DocumentSchema {
+    // Section order IS reading order, and the line items come LAST. Every
+    // trade document on paper works this way: who, when, and what this is
+    // about at the top, the itemized body under it, the total at the foot. A
+    // crew reads ASSIGNMENT and SITE NOTES before they read a single task; a
+    // client may read SCOPE OF WORK and never read the lines at all.
+    sections.push(SchemaSection {
+        key: "line_items".into(),
+        kind: "line_items".into(),
+        label: "Items".into(),
+        priced,
+        line_detail: line_detail.into(),
+        fields: vec![],
+    });
     DocumentSchema {
         id: id.to_string(),
         kind: kind.to_string(),
@@ -332,13 +407,7 @@ fn builtin_schema(
         trade_key: trade_key.map(str::to_string),
         total_kind: total_kind.to_string(),
         total_label_key: total_label_key.to_string(),
-        sections: vec![SchemaSection {
-            key: "line_items".into(),
-            kind: "line_items".into(),
-            label: "Items".into(),
-            priced,
-            fields: vec![],
-        }],
+        sections,
         schema_version: 1,
         // Fixed literals (Plan 19 Stage 1): a seeded row is byte-identical
         // on every device.
@@ -367,13 +436,122 @@ fn builtin_schema(
 /// would be noise.
 pub fn builtin_schemas() -> Vec<DocumentSchema> {
     vec![
-        builtin_schema(BUILTIN_SCHEMA_ID_ESTIMATE, "estimate", "Estimate", "EST", None, true, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_INVOICE, "invoice", "Invoice", "INV", None, true, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_WORK_ORDER, "work_order", "Work Order", "WO", None, false, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_CONDITION, "condition", "Condition Report", "COND", Some("property"), false, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_MOVE_OUT, "move_out", "Move-Out Report", "MO", Some("property"), false, ("sum", "total")),
-        builtin_schema(BUILTIN_SCHEMA_ID_INSPECTION, "inspection", "Inspection Report", "IR", Some("inspection"), false, ("static", "findings")),
-        builtin_schema(BUILTIN_SCHEMA_ID_REPORT, "report", "Report", "DOC", None, false, ("sum", "total")),
+        // ESTIMATE — read by a client deciding whether to say yes. The scope
+        // paragraph is what makes the number defensible: a bare list of
+        // priced lines reads like a receipt for work nobody has agreed to,
+        // and it is the paragraph, not the total, that a client forwards to
+        // their spouse.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_ESTIMATE, "estimate", "Estimate", "EST", None, true,
+            ("sum", "total"), "inclusion",
+            vec![filled("scope", "Scope of Work", vec![walk_field(
+                "scope_summary", "long_text", "Scope of work",
+                "2-3 plain sentences a client can read, in FUTURE tense: what will be done, \
+                 where on the property, and anything notable about how or in what order. \
+                 No prices — they are on the lines.",
+            )])],
+        ),
+        // INVOICE — the same document after the fact, and the difference is
+        // not cosmetic: an estimate offers, an invoice demands. Past tense,
+        // and the total says what is owed.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_INVOICE, "invoice", "Invoice", "INV", None, true,
+            ("sum", "amount_due"), "inclusion",
+            vec![filled("work", "Work Performed", vec![walk_field(
+                "work_summary", "long_text", "Work performed",
+                "2-3 plain sentences in PAST tense: what was actually done, where, and \
+                 anything the client should know about the finished work. No prices.",
+            )])],
+        ),
+        // WORK ORDER — the only one of these written for the crew, and the
+        // reason it carries no money: a sub who sees the client price bids
+        // higher next time. What it carries instead is everything a crew
+        // needs to start without calling: who, when, how to get in, what will
+        // hurt them.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_WORK_ORDER, "work_order", "Work Order", "WO", None, false,
+            ("sum", "total"), "directive",
+            vec![
+                filled("assignment", "Assignment", vec![
+                    walk_field(
+                        "crew", "text", "Assigned to",
+                        "The people named as doing this work, comma-separated, exactly as \
+                         spoken (\"Jose, Michael\"). Only names actually said — never invent \
+                         a crew.",
+                    ),
+                    walk_field(
+                        "schedule", "text", "Scheduled",
+                        "When the work is to happen, in the operator's own words (\"Thursday \
+                         morning\", \"first thing Monday\"). Only if it was stated.",
+                    ),
+                ]),
+                filled("site", "Site Notes", vec![
+                    walk_field(
+                        "access", "long_text", "Access",
+                        "How the crew gets in and what they must know before starting: gate \
+                         codes, parking, which door, dogs, tenant or client contact, hours \
+                         they may work. Only what was said.",
+                    ),
+                    walk_field(
+                        "safety", "long_text", "Safety",
+                        "Hazards a crew must be warned about before they arrive: buried or \
+                         overhead utilities, slopes, unstable structures, irrigation lines, \
+                         chemicals. Only what was said.",
+                    ),
+                ]),
+            ],
+        ),
+        // CONDITION REPORT — evidence of a property's state at a moment,
+        // usually move-in. Its whole value is being specific enough to prove
+        // what changed later.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_CONDITION, "condition", "Condition Report", "COND",
+            Some("property"), false, ("sum", "total"), "observation",
+            vec![filled("summary", "Summary", vec![walk_field(
+                "summary", "long_text", "Summary",
+                "2-4 plain sentences: the unit or property, what this walk covered, and the \
+                 overall condition found. Neutral and factual — this is a record.",
+            )])],
+        ),
+        // MOVE-OUT REPORT — the deposit document, and therefore a MONEY
+        // document. It exists to justify what is withheld, line by line,
+        // against a legal deadline; an unpriced version of it cannot do the
+        // one job it has.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_MOVE_OUT, "move_out", "Move-Out Report", "MO",
+            Some("property"), true, ("sum", "deposit_deduction"), "observation",
+            vec![filled("summary", "Summary", vec![walk_field(
+                "summary", "long_text", "Summary",
+                "2-4 plain sentences: the unit, the move-out date if stated, and the overall \
+                 condition — separating damage from normal wear where it was called out. \
+                 This may be read by a tenant disputing a deduction, so stay factual.",
+            )])],
+        ),
+        // INSPECTION REPORT — findings, not money, which is why it counts
+        // instead of summing.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_INSPECTION, "inspection", "Inspection Report", "IR",
+            Some("inspection"), false, ("static", "findings"), "observation",
+            vec![filled("summary", "Summary", vec![walk_field(
+                "summary", "long_text", "Summary",
+                "3-4 plain sentences: the property, what was inspected, and the findings that \
+                 matter most — safety items first. Never state a system is sound if it was \
+                 not examined.",
+            )])],
+        ),
+        // REPORT — the universal write-up, and the one an unknown trade
+        // falls back to. It has no money and no specialist structure, so the
+        // narrative and the per-line observations ARE the document.
+        builtin_schema(
+            BUILTIN_SCHEMA_ID_REPORT, "report", "Report", "DOC", None, false,
+            ("sum", "total"), "observation",
+            vec![filled("summary", "Summary", vec![walk_field(
+                "summary", "long_text", "Summary",
+                "3-4 plain sentences: where this was, what the visit covered, what was found \
+                 or decided, and anything outstanding. This is the whole write-up, so it \
+                 carries the context the terse lines below cannot.",
+            )])],
+        ),
     ]
 }
 

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -312,29 +312,46 @@ fn compose_document_tool_spec(wants_lines: bool, wants_assignee: bool) -> ToolSp
 /// price, "strip the old bark before laying — watch the irrigation heads"
 /// for the crew doing it, and "south slope, three shingles lifted at the
 /// ridge" for whoever reads the record next year.
-fn line_brief(line_detail: &str) -> Option<&'static str> {
-    match line_detail {
-        "inclusion" => Some(
+fn line_brief(line_detail: &str) -> Option<String> {
+    // The rule that stops this pass padding, appended to every brief so it
+    // cannot drift out of one of them.
+    //
+    // It is here because the first real-API run produced it: handed the item
+    // "Strip old bark from front beds", the model wrote back "Strip old bark
+    // from front beds before mulching." — new words, no new information, on
+    // every single line. That is worse than a blank second line. It doubles
+    // the length of the document AND teaches the reader that the second line
+    // is noise, so they skim past the one line that actually carries a
+    // warning. Mocks cannot catch this: the shape was perfect.
+    const NOTHING_TO_ADD: &str = " If the line's own title already says everything you would \
+         write, OMIT that line entirely — a second line that restates the first is padding, and \
+         a document that pads is one a reader stops trusting. Never restate the title in other \
+         words. Write only where you are ADDING something the title does not say.";
+
+    let brief = match line_detail {
+        "inclusion" => {
             "For each line, write what that line COVERS — quantity, material, and what is \
              included in its price (delivered? hauled away? how many coats?). A short phrase, \
              not a sentence. It is read by a client deciding whether the number beside it is \
-             fair, so it must justify the number without repeating it.",
-        ),
-        "directive" => Some(
+             fair, so it must justify the number without repeating it."
+        }
+        "directive" => {
             "This is a WORK ORDER: the crew reads it, standing at the site, to do the job \
-             without calling anyone. For each line write what to actually DO and anything they \
-             must watch out for — one or two short imperative sentences, in trade language, in \
-             the order the work happens. Where the operator named a person for a line, set \
-             `assignee` to that name exactly as spoken.",
-        ),
-        "observation" => Some(
+             without calling anyone. For each line write ONLY what the title does not already \
+             tell them — the order to work in, the technique, the thing to watch out for, the \
+             spec to match. One short imperative sentence, in trade language. Where the \
+             operator named a person for a line, set `assignee` to that name exactly as \
+             spoken; a line nobody was named for gets no assignee."
+        }
+        "observation" => {
             "For each line, write what was actually OBSERVED — where it is, how bad, how much, \
-             what condition. One or two short phrases. This is a record that may be read \
-             months from now by someone who was not there (a tenant disputing a deduction, a \
-             buyer, an adjuster), so specifics beat adjectives.",
-        ),
-        _ => None,
-    }
+             what condition. One or two short phrases. This is a record that may be read months \
+             from now by someone who was not there (a tenant disputing a deduction, a buyer, an \
+             adjuster), so specifics beat adjectives."
+        }
+        _ => return None,
+    };
+    Some(format!("{brief}{NOTHING_TO_ADD}"))
 }
 
 /// Renders the coordination notes the walk already produced as context.
@@ -362,6 +379,30 @@ fn format_notes_context(buckets: &[NotesEntry]) -> String {
     // No trailing newline — every block in the user message supplies its own
     // leading separator, so one here doubles up.
     out.trim_end().to_string()
+}
+
+/// The output budget for one compose call, scaled to the document.
+///
+/// The pricing pass writes an integer per line and fits in a flat budget
+/// forever. This one writes PROSE — a paragraph per field plus a sentence or
+/// two per line — so a flat budget is a cliff: the model runs out mid-tool-call,
+/// the JSON is truncated, the parse fails, and the whole pass degrades to
+/// `queued` with every field a gap and every line bare.
+///
+/// That failure is silent and lands hardest on exactly the walks worth the
+/// most — a thirty-item walk on a big job blows a 1024-token budget while a
+/// four-item walk sails through, so the operator experiences it as "the long
+/// ones don't work" with no error to report. Hence: budget by the size of the
+/// thing being written, floored at the caller's value so no document gets
+/// LESS room than before, and capped so a runaway item list cannot authorize
+/// an unbounded spend.
+fn compose_budget(floor: u32, field_count: usize, item_count: usize, writes_lines: bool) -> u32 {
+    const PER_FIELD: u32 = 128; // a long_text field is a short paragraph
+    const PER_LINE: u32 = 64; // one or two short sentences, plus JSON overhead
+    const CEILING: u32 = 8192;
+    let lines = if writes_lines { item_count as u32 * PER_LINE } else { 0 };
+    let wanted = 256 + (field_count as u32 * PER_FIELD) + lines;
+    wanted.clamp(floor, CEILING)
 }
 
 /// The document's prose, in one call.
@@ -421,7 +462,8 @@ pub(crate) async fn compose_document(
             .join("\n");
         format!("\n\nFields to write:\n{rendered}")
     };
-    let lines_block = brief.map(|b| format!("\n\nThe lines:\n{b}")).unwrap_or_default();
+    let lines_block =
+        brief.as_deref().map(|b| format!("\n\nThe lines:\n{b}")).unwrap_or_default();
     let items_block = format_pricing_items(items);
     let notes_block = format_notes_context(notes);
     let summary_block = if summary.trim().is_empty() {
@@ -439,7 +481,7 @@ pub(crate) async fn compose_document(
             system,
             messages: vec![Message::user_text(user_message)],
             tools: vec![compose_document_tool_spec(brief.is_some(), wants_assignee)],
-            max_tokens,
+            max_tokens: compose_budget(max_tokens, fields.len(), items.len(), brief.is_some()),
             tool_choice: Some(COMPOSE_DOCUMENT.to_string()),
             // Single-shot — see the PRICE_ITEMS note above.
             cache_prefix: false,
@@ -2061,6 +2103,24 @@ mod tests {
             v["lines"][1]["is_gap"], true,
             "an unpriced deduction is an open question, not a free pass"
         );
+    }
+
+    /// A flat output budget is a cliff for a pass that writes prose: the
+    /// model runs out mid-tool-call, the JSON truncates, and the document
+    /// degrades to all-gaps — silently, and only on the longest walks.
+    #[test]
+    fn the_compose_budget_grows_with_the_document() {
+        // A four-item walk with one field is small; the caller's floor holds.
+        assert_eq!(compose_budget(1024, 1, 4, true), 1024);
+        // A thirty-item work order with four fields needs real room — under a
+        // flat 1024 this is the walk that would have come back empty.
+        assert!(compose_budget(1024, 4, 30, true) > 2000);
+        // No per-line writing, no per-line budget.
+        assert!(compose_budget(256, 1, 30, false) < compose_budget(256, 1, 30, true));
+        // Bounded: a runaway item list cannot authorize an unbounded spend.
+        assert_eq!(compose_budget(1024, 4, 100_000, true), 8192);
+        // And never LESS room than the caller asked for.
+        assert!(compose_budget(4096, 1, 1, false) >= 4096);
     }
 
     /// The contrast pin: the call SUCCEEDED but omitted a field — a truthful

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -15,6 +15,7 @@ use harness::{
 use crate::domain::{Artifact, CapturedItem, DocumentSchema, SchemaField, SessionStatus};
 use crate::error::CoreError;
 use crate::pipeline::spoken_price::{fold_spoken_prices, FoldedPrices};
+use crate::pipeline::notes::{parse_notes_artifact, NotesEntry, NOTE_BUCKETS};
 use crate::pipeline::{doc_kinds_for_template, is_pricing_kind};
 use crate::store::Store;
 
@@ -96,6 +97,8 @@ pub(crate) fn render_lines(
                 "section": null,
                 "is_gap": is_gap,
                 "item_id": item.id,
+                // Written only by the compose pass, on `directive` documents.
+                "assignee": null,
             })
         })
         .collect()
@@ -228,101 +231,232 @@ pub(crate) async fn price_items(
     Ok(map)
 }
 
-const FILL_FIELDS: &str = "fill_fields";
+const COMPOSE_DOCUMENT: &str = "compose_document";
 
-fn fill_fields_tool_spec() -> ToolSpec {
+/// What the compose pass wrote onto one line.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct LineComposition {
+    /// The second line under the item: what it covers, what to do, or what
+    /// was seen — per the schema's `line_detail`.
+    pub detail: String,
+    /// Who is doing it. `directive` documents only, and only when a person
+    /// was actually named for that line.
+    pub assignee: Option<String>,
+}
+
+/// One pass's output: the authored fields, and the per-line writing.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct Composition {
+    /// Field key → value. Absent = a truthful gap.
+    pub fields: HashMap<String, String>,
+    /// `item_id` → what to write on that line.
+    pub lines: HashMap<String, LineComposition>,
+}
+
+fn compose_document_tool_spec(wants_lines: bool, wants_assignee: bool) -> ToolSpec {
+    let mut line_props = serde_json::json!({
+        "item_id": { "type": "string" },
+        "detail": { "type": "string", "description": "the second line under this item" },
+    });
+    if wants_assignee {
+        line_props["assignee"] = serde_json::json!({
+            "type": "string",
+            "description": "the person named as doing THIS line, exactly as spoken. Omit \
+                             unless someone was actually named for it."
+        });
+    }
+    let mut properties = serde_json::json!({
+        "fields": {
+            "type": "array",
+            "description": "Values for the named fields. Omit any field you are unsure about.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": { "type": "string" },
+                    "value": { "type": "string" }
+                },
+                "required": ["key", "value"]
+            }
+        }
+    });
+    if wants_lines {
+        properties["lines"] = serde_json::json!({
+            "type": "array",
+            "description": "One entry per line you can say something REAL about, by its exact \
+                             item_id. Omit any line you would have to invent detail for.",
+            "items": {
+                "type": "object",
+                "properties": line_props,
+                "required": ["item_id", "detail"]
+            }
+        });
+    }
     ToolSpec {
-        name: FILL_FIELDS.into(),
-        description: "Fill named document fields from the session. Put a value only on a field \
-                       whose answer was clearly stated — omit any field you are unsure about. \
-                       You may fill only fields from the given list, by their exact key."
+        name: COMPOSE_DOCUMENT.into(),
+        description: "Write the prose of a field-work document: the named fields, and the \
+                       second line under each item. You may fill only the fields and items \
+                       given, by their exact key and item_id — you cannot add, rename, drop \
+                       or reorder anything."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
-            "properties": {
-                "fields": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "key": { "type": "string" },
-                            "value": { "type": "string" }
-                        },
-                        "required": ["key", "value"]
-                    }
-                }
-            },
+            "properties": properties,
             "required": ["fields"]
         }),
     }
 }
 
-/// Plan 19 Stage 5: the one focused fill pass — `price_items`' exact twin,
-/// including its degrade contract. Input is the items + session summary ONLY
-/// (never the transcript, R6); the items block reuses `format_pricing_items`
-/// (ONE item-formatting helper, no divergent shape). Echo-and-validate
-/// against the offered field keys, first-wins dedup, drop unknown keys.
-/// Usage is accumulated as soon as a response arrives (R9: an unparseable
-/// response still cost tokens) — BEFORE success/failure is decided. A
-/// provider `Err` carries no usage; a completed response whose tool block is
-/// missing/unparseable is `Err(HarnessError::Provider(..))` after
-/// `usage.add`, exactly like `price_items`. A tool block that IS present but
-/// simply omits a field is NOT an error — that field is a truthful gap.
-pub(crate) async fn fill_fields(
+/// The per-line brief, keyed by the schema's `line_detail`. Each one names
+/// the READER, because that is what actually decides the writing: the same
+/// item becomes "delivered and installed, 3 cu yd" for a client weighing a
+/// price, "strip the old bark before laying — watch the irrigation heads"
+/// for the crew doing it, and "south slope, three shingles lifted at the
+/// ridge" for whoever reads the record next year.
+fn line_brief(line_detail: &str) -> Option<&'static str> {
+    match line_detail {
+        "inclusion" => Some(
+            "For each line, write what that line COVERS — quantity, material, and what is \
+             included in its price (delivered? hauled away? how many coats?). A short phrase, \
+             not a sentence. It is read by a client deciding whether the number beside it is \
+             fair, so it must justify the number without repeating it.",
+        ),
+        "directive" => Some(
+            "This is a WORK ORDER: the crew reads it, standing at the site, to do the job \
+             without calling anyone. For each line write what to actually DO and anything they \
+             must watch out for — one or two short imperative sentences, in trade language, in \
+             the order the work happens. Where the operator named a person for a line, set \
+             `assignee` to that name exactly as spoken.",
+        ),
+        "observation" => Some(
+            "For each line, write what was actually OBSERVED — where it is, how bad, how much, \
+             what condition. One or two short phrases. This is a record that may be read \
+             months from now by someone who was not there (a tenant disputing a deduction, a \
+             buyer, an adjuster), so specifics beat adjectives.",
+        ),
+        _ => None,
+    }
+}
+
+/// Renders the coordination notes the walk already produced as context.
+///
+/// These cost NOTHING to include: `summarize()` captured them at finish and
+/// they are sitting in the session's `notes` artifact. They are also exactly
+/// what the terse item list is missing — the gate code, the client's
+/// preference, the condition that changes the work — so a document written
+/// without them is guaranteed to be thinner than the walk was.
+fn format_notes_context(buckets: &[NotesEntry]) -> String {
+    if buckets.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n\nWhat was said around the work:\n");
+    for bucket in NOTE_BUCKETS {
+        let entries: Vec<&NotesEntry> = buckets.iter().filter(|b| b.bucket == bucket).collect();
+        if entries.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("{}:\n", bucket.replace('_', " ")));
+        for e in entries {
+            out.push_str(&format!("- {}: {}\n", e.label, e.detail));
+        }
+    }
+    // No trailing newline — every block in the user message supplies its own
+    // leading separator, so one here doubles up.
+    out.trim_end().to_string()
+}
+
+/// The document's prose, in one call.
+///
+/// This is `price_items`' twin in every structural way — forced single-shot
+/// tool, echo-and-validate against ids we supplied, first-wins dedup,
+/// unknown ids dropped rather than failing the pass, usage banked before
+/// success is decided (R9) — and it replaces the narrower `fill_fields`.
+///
+/// **Why one pass and not two.** Fields and line details are the same act of
+/// writing: the scope paragraph is a summary of the very lines being
+/// detailed, so a model that writes both at once writes a document that
+/// agrees with itself, and a second call would pay the same input tokens
+/// twice to produce something that disagrees with the first. Pricing stays
+/// separate — money is a different risk class with its own validation and
+/// its own spoken-total hint, and it must not be entangled with prose.
+///
+/// **What it cannot do.** It cannot add, drop, rename or reorder a line, or
+/// invent a field key: the structure is already fixed by the deterministic
+/// render, and only the writing is at stake. R6 runs through the prompt: a
+/// line it has nothing real to say about gets nothing, because a document
+/// that pads is a document that eventually pads with something false.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn compose_document(
     provider: &Arc<dyn LlmProvider>,
+    document_label: &str,
+    line_detail: &str,
     fields: &[SchemaField],
     items: &[CapturedItem],
     summary: &str,
+    notes: &[NotesEntry],
     max_tokens: u32,
     usage: &mut Usage,
-) -> Result<HashMap<String, String>, HarnessError> {
-    let system = "You fill named fields of a field-work document for a tradesperson. Put a \
-                  value only on a field whose answer was clearly stated in the session — never \
-                  guess. You may fill only fields from the given list, by their exact key.";
-    let fields_block = fields
-        .iter()
-        .map(|f| format!("- [{}] {}", f.key, f.label))
-        .collect::<Vec<_>>()
-        .join("\n");
+) -> Result<Composition, HarnessError> {
+    let brief = line_brief(line_detail);
+    let wants_assignee = line_detail == "directive";
+    let system = format!(
+        "You write the prose of a {document_label} for a small trade operator, from one \
+         recorded site walk. Everything you write must come from what was actually said on \
+         that walk. Never invent a quantity, a price, a name, a date, an access detail or a \
+         condition — a document that is thin where the walk was thin is correct; one that \
+         reads well because you filled the gaps is the single worst thing this product can \
+         produce. Write in the operator's own trade language, not in marketing language, and \
+         never mention the recording, the transcript, or yourself."
+    );
+
+    let fields_block = if fields.is_empty() {
+        String::new()
+    } else {
+        let rendered = fields
+            .iter()
+            .map(|f| match &f.hint {
+                Some(h) => format!("- [{}] {} — {h}", f.key, f.label),
+                None => format!("- [{}] {}", f.key, f.label),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n\nFields to write:\n{rendered}")
+    };
+    let lines_block = brief.map(|b| format!("\n\nThe lines:\n{b}")).unwrap_or_default();
     let items_block = format_pricing_items(items);
-    // The exact WE-B user message (§6) — the items block is
-    // `format_pricing_items` verbatim; only the Fields/summary framing is
-    // the fill prompt's own.
+    let notes_block = format_notes_context(notes);
+    let summary_block = if summary.trim().is_empty() {
+        String::new()
+    } else {
+        format!("\n\nSession summary:\n{summary}")
+    };
     let user_message = format!(
-        "Fill these document fields from the session. Put a value only on a field whose\n\
-         answer was clearly stated — omit any field you are unsure about; a blank field\n\
-         is cheaper than a wrong one.\n\
-         \n\
-         Fields:\n{fields_block}\n\
-         \n\
-         Session items:\n{items_block}\n\
-         \n\
-         Session summary:\n{summary}"
+        "Write this {document_label}.{fields_block}{lines_block}\
+         \n\nThe items on it:\n{items_block}{notes_block}{summary_block}"
     );
 
     let response = provider
         .complete(CompletionRequest {
-            system: system.to_string(),
+            system,
             messages: vec![Message::user_text(user_message)],
-            tools: vec![fill_fields_tool_spec()],
+            tools: vec![compose_document_tool_spec(brief.is_some(), wants_assignee)],
             max_tokens,
-            tool_choice: Some(FILL_FIELDS.to_string()),
-            // Single-shot schema fill — see the PRICE_ITEMS note above.
+            tool_choice: Some(COMPOSE_DOCUMENT.to_string()),
+            // Single-shot — see the PRICE_ITEMS note above.
             cache_prefix: false,
         })
         .await?;
     usage.add(&response.usage);
 
     let input = response.content.iter().find_map(|b| match b {
-        ContentBlock::ToolUse { name, input, .. } if name == FILL_FIELDS => Some(input.clone()),
+        ContentBlock::ToolUse { name, input, .. } if name == COMPOSE_DOCUMENT => Some(input.clone()),
         _ => None,
     });
     let input = input.ok_or_else(|| {
-        HarnessError::Provider("fill_fields response missing fill_fields call".into())
+        HarnessError::Provider("compose_document response missing compose_document call".into())
     })?;
 
     let valid_keys: HashSet<&str> = fields.iter().map(|f| f.key.as_str()).collect();
-    let mut map: HashMap<String, String> = HashMap::new();
+    let mut out = Composition::default();
     if let Some(entries) = input.get("fields").and_then(|v| v.as_array()) {
         for e in entries {
             let (Some(key), Some(value)) =
@@ -332,12 +466,66 @@ pub(crate) async fn fill_fields(
             };
             // First-wins dedup; unknown/hallucinated keys are dropped — never
             // fail the whole pass over one bad row.
-            if valid_keys.contains(key) && !map.contains_key(key) {
-                map.insert(key.to_string(), value.to_string());
+            if valid_keys.contains(key) && !out.fields.contains_key(key) && !value.trim().is_empty()
+            {
+                out.fields.insert(key.to_string(), value.trim().to_string());
             }
         }
     }
-    Ok(map)
+
+    let valid_ids: HashSet<&str> = items.iter().map(|i| i.id.as_str()).collect();
+    if let Some(entries) = input.get("lines").and_then(|v| v.as_array()) {
+        for e in entries {
+            let Some(id) = e.get("item_id").and_then(|v| v.as_str()) else { continue };
+            if !valid_ids.contains(id) || out.lines.contains_key(id) {
+                continue;
+            }
+            let detail =
+                e.get("detail").and_then(|v| v.as_str()).unwrap_or_default().trim().to_string();
+            // The assignee is only READ on a directive document. A model that
+            // volunteers one on an estimate is answering a question nobody
+            // asked, and a name in the price column would be a rendering bug
+            // wearing a data bug's clothes.
+            let assignee = if wants_assignee {
+                e.get("assignee")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+            } else {
+                None
+            };
+            if detail.is_empty() && assignee.is_none() {
+                continue;
+            }
+            out.lines.insert(id.to_string(), LineComposition { detail, assignee });
+        }
+    }
+    Ok(out)
+}
+
+/// Writes the composed prose onto the rendered lines. A line whose `item_id`
+/// the pass wrote about gains its `detail` and `assignee`; every other line
+/// is left exactly as the deterministic render produced it.
+fn apply_composition(composed: &HashMap<String, LineComposition>, lines: &mut [serde_json::Value]) {
+    let mut claimed: HashSet<String> = HashSet::new();
+    for line in lines.iter_mut() {
+        let Some(item_id) = line.get("item_id").and_then(|v| v.as_str()).map(str::to_string) else {
+            continue;
+        };
+        if claimed.contains(&item_id) {
+            continue;
+        }
+        if let Some(written) = composed.get(&item_id) {
+            if !written.detail.is_empty() {
+                line["detail"] = serde_json::json!(written.detail);
+            }
+            if let Some(assignee) = &written.assignee {
+                line["assignee"] = serde_json::json!(assignee);
+            }
+            claimed.insert(item_id);
+        }
+    }
 }
 
 /// Assembles the payload `fields[]` (Plan 19 Stage 5): one entry per
@@ -556,36 +744,55 @@ impl DocumentBuilder {
             }
         }
 
-        // §4 step 5 — the fill pass: ONE focused call iff the schema has ≥1
-        // LLM-fillable (`fill: "walk"`) field. Built-ins have none → zero
-        // calls → byte-identical (the launch-safety spine). `manual` fields
-        // are never offered to the model — they are always gaps in v1.
+        // §4 step 5 — the compose pass: ONE call iff this document has prose
+        // to write, i.e. ≥1 LLM-fillable (`fill: "walk"`) field OR a
+        // `line_detail` style. A schema with neither — an operator's own bare
+        // list — still makes zero calls. `manual` fields are never offered to
+        // the model; they are always gaps in v1.
         let walk_fields: Vec<SchemaField> = schema
             .sections
             .iter()
             .filter(|s| s.kind == "filled")
             .flat_map(|s| s.fields.iter().filter(|f| f.fill == "walk").cloned())
             .collect();
-        let mut fill_values: HashMap<String, String> = HashMap::new();
-        if !walk_fields.is_empty() {
-            match fill_fields(
+        let line_detail = schema
+            .sections
+            .iter()
+            .find(|s| s.kind == "line_items")
+            .map(|s| s.line_detail.clone())
+            .unwrap_or_default();
+        let mut composed = Composition::default();
+        if !walk_fields.is_empty() || line_brief(&line_detail).is_some() {
+            // The coordination notes the walk already produced — free
+            // context: `summarize()` captured them at finish and they are
+            // sitting in this session's `notes` artifact. Without them the
+            // document is guaranteed to be thinner than the walk was.
+            let notes = self.session_notes(session_id)?;
+            match compose_document(
                 &self.provider,
+                &schema.label,
+                &line_detail,
                 &walk_fields,
-                &items,
+                &folded.items,
                 session.summary.as_deref().unwrap_or(""),
+                &notes,
                 self.max_tokens,
                 &mut usage,
             )
             .await
             {
-                Ok(map) => fill_values = map,
+                Ok(c) => {
+                    apply_composition(&c.lines, &mut lines);
+                    composed = c;
+                }
                 // Mirrors the pricing degrade exactly (R7): a model call this
                 // build needed didn't complete — regenerate to retry. Every
-                // walk field then falls to a truthful gap below.
+                // walk field then falls to a truthful gap below, and the lines
+                // keep the operator's own words with no second line.
                 Err(_) => queued = true,
             }
         }
-        let fields = assemble_fields(&schema, &fill_values);
+        let fields = assemble_fields(&schema, &composed.fields);
 
         // §4 step 6 — the total shape comes from the schema envelope (for
         // every built-in this equals the old total_shape(doc_kind) exactly).
@@ -631,6 +838,20 @@ impl DocumentBuilder {
         Ok(meta
             .and_then(|a| serde_json::from_str::<serde_json::Value>(&a.body).ok())
             .and_then(|v| v.get("spoken_total_cents").and_then(|n| n.as_i64())))
+    }
+
+    /// The coordination notes `process()` wrote at finish, as compose-pass
+    /// context. `[]` when the walk produced none, or the artifact is garbled
+    /// — `parse_notes_artifact` is deliberately tolerant (R7), and a document
+    /// written without this context is thinner, never wrong.
+    fn session_notes(&self, session_id: &str) -> Result<Vec<NotesEntry>, CoreError> {
+        let artifacts = self.locked()?.list_artifacts_for_session(session_id)?;
+        Ok(artifacts
+            .iter()
+            .rev()
+            .find(|a| a.kind == "notes")
+            .map(|a| parse_notes_artifact(&a.body))
+            .unwrap_or_default())
     }
 }
 
@@ -837,6 +1058,12 @@ mod tests {
         DocumentBuilder::new(provider, store, Arc::new(Mutex::new(Memory::default())), Arc::new(NullMemoryStore))
     }
 
+    /// The decoded document body for an artifact id.
+    fn v_of(store: &Arc<Mutex<Store>>, artifact_id: &str) -> serde_json::Value {
+        let store = store.lock().unwrap();
+        serde_json::from_str(&store.get_artifact(artifact_id).unwrap().body).unwrap()
+    }
+
     #[tokio::test]
     async fn build_happy_path_prices_and_mints_a_document() {
         let (store, sid) = processed_session_with_items(&[("todo", "mulch"), ("safety", "loose railing")]);
@@ -844,15 +1071,30 @@ mod tests {
         let a1 = store.list_items_for_session(&sid).unwrap()[0].id.clone();
         let store = Arc::new(Mutex::new(store));
 
-        let provider = Arc::new(MockProvider::new(vec![tool_use(
-            "price_items",
-            serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 28500}]}),
-        )]));
+        let provider = Arc::new(MockProvider::new(vec![
+            tool_use(
+                "price_items",
+                serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 28500}]}),
+            ),
+            compose_response(
+                serde_json::json!([{"key": "scope_summary", "value": "Mulch the front beds."}]),
+                serde_json::json!([{"item_id": a1, "detail": "3 cu yd, delivered and installed"}]),
+            ),
+        ]));
         let b = builder(store.clone(), provider);
 
         let outcome = b.build(&sid, "estimate").await.unwrap();
         assert!(!outcome.queued);
-        assert_eq!(outcome.usage, Usage { input_tokens: 80, output_tokens: 15, ..Default::default() });
+        assert_eq!(
+            outcome.usage,
+            Usage { input_tokens: 160, output_tokens: 30, ..Default::default() },
+            "two calls on an estimate: the money, then the prose"
+        );
+        assert_eq!(
+            v_of(&store, &outcome.document_artifact_id)["lines"][0]["detail"],
+            "3 cu yd, delivered and installed",
+            "the line says what it covers, so the number beside it is defensible"
+        );
 
         let store = store.lock().unwrap();
         let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
@@ -942,7 +1184,8 @@ mod tests {
         let (store, sid) =
             processed_session_with_items(&[("part", "5 yards mulch"), ("price", "$200 mulch")]);
         let store = Arc::new(Mutex::new(store));
-        let provider = Arc::new(MockProvider::new(vec![]));
+        let provider =
+            Arc::new(MockProvider::new(vec![compose_response(serde_json::json!([]), serde_json::json!([]))]));
         let b = builder(store.clone(), provider.clone());
 
         let outcome = b.build(&sid, "work_order").await.unwrap();
@@ -952,7 +1195,7 @@ mod tests {
         let titles: Vec<&str> =
             v["lines"].as_array().unwrap().iter().map(|l| l["title"].as_str().unwrap()).collect();
         assert_eq!(titles, vec!["5 yards mulch", "$200 mulch"]);
-        assert!(provider.requests().is_empty(), "still zero calls for a non-pricing kind");
+        assert_eq!(provider.requests().len(), 1, "the prose pass, never a pricing one");
     }
 
     /// A walk whose every item priced itself needs no model call at all.
@@ -963,13 +1206,21 @@ mod tests {
             ("price", "$200 mulch"),
         ]);
         let store = Arc::new(Mutex::new(store));
-        let provider = Arc::new(MockProvider::new(vec![]));
+        let provider =
+            Arc::new(MockProvider::new(vec![compose_response(serde_json::json!([]), serde_json::json!([]))]));
         let b = builder(store.clone(), provider.clone());
 
         let outcome = b.build(&sid, "estimate").await.unwrap();
         assert!(!outcome.queued, "nothing to ask is not a degrade");
-        assert_eq!(outcome.usage, Usage::default());
-        assert!(provider.requests().is_empty(), "every line was priced by the operator");
+        assert_eq!(
+            provider.requests().len(),
+            1,
+            "the prose pass still runs; the PRICING call is what the operator saved"
+        );
+        assert!(
+            !format!("{:?}", provider.requests()[0].tools).contains("price_items"),
+            "every line was priced by the operator"
+        );
 
         let store = store.lock().unwrap();
         let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
@@ -1001,26 +1252,50 @@ mod tests {
         }
     }
 
+    /// A non-pricing kind still never makes a PRICING call — the invariant
+    /// that matters, and the one that keeps money off a work order. (It does
+    /// now make a prose call: a work order's whole value is the directives,
+    /// so "zero calls" stopped being the goal the moment it started carrying
+    /// them. The genuinely call-free case is pinned below.)
     #[tokio::test]
-    async fn build_non_pricing_kind_makes_zero_calls() {
+    async fn build_non_pricing_kind_never_makes_a_pricing_call() {
         let (store, sid) = processed_session_with_items(&[("todo", "mulch")]);
         let store = Arc::new(Mutex::new(store));
-        let provider = Arc::new(MockProvider::new(vec![]));
+        let provider = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([{"key": "crew", "value": "Jose"}]),
+            serde_json::json!([]),
+        )]));
         let b = builder(store.clone(), provider.clone());
 
         let outcome = b.build(&sid, "work_order").await.unwrap();
         assert!(!outcome.queued);
+        let tools = format!("{:?}", provider.requests()[0].tools);
+        assert!(tools.contains("compose_document"));
+        assert!(!tools.contains("price_items"), "a work order is never priced");
+        assert_eq!(provider.requests().len(), 1, "one call, not two");
+    }
+
+    /// The call-free path: a schema with no walk fields and no `line_detail`
+    /// — an operator's own bare list — still costs nothing to build.
+    #[tokio::test]
+    async fn a_schema_with_no_prose_to_write_makes_zero_calls() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch")]);
+        let mut bare = hoa_schema();
+        bare.sections.retain(|s| s.kind == "line_items");
+        store.save_document_schema(&bare).unwrap();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "hoa_addendum").await.unwrap();
+        assert!(!outcome.queued);
         assert_eq!(outcome.usage, Usage::default());
-        assert!(provider.requests().is_empty(), "non-pricing kinds never call the LLM");
+        assert!(provider.requests().is_empty(), "nothing to write, nothing to spend");
 
         let store = store.lock().unwrap();
         assert!(
-            store
-                .list_llm_usage_for_session(&sid)
-                .unwrap()
-                .iter()
-                .all(|r| r.purpose != "document"),
-            "non-pricing kinds log no 'document'-purpose usage row"
+            store.list_llm_usage_for_session(&sid).unwrap().iter().all(|r| r.purpose != "document"),
+            "and no 'document'-purpose usage row"
         );
     }
 
@@ -1170,13 +1445,18 @@ mod tests {
         }
     }
 
-    /// The Stage 4 golden: for each of the 7 built-ins, the decoded payload's
-    /// today-existing fields equal the pre-refactor values (computed here
-    /// from the OLD hardcoded functions `is_pricing_kind`/`total_shape`,
-    /// which stay in `pipeline/mod.rs` as the parity reference). `id`/
-    /// `doc_number` excluded — non-deterministic pre-refactor too.
+    /// The golden: for each of the 7 built-ins, the decoded payload's shared
+    /// fields equal the values `is_pricing_kind`/`total_shape` declare — the
+    /// hardcoded parity reference in `pipeline/mod.rs` that the seeded rows
+    /// must never silently drift from. `id`/`doc_number` excluded (they are
+    /// non-deterministic by design).
+    ///
+    /// Since 2026-08-09 every built-in also writes prose, so each build here
+    /// scripts one compose response; the per-line `detail` it returns is
+    /// asserted too, because a document whose lines lost their second line
+    /// would still pass every other check in this test.
     #[tokio::test]
-    async fn builtin_output_is_byte_identical_per_trade_kind() {
+    async fn builtin_output_matches_the_pricing_and_total_reference() {
         use crate::pipeline::total_shape;
         let builtins: &[(Option<&str>, &str)] = &[
             (Some("landscape"), "estimate"),
@@ -1200,16 +1480,21 @@ mod tests {
                 .collect();
             let store = Arc::new(Mutex::new(store));
             let pricing = is_pricing_kind(kind);
-            // Pricing kinds get a scripted price on item 1 (both pre- and
-            // post-refactor paths make exactly one pricing call).
-            let responses = if pricing {
-                vec![tool_use(
+            // Pricing kinds get a scripted price on item 1; every built-in
+            // then gets its one compose call, writing a second line onto
+            // item 1 only — so the test also proves a line the model said
+            // nothing about keeps an empty detail rather than inventing one.
+            let mut responses = Vec::new();
+            if pricing {
+                responses.push(tool_use(
                     "price_items",
                     serde_json::json!({"prices": [{"item_id": ids[0], "amount_cents": 28500}]}),
-                )]
-            } else {
-                vec![]
-            };
+                ));
+            }
+            responses.push(compose_response(
+                serde_json::json!([]),
+                serde_json::json!([{"item_id": ids[0], "detail": "from the yard"}]),
+            ));
             let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(responses));
             let b = builder(store.clone(), provider);
             let outcome = b.build(&sid, kind).await.unwrap();
@@ -1225,19 +1510,22 @@ mod tests {
             assert_eq!(v["queued"], false, "{kind}: no degrade in the golden path");
             let lines = v["lines"].as_array().unwrap();
             assert_eq!(lines.len(), 2);
-            let expected: Vec<(&str, &str, Option<i64>, bool)> = if pricing {
+            let expected: Vec<(&str, &str, Option<i64>, bool, &str)> = if pricing {
                 vec![
-                    ("order lumber", "", Some(28500), false),
-                    ("bark mulch", "", None, true),
+                    ("order lumber", "", Some(28500), false, "from the yard"),
+                    ("bark mulch", "", None, true, ""),
                 ]
             } else {
-                vec![("order lumber", "", None, false), ("bark mulch", "", None, false)]
+                vec![
+                    ("order lumber", "", None, false, "from the yard"),
+                    ("bark mulch", "", None, false, ""),
+                ]
             };
-            for ((line, item_id), (title, qty, amount, is_gap)) in
+            for ((line, item_id), (title, qty, amount, is_gap, detail)) in
                 lines.iter().zip(&ids).zip(expected)
             {
                 assert_eq!(line["title"], title, "{kind}");
-                assert_eq!(line["detail"], "", "{kind}");
+                assert_eq!(line["detail"], detail, "{kind}: written, or honestly empty");
                 assert_eq!(line["qty"], qty, "{kind}");
                 assert_eq!(
                     line["amount_cents"],
@@ -1287,6 +1575,7 @@ mod tests {
             label: label.into(),
             fill: "walk".into(),
             static_value: None,
+            hint: None,
         }
     }
 
@@ -1308,6 +1597,7 @@ mod tests {
                     kind: "line_items".into(),
                     label: "Items".into(),
                     priced: false,
+                    line_detail: String::new(),
                     fields: vec![],
                 },
                 SchemaSection {
@@ -1315,6 +1605,7 @@ mod tests {
                     kind: "filled".into(),
                     label: "Approvals".into(),
                     priced: false,
+                    line_detail: String::new(),
                     fields: vec![
                         walk_field("hoa_no", "HOA approval #"),
                         walk_field("reviewed_by", "Reviewed by"),
@@ -1325,12 +1616,14 @@ mod tests {
                     kind: "static".into(),
                     label: "Terms".into(),
                     priced: false,
+                    line_detail: String::new(),
                     fields: vec![SchemaField {
                         key: "terms_body".into(),
                         kind: "static".into(),
                         label: "Terms".into(),
                         fill: "static".into(),
                         static_value: Some("Valid for 30 days.".into()),
+                        hint: None,
                     }],
                 },
             ],
@@ -1369,7 +1662,15 @@ mod tests {
     }
 
     fn fill_response(fields: serde_json::Value) -> harness::CompletionResponse {
-        tool_use("fill_fields", serde_json::json!({ "fields": fields }))
+        tool_use("compose_document", serde_json::json!({ "fields": fields }))
+    }
+
+    /// A compose response that also writes the lines.
+    fn compose_response(
+        fields: serde_json::Value,
+        lines: serde_json::Value,
+    ) -> harness::CompletionResponse {
+        tool_use("compose_document", serde_json::json!({ "fields": fields, "lines": lines }))
     }
 
     fn decoded_document(
@@ -1382,7 +1683,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fill_fields_echoes_and_validates_and_drops_unknown_keys() {
+    async fn compose_echoes_and_validates_and_drops_unknown_keys() {
         let fields = vec![walk_field("hoa_no", "HOA approval #"), walk_field("reviewed_by", "Reviewed by")];
         let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(vec![fill_response(
             serde_json::json!([
@@ -1393,7 +1694,12 @@ mod tests {
             ]),
         )]));
         let mut usage = Usage::default();
-        let map = fill_fields(&provider, &fields, &[], "summary", 512, &mut usage).await.unwrap();
+        let map = compose_document(
+            &provider, "HOA Addendum", "", &fields, &[], "summary", &[], 512, &mut usage,
+        )
+        .await
+        .unwrap()
+        .fields;
         assert_eq!(map.get("hoa_no").map(String::as_str), Some("41827"), "first-wins dedup");
         assert_eq!(map.get("reviewed_by").map(String::as_str), Some("Dana"));
         assert_eq!(map.get("gate_code"), None, "hallucinated key dropped");
@@ -1401,11 +1707,11 @@ mod tests {
         assert_eq!(usage, Usage { input_tokens: 80, output_tokens: 15, ..Default::default() }, "R9: usage accumulated");
     }
 
-    /// R6 + the WE-B exact prompt: items (via `format_pricing_items`
-    /// verbatim — no `right_text`) + summary reach the request; the
-    /// transcript never does.
+    /// R6 + the exact compose prompt: items (via `format_pricing_items`
+    /// verbatim — no `right_text`), the coordination notes, and the summary
+    /// reach the request; the transcript never does.
     #[tokio::test]
-    async fn fill_fields_fed_items_and_summary_never_the_transcript() {
+    async fn compose_fed_items_notes_and_summary_never_the_transcript() {
         let store = Store::open_in_memory("device-a").unwrap();
         let session = store.start_session(None).unwrap();
         // Literal WE-B item ids, hand-built (not store-minted) so the pinned
@@ -1430,11 +1736,18 @@ mod tests {
         ]))]));
         let dyn_provider: Arc<dyn LlmProvider> = provider.clone();
         let mut usage = Usage::default();
-        fill_fields(
+        compose_document(
             &dyn_provider,
+            "HOA Addendum",
+            "",
             &fields,
             &items,
             "Walked the front yard; HOA approval 41827 on file.",
+            &[NotesEntry {
+                bucket: "constraints".into(),
+                label: "Gate".into(),
+                detail: "Code 4412, park on the street.".into(),
+            }],
             512,
             &mut usage,
         )
@@ -1445,22 +1758,27 @@ mod tests {
         let ContentBlock::Text { text } = &reqs[0].messages[0].content[0] else {
             panic!("expected text content");
         };
-        let expected = "Fill these document fields from the session. Put a value only on a field whose\n\
-                        answer was clearly stated — omit any field you are unsure about; a blank field\n\
-                        is cheaper than a wrong one.\n\
+        let expected = "Write this HOA Addendum.\n\
                         \n\
-                        Fields:\n\
+                        Fields to write:\n\
                         - [hoa_no] HOA approval #\n\
                         - [reviewed_by] Reviewed by\n\
                         \n\
-                        Session items:\n\
+                        The items on it:\n\
                         - [todo] Install boxwood hedge (item_id: item-A)\n\
                         - [part] bark mulch (item_id: item-B)\n\
                         \n\
+                        What was said around the work:\n\
+                        constraints:\n\
+                        - Gate: Code 4412, park on the street.\n\
+                        \n\
                         Session summary:\n\
                         Walked the front yard; HOA approval 41827 on file.";
-        assert_eq!(text, expected, "the exact WE-B user message — note right_text is absent \
-                    (format_pricing_items omits it; the fill pass does not re-add it)");
+        assert_eq!(
+            text, expected,
+            "the exact compose user message — right_text is absent (format_pricing_items \
+             omits it), and the coordination notes ride along at no extra call"
+        );
         assert!(!text.to_lowercase().contains("transcript"), "never the transcript (R6)");
     }
 
@@ -1556,6 +1874,7 @@ mod tests {
             label: "Signed by".into(),
             fill: "manual".into(),
             static_value: None,
+            hint: None,
         }];
         store.save_document_schema(&schema).unwrap();
         let store = Arc::new(Mutex::new(store));
@@ -1590,6 +1909,158 @@ mod tests {
         assert_eq!(v["fields"][1]["is_gap"], true, "reviewed_by degraded to a gap");
         assert_eq!(v["fields"][2]["is_gap"], false, "the static field is untouched by the degrade");
         assert_eq!(v["doc_number"], 1, "the document still mints and lands (R7)");
+    }
+
+    // ---- What the compose pass is FOR ------------------------------------
+
+    /// The work order Isaac asked for: "if during my walk I say Jose is gonna
+    /// do X, Michael is gonna do Y, that should be mentioned."
+    #[tokio::test]
+    async fn a_work_order_carries_directives_and_the_names_against_them() {
+        let (store, sid) = processed_session_with_items(&[
+            ("todo", "mulch the front beds"),
+            ("todo", "rebuild the back fence panel"),
+        ]);
+        let ids: Vec<String> =
+            store.list_items_for_session(&sid).unwrap().into_iter().map(|i| i.id).collect();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([{"key": "crew", "value": "Jose, Michael"}]),
+            serde_json::json!([
+                {"item_id": ids[0], "detail": "Strip the old bark first. Watch the irrigation heads.",
+                 "assignee": "Jose"},
+                {"item_id": ids[1], "detail": "Pull the cracked panel; match the existing pickets.",
+                 "assignee": "Michael"}
+            ]),
+        )]));
+        let b = builder(store.clone(), provider);
+
+        let outcome = b.build(&sid, "work_order").await.unwrap();
+        let v = decoded_document(&store, &outcome.document_artifact_id);
+        let lines = v["lines"].as_array().unwrap();
+        assert_eq!(lines[0]["detail"], "Strip the old bark first. Watch the irrigation heads.");
+        assert_eq!(lines[0]["assignee"], "Jose");
+        assert_eq!(lines[1]["assignee"], "Michael");
+        assert_eq!(lines[0]["amount_cents"], serde_json::Value::Null, "still no money");
+        assert_eq!(v["fields"][0]["value"], "Jose, Michael");
+    }
+
+    /// An assignee is only ever read on a document written FOR a crew. A
+    /// model that volunteers one on an estimate is answering a question
+    /// nobody asked, and a name in the price column would be a rendering bug
+    /// wearing a data bug's clothes.
+    #[tokio::test]
+    async fn an_estimate_never_takes_an_assignee() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch the front beds")]);
+        let id = store.list_items_for_session(&sid).unwrap()[0].id.clone();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![
+            tool_use("price_items", serde_json::json!({"prices": []})),
+            compose_response(
+                serde_json::json!([]),
+                serde_json::json!([
+                    {"item_id": id, "detail": "3 cu yd, delivered", "assignee": "Jose"}
+                ]),
+            ),
+        ]));
+        let b = builder(store.clone(), provider.clone());
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        let v = decoded_document(&store, &outcome.document_artifact_id);
+        assert_eq!(v["lines"][0]["detail"], "3 cu yd, delivered", "the inclusion still lands");
+        assert_eq!(v["lines"][0]["assignee"], serde_json::Value::Null, "the name does not");
+        assert!(
+            !format!("{:?}", provider.requests()[1].tools).contains("assignee"),
+            "and the tool never offered the field, so there was nothing to volunteer"
+        );
+    }
+
+    /// A line the pass had nothing real to say about keeps the operator's own
+    /// words and no second line. Padding every line is how a document starts
+    /// padding with something false.
+    #[tokio::test]
+    async fn a_line_the_pass_declined_gets_no_invented_detail() {
+        let (store, sid) =
+            processed_session_with_items(&[("todo", "mulch the beds"), ("todo", "check the gate")]);
+        let ids: Vec<String> =
+            store.list_items_for_session(&sid).unwrap().into_iter().map(|i| i.id).collect();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([]),
+            serde_json::json!([
+                {"item_id": ids[0], "detail": "Front beds only."},
+                {"item_id": "hallucinated-id", "detail": "invented"},
+                {"item_id": ids[0], "detail": "a second bite"}
+            ]),
+        )]));
+        let b = builder(store.clone(), provider);
+
+        let outcome = b.build(&sid, "work_order").await.unwrap();
+        let v = decoded_document(&store, &outcome.document_artifact_id);
+        assert_eq!(v["lines"][0]["detail"], "Front beds only.", "first-wins dedup");
+        assert_eq!(v["lines"][1]["detail"], "", "declined -> empty, never filler");
+        assert_eq!(v["lines"].as_array().unwrap().len(), 2, "and no line was added");
+    }
+
+    /// The coordination notes the walk already produced reach the pass — the
+    /// gate code a crew needs is in `constraints`, not in the item list, and
+    /// it costs nothing to carry.
+    #[tokio::test]
+    async fn the_walks_notes_reach_the_compose_pass() {
+        let (store, sid) = processed_session_with_items(&[("todo", "mulch the beds")]);
+        store
+            .add_artifact(
+                &sid,
+                "notes",
+                "notes",
+                &crate::pipeline::notes::serialize_buckets(&[NotesEntry {
+                    bucket: "constraints".into(),
+                    label: "Access".into(),
+                    detail: "Gate code 4412; dog in the back yard until eight.".into(),
+                }]),
+            )
+            .unwrap();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([]),
+            serde_json::json!([]),
+        )]));
+        let b = builder(store.clone(), provider.clone());
+        b.build(&sid, "work_order").await.unwrap();
+
+        let asked = format!("{:?}", provider.requests()[0].messages[0].content);
+        assert!(asked.contains("Gate code 4412"), "the crew's own gate code reached the writer");
+        assert!(asked.contains("dog in the back yard"));
+    }
+
+    /// A move-out report is a MONEY document: the deduction total is the
+    /// whole point, and the label says what the sum means.
+    #[tokio::test]
+    async fn a_move_out_report_prices_its_deductions() {
+        let (store, sid) = processed_session_with_template(
+            Some("property"),
+            &[("todo", "carpet stain, bedroom 1"), ("todo", "blinds, kitchen")],
+        );
+        let ids: Vec<String> =
+            store.list_items_for_session(&sid).unwrap().into_iter().map(|i| i.id).collect();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![
+            tool_use(
+                "price_items",
+                serde_json::json!({"prices": [{"item_id": ids[0], "amount_cents": 14000}]}),
+            ),
+            compose_response(serde_json::json!([]), serde_json::json!([])),
+        ]));
+        let b = builder(store.clone(), provider);
+
+        let outcome = b.build(&sid, "move_out").await.unwrap();
+        let v = decoded_document(&store, &outcome.document_artifact_id);
+        assert_eq!(v["total_label_key"], "deposit_deduction", "the sum says what it is");
+        assert_eq!(v["lines"][0]["amount_cents"], 14000);
+        assert_eq!(
+            v["lines"][1]["is_gap"], true,
+            "an unpriced deduction is an open question, not a free pass"
+        );
     }
 
     /// The contrast pin: the call SUCCEEDED but omitted a field — a truthful
@@ -1651,15 +2122,30 @@ mod tests {
     /// The byte-identical guard on the additive keys: built-ins emit
     /// `fields: []` and today's prefix.
     #[tokio::test]
-    async fn builtins_emit_empty_fields_and_todays_prefix() {
+    async fn a_work_order_emits_its_assignment_block_and_todays_prefix() {
         let (store, sid) = processed_session_with_items(&[("todo", "mulch")]);
         let store = Arc::new(Mutex::new(store));
-        let provider = Arc::new(MockProvider::new(vec![]));
+        let provider = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([
+                {"key": "crew", "value": "Jose, Michael"},
+                {"key": "access", "value": "Gate code 4412."}
+            ]),
+            serde_json::json!([]),
+        )]));
         let b = builder(store.clone(), provider.clone());
         let outcome = b.build(&sid, "work_order").await.unwrap();
         let v = decoded_document(&store, &outcome.document_artifact_id);
-        assert_eq!(v["fields"], serde_json::json!([]), "zero authored fields on a built-in");
+
+        // The four fields a crew standing at the gate actually needs, in
+        // schema order — two written, two honestly blank.
+        let keys: Vec<&str> =
+            v["fields"].as_array().unwrap().iter().map(|f| f["key"].as_str().unwrap()).collect();
+        assert_eq!(keys, vec!["crew", "schedule", "access", "safety"]);
+        assert_eq!(v["fields"][0]["value"], "Jose, Michael");
+        assert_eq!(v["fields"][0]["label"], "Assigned to");
+        assert_eq!(v["fields"][1]["is_gap"], true, "no date was said — never invented");
+        assert_eq!(v["fields"][2]["value"], "Gate code 4412.");
+        assert_eq!(v["fields"][3]["is_gap"], true, "no hazards were said");
         assert_eq!(v["number_prefix"], "WO", "today's Swift-side prefix, now also in the body");
-        assert!(provider.requests().is_empty(), "zero fill calls (launch-safety)");
     }
 }

--- a/crates/murmur-core/src/pipeline/mod.rs
+++ b/crates/murmur-core/src/pipeline/mod.rs
@@ -42,9 +42,16 @@ pub fn doc_kinds_for_template(template: Option<&str>) -> &'static [&'static str]
 }
 
 /// Plan 13 D5: whether a `doc_kind` needs a pricing pass (an amount on every
-/// line). Only `estimate`/`invoice` are pricing kinds.
+/// line).
+///
+/// `move_out` joined the two obvious ones on 2026-08-09. A move-out report
+/// exists to justify what is withheld from a deposit, line by line, against a
+/// statutory deadline — the deduction total IS the document, and the unpriced
+/// version could not do the one job it has. (It had been unpriced while the
+/// demo screen the product is sold on showed "DEPOSIT DEDUCTION $185", a
+/// number the shipped build could not produce.)
 pub fn is_pricing_kind(kind: &str) -> bool {
-    matches!(kind, "estimate" | "invoice")
+    matches!(kind, "estimate" | "invoice" | "move_out")
 }
 
 /// Total-shape per BUILT-IN `doc_kind` (Plan 13; lifted here from
@@ -56,6 +63,11 @@ pub fn is_pricing_kind(kind: &str) -> bool {
 pub fn total_shape(doc_kind: &str) -> (&'static str, &'static str) {
     match doc_kind {
         "inspection" => ("static", "findings"),
+        // What the sum MEANS differs, and the label is the only place a
+        // reader learns it: an estimate totals an offer, an invoice states a
+        // debt, and a move-out report tallies what is being kept.
+        "invoice" => ("sum", "amount_due"),
+        "move_out" => ("sum", "deposit_deduction"),
         _ => ("sum", "total"),
     }
 }
@@ -938,13 +950,22 @@ mod tests {
     }
 
     #[test]
-    fn is_pricing_kind_flags_only_estimate_and_invoice() {
+    fn is_pricing_kind_flags_the_three_money_documents() {
         assert!(is_pricing_kind("estimate"));
         assert!(is_pricing_kind("invoice"));
-        assert!(!is_pricing_kind("work_order"));
+        assert!(is_pricing_kind("move_out"), "the deduction total IS the move-out report");
+        assert!(!is_pricing_kind("work_order"), "money on a crew's copy is the wrong document");
         assert!(!is_pricing_kind("inspection"));
         assert!(!is_pricing_kind("report"));
-        assert!(!is_pricing_kind("condition"));
+        assert!(!is_pricing_kind("condition"), "a move-in record tallies nothing");
+    }
+
+    #[test]
+    fn a_sum_is_labelled_by_what_it_means() {
+        assert_eq!(total_shape("estimate"), ("sum", "total"));
+        assert_eq!(total_shape("invoice"), ("sum", "amount_due"));
+        assert_eq!(total_shape("move_out"), ("sum", "deposit_deduction"));
+        assert_eq!(total_shape("inspection"), ("static", "findings"));
     }
 
     /// Plan 13 N3 (Stage 2 flip): `doc_kind_for_template` is now

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -345,6 +345,7 @@ mod tests {
                 kind: "line_items".into(),
                 label: "Items".into(),
                 priced: false,
+                line_detail: String::new(),
                 fields: vec![],
             }],
             schema_version: 1,
@@ -421,9 +422,36 @@ mod tests {
                 b.kind
             );
             assert!(
-                line_items[0].fields.is_empty()
-                    && b.sections.iter().all(|s| s.fields.is_empty()),
-                "{}: built-ins carry ZERO fields (launch-safety: zero fill calls)",
+                line_items[0].fields.is_empty(),
+                "{}: the line_items section itself never carries fields",
+                b.kind
+            );
+            // Every built-in writes prose now, so every one must be able to:
+            // an authored section with at least one walk field, and a
+            // `line_detail` from the allowlist. A built-in that silently lost
+            // its sections would still build — it would just quietly go back
+            // to being a list.
+            assert!(
+                crate::domain::VALID_LINE_DETAILS.contains(&line_items[0].line_detail.as_str()),
+                "{}: unknown line_detail '{}'",
+                b.kind,
+                line_items[0].line_detail
+            );
+            let walk_fields: Vec<&str> = b
+                .sections
+                .iter()
+                .flat_map(|s| s.fields.iter())
+                .filter(|f| f.fill == "walk")
+                .map(|f| f.key.as_str())
+                .collect();
+            assert!(!walk_fields.is_empty(), "{}: no authored fields to write", b.kind);
+            assert!(
+                b.sections
+                    .iter()
+                    .flat_map(|s| s.fields.iter())
+                    .filter(|f| f.fill == "walk")
+                    .all(|f| f.hint.is_some()),
+                "{}: a walk field without a hint fills badly — see SchemaField::hint",
                 b.kind
             );
         }
@@ -720,6 +748,7 @@ mod tests {
             kind: "gallery".into(),
             label: "Gallery".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![],
         });
         let err = s.save_document_schema(&bad).unwrap_err();
@@ -743,12 +772,14 @@ mod tests {
             kind: "filled".into(),
             label: "S2".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![SchemaField {
                 key: "b".into(),
                 kind: "barcode".into(),
                 label: "B".into(),
                 fill: "walk".into(),
                 static_value: None,
+                hint: None,
             }],
         });
         let err = s.save_document_schema(&bad).unwrap_err();
@@ -771,12 +802,14 @@ mod tests {
             kind: "filled".into(),
             label: "S2".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![SchemaField {
                 key: "f".into(),
                 kind: "text".into(),
                 label: "F".into(),
                 fill: "psychic".into(),
                 static_value: None,
+                hint: None,
             }],
         });
         let err = s.save_document_schema(&bad).unwrap_err();
@@ -822,12 +855,14 @@ mod tests {
             kind: "filled".into(),
             label: "Approvals".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![SchemaField {
                 key: "hoa_no".into(),
                 kind: "text".into(),
                 label: "HOA approval #".into(),
                 fill: "walk".into(),
                 static_value: None,
+                hint: None,
             }],
         });
         schema.sections.push(SchemaSection {
@@ -835,12 +870,14 @@ mod tests {
             kind: "static".into(),
             label: "Terms".into(),
             priced: false,
+            line_detail: String::new(),
             fields: vec![SchemaField {
                 key: "terms_body".into(),
                 kind: "static".into(),
                 label: "Terms".into(),
                 fill: "static".into(),
                 static_value: Some("Valid for 30 days.".into()),
+                hint: None,
             }],
         });
         let saved = s.save_document_schema(&schema).unwrap();

--- a/crates/murmur-core/tests/document_smoke.rs
+++ b/crates/murmur-core/tests/document_smoke.rs
@@ -1,0 +1,129 @@
+//! Env-gated smoke test for the DOCUMENT path against the real API. Ignored
+//! by default — it costs real tokens and needs a key. Run explicitly with:
+//!
+//! ```sh
+//! ANTHROPIC_API_KEY=sk-... ANTHROPIC_BASE_URL=https://api.ppq.ai \
+//!     cargo test -p murmur-core --test document_smoke -- --ignored --nocapture
+//! ```
+//!
+//! Sibling of `anthropic_smoke.rs`, one layer further along: that one proves a
+//! walk processes, this one proves the walk becomes a DOCUMENT.
+//!
+//! It exists because every other test of the compose pass uses `MockProvider`,
+//! which proves the plumbing and nothing about the writing. The failure this
+//! catches is the one mocks structurally cannot: a prompt that parses fine and
+//! produces a document nobody would send — a "directive" that just restates
+//! the item, an invented gate code, a name attached to a line nobody was
+//! assigned. `--nocapture` prints the document so a human can read it, because
+//! the interesting half of this is not assertable.
+//!
+//! The assertions are the ones that CAN be made mechanically: the structure
+//! survives, every line keeps the operator's own words, and nothing the model
+//! wrote about a line landed on a line it wasn't about.
+
+use std::sync::{Arc, Mutex};
+
+use harness::{AnthropicProvider, HarnessError, Memory, MemoryStore};
+use murmur_core::{DocumentBuilder, SessionProcessor, Store};
+
+const MODEL: &str = "claude-haiku-4-5";
+
+/// A walk that names people against tasks — the thing Isaac asked for, and
+/// the case a mock cannot evaluate.
+const TRANSCRIPT: &str = "Okay, front yard at the Hollis place. We're doing five yards \
+of dark mulch in the front beds, and two bags of compost worked into the rose bed. \
+Jose is going to strip the old bark out first and lay the mulch, Michael takes the \
+edging along the walkway, sixty feet of it, spade edge. Gate code is 4412 on the side \
+yard, park on the street because they're sealing the driveway Thursday. Watch the \
+irrigation heads along that walkway bed, they sit shallow. Dog's in the back until \
+about eight. We're starting Thursday first thing.";
+
+struct NullMemoryStore;
+impl MemoryStore for NullMemoryStore {
+    fn load(&self) -> Result<Memory, HarnessError> {
+        Ok(Memory::default())
+    }
+    fn save(&self, _m: &Memory) -> Result<(), HarnessError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+#[ignore = "hits the real API; set ANTHROPIC_API_KEY and run with --ignored"]
+async fn real_walk_becomes_a_work_order() {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .expect("set ANTHROPIC_API_KEY to run the real-provider document smoke test");
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, MODEL));
+
+    let store = Store::open_in_memory("smoke-device").unwrap();
+    let session = store.start_session_with_template(None, "landscape").unwrap();
+    store.append_transcript(&session.id, TRANSCRIPT).unwrap();
+    store.end_and_record_session(&session.id).unwrap();
+    let store = Arc::new(Mutex::new(store));
+
+    let processor = SessionProcessor::new(
+        provider.clone(),
+        store.clone(),
+        Arc::new(Mutex::new(Memory::default())),
+        Arc::new(NullMemoryStore),
+    );
+    processor.process(&session.id).await.expect("processing failed");
+
+    let builder = DocumentBuilder::new(
+        provider,
+        store.clone(),
+        Arc::new(Mutex::new(Memory::default())),
+        Arc::new(NullMemoryStore),
+    );
+    let outcome = builder.build(&session.id, "work_order").await.expect("build failed");
+
+    let guard = store.lock().unwrap();
+    let artifact = guard.get_artifact(&outcome.document_artifact_id).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&artifact.body).unwrap();
+
+    // Print it — the half that matters here is whether it READS right.
+    println!("\n===== WORK ORDER =====");
+    for field in doc["fields"].as_array().unwrap() {
+        println!(
+            "[{}] {}: {}",
+            field["section_key"].as_str().unwrap_or(""),
+            field["label"].as_str().unwrap_or(""),
+            field["value"].as_str().unwrap_or("—— (gap)")
+        );
+    }
+    for line in doc["lines"].as_array().unwrap() {
+        println!(
+            "\n  {}\n    {}\n    assignee: {}  amount: {}",
+            line["title"].as_str().unwrap_or(""),
+            line["detail"].as_str().unwrap_or(""),
+            line["assignee"].as_str().unwrap_or("—"),
+            line["amount_cents"]
+        );
+    }
+    println!("======================\n");
+
+    assert!(!outcome.queued, "the compose call did not complete");
+
+    // Structure: the fields the schema authored, in order, all present.
+    let keys: Vec<&str> =
+        doc["fields"].as_array().unwrap().iter().map(|f| f["key"].as_str().unwrap()).collect();
+    assert_eq!(keys, vec!["crew", "schedule", "access", "safety"]);
+
+    // A work order NEVER carries money, whatever the model returns.
+    for line in doc["lines"].as_array().unwrap() {
+        assert!(line["amount_cents"].is_null(), "money on a work order: {line}");
+    }
+
+    // Line count and titles are the deterministic render's, not the model's:
+    // the compose pass may only write onto lines, never author them.
+    let items = guard.list_items_for_session(&session.id).unwrap();
+    assert_eq!(
+        doc["lines"].as_array().unwrap().len(),
+        items.len(),
+        "the compose pass added or dropped a line"
+    );
+    for (line, item) in doc["lines"].as_array().unwrap().iter().zip(&items) {
+        assert_eq!(line["title"].as_str().unwrap(), item.text, "a line was rewritten");
+        assert_eq!(line["item_id"].as_str().unwrap(), item.id, "a line lost its item");
+    }
+}


### PR DESCRIPTION
Isaac, on the seven document types: *"I want things to be what someone would expect in the industry… I want someone to generate a document and be like 'this is exactly what I was expecting.'"* Plus three specifics — a work order should carry directives and who is doing what, a report should carry the detail the notes had, and estimates and invoices should open with a summary of the work.

## Thinking

### The actual problem: every document was the same list

Seven kinds, one shape. Same lines, same columns, a different word above the total. The differences a trade reader looks for — who this is for, what it covers, what to do, what was found — were nowhere, because the render is one line per item and nothing else.

The parts to fix it turned out to be **already built and unused**:

- `DocLine.detail` has rendered as each row's second line since Plan 07, and the builder has always set it to `""`.
- `DocField` exists across the FFI. Nothing in the app has ever rendered it.
- Plan 19's fill pass works fine and ran for **zero** built-ins, because no built-in had a field to fill.

So this is less "new machinery" than "connect the machinery and author the schemas", which is also why the diff is mostly data and prose.

### One composition pass, not two

`fill_fields` becomes `compose_document` and returns both the authored field values and each line's second line, echo-validated by `item_id` exactly like `price_items` — it can't add, drop, rename or reorder anything, only write.

**Why one call.** The scope paragraph is a summary of the very lines being detailed. A model writing both at once writes a document that agrees with itself; two calls pay the same input tokens twice to produce a paragraph that contradicts the lines under it. **Pricing stays its own pass** — money is a different risk class, with its own validation and its own spoken-total hint, and it should not be entangled with prose.

**It reads what the walk already produced.** `summarize()` captures coordination notes at finish (`scope_of_work` / `constraints` / `conditions_and_issues`) and they sit unused in the session's `notes` artifact. Feeding them to the compose pass costs nothing and is exactly what the terse item list is missing — the gate code, the client's preference, the condition that changes the work. A document written without them is guaranteed to be thinner than the walk was.

**The per-line brief is keyed to the reader**, because that is what actually decides the writing. The same item becomes:

| | |
|---|---|
| `inclusion` | "delivered and installed, 3 cu yd" — a client weighing a price |
| `directive` | "strip the old bark before laying — watch the irrigation heads" — a crew executing |
| `observation` | "south slope, three shingles lifted at the ridge" — whoever reads the record next year |

R6 runs through the prompt: a line it has nothing real to say about gets nothing. Padding every line is how a document eventually pads with something false.

### The seven

- **Estimate** — SCOPE OF WORK, future tense. A bare list of priced lines reads like a receipt for work nobody agreed to, and it's the paragraph, not the total, that a client forwards to their spouse.
- **Invoice** — WORK PERFORMED, past tense, and the total says **AMOUNT DUE**. An estimate offers; an invoice demands.
- **Work Order** — ASSIGNMENT (crew, schedule) and SITE NOTES (access, safety) above the tasks, per-line directives, and **`DocLine.assignee`** rendered in the column the money would occupy. Still no money: a sub who sees the client price bids higher next time, and the empty price column is exactly where a foreman's eye already travels.
- **Report / Condition / Inspection** — narrative summary plus per-line observations.
- **Move-Out** — **now a money document.** The deduction total *is* the report; it justifies what's withheld against a statutory deadline. It was seeded unpriced while the demo screen we sell on showed "DEPOSIT DEDUCTION $185" — a number the shipped build could not produce.

Section order is reading order and the line items come **last**, the way every trade document on paper works: who and what this is about at the top, the itemized body under it, the total at the foot.

### Nothing operator-facing reaches a client

Isaac, mid-session: *"little tag lines like 'added by you' are not included."* Right, and the same bug class as everything else here — the review screen and the PDF render from one model, and a handful of marks on that screen are the app talking to the *operator*.

The marks now live in one `OperatorNote` enum and the print path strips everything in it. Also stripped: the **price-book hint** (`LAST 3: $110 · $120 · $125` — what this operator charged their last three customers, which is a pricing leak on a quote), gap dashes, unfilled field blocks, and the `+N GAP` badge. A test sweeps the known marks, so a new one added at a call site fails there instead of on a customer's paperwork.

## Three found while checking

- **The app threw away the document number core mints.** The letterhead read the trade *fixture's* number for a trade's lead kind and printed **nothing** for the other six. So every real invoice went out unnumbered, headed ESTIMATE, attached as `EST-0047.pdf` — three separate ways of telling a client this is a different document than it is. An invoice without its own number isn't something a bookkeeper can accept.
- **"TREC REPORT"** stamped on the inspection button. TREC is the Texas Real Estate Commission's mandatory inspection form, which a licensed Texas inspector must deliver on — and there is no TREC mapping anywhere in the codebase. Now "FINDINGS".
- **The demo engine produced less than the real one.** It's what onboarding teaches from and what an App Store reviewer sees, so it now carries the same sections, crew names, per-kind numbers and total labels.

## Testing

- 533 Rust tests, clippy clean, FFI bindings regenerated and verified in sync.
- 146 iOS tests, including a sweep that fails if an operator-facing marker is ever added without being registered.
- Demo (the CI path) and real-core both **BUILD SUCCEEDED**.
- All seven rendered on iPhone 17, and the exported work-order PDF pulled off the simulator and read: WORK ORDER / WO-0047, assignment, site notes, six tasks with crew names, no money, no scaffolding.

`doc=<kind>` renders any of the seven unattended — simctl cannot tap the button that picks them, and six of seven were otherwise only visible with a device in hand.

## For dam

Core changes: `pipeline/document.rs` (the compose pass replacing `fill_fields`), the seven schemas in `domain.rs`, and two additive schema fields (`SchemaSection.line_detail`, `SchemaField.hint`) — both `#[serde(default)]`, so every existing and operator-authored row parses unchanged. `DocLine.assignee` is additive across the FFI.

The judgement calls worth your eye: **one compose call instead of two** (§ above), **`move_out` joining `is_pricing_kind`**, and **what the compose pass is allowed to touch** — it can write prose onto a fixed structure and nothing else, so the worst it can do is say something thin, never something structurally wrong.
