### PR TITLE
fix: an app update can actually change a built-in document

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1562,6 +1562,31 @@ final class AppModel {
         editingRowIsNew = false
     }
 
+    /// Takes the block off this document entirely.
+    ///
+    /// Distinct from clearing it, and both are wanted: clearing says "this
+    /// belongs here and I still owe it a value", so the field stays visible as
+    /// a gap you can come back to. Removing says "this document doesn't need
+    /// this block" — a one-line fence repair does not want a SAFETY paragraph
+    /// on it, and leaving an empty heading there is the "heading over an empty
+    /// box" problem the operator can't fix any other way.
+    ///
+    /// A section that loses its last field goes with it, for the same reason.
+    func removeEditingField() {
+        guard let target = editingField, var doc = document,
+              let sectionIndex = doc.sections.firstIndex(where: { $0.key == target.section })
+        else {
+            editingField = nil
+            return
+        }
+        doc.sections[sectionIndex].fields.removeAll { $0.key == target.key }
+        if doc.sections[sectionIndex].fields.isEmpty {
+            doc.sections.remove(at: sectionIndex)
+        }
+        document = doc
+        editingField = nil
+    }
+
     /// Writes the field back. An emptied value returns it to a truthful gap —
     /// the same rule as an emptied amount, for the same reason.
     func commitFieldEdit() {

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -357,6 +357,17 @@ struct ReviewView: View {
                 BlockLabel("SET")
             }
             .buttonStyle(RaisedBlockStyle(height: Theme.S.buttonHeight, leadingDot: false))
+
+            // Removing is not the same as clearing, and the copy has to say
+            // so: clearing leaves a gap you owe a value to, this takes the
+            // block off the document. Ink rather than red, and last —
+            // the same call DISCARD makes on this screen.
+            Button { model.removeEditingField() } label: {
+                Text("Remove this block")
+                    .font(Theme.F.ui(13, .semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.wellChip)
             Spacer(minLength: 0)
         }
         .padding(Theme.S.screenPad)

--- a/apps/ios/Tests/DocumentLineEditTests.swift
+++ b/apps/ios/Tests/DocumentLineEditTests.swift
@@ -223,6 +223,97 @@ final class DocumentLineEditTests: XCTestCase {
         XCTAssertEqual(model.document?.rows[0].amount, "$125.50")
     }
 
+    // MARK: The authored blocks
+
+    private func modelWithSections() -> AppModel {
+        let model = model()
+        model.document?.sections = [
+            DocSectionFixture(key: "scope", label: "SCOPE OF WORK", fields: [
+                DocFieldFixture(
+                    key: "scope_summary", label: "Scope of work",
+                    value: "Refresh the front beds.", isGap: false, isParagraph: true
+                ),
+            ]),
+            DocSectionFixture(key: "site", label: "SITE NOTES", fields: [
+                DocFieldFixture(
+                    key: "access", label: "Access", value: "Gate code 4412.",
+                    isGap: false, isParagraph: true
+                ),
+                DocFieldFixture(
+                    key: "safety", label: "Safety", value: nil, isGap: true, isParagraph: true
+                ),
+            ]),
+        ]
+        return model
+    }
+
+    func testASummaryBlockIsEditable() {
+        let model = modelWithSections()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        XCTAssertEqual(model.editTitle, "Refresh the front beds.")
+
+        model.editTitle = "Refresh the front beds and re-cut the edging."
+        model.commitFieldEdit()
+
+        XCTAssertEqual(
+            model.document?.sections[0].fields[0].value,
+            "Refresh the front beds and re-cut the edging."
+        )
+        XCTAssertFalse(model.document!.sections[0].fields[0].isGap)
+        XCTAssertNil(model.editingField, "the sheet closes")
+    }
+
+    func testAnEmptiedBlockGoesBackToAGapRatherThanVanishing() {
+        let model = modelWithSections()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        model.editTitle = "   "
+        model.commitFieldEdit()
+
+        XCTAssertNil(model.document?.sections[0].fields[0].value)
+        XCTAssertTrue(
+            model.document!.sections[0].fields[0].isGap,
+            "cleared means 'I still owe this a value', not 'delete it'"
+        )
+        XCTAssertEqual(model.document?.sections.count, 2, "the block is still on the document")
+    }
+
+    func testABlockCanBeRemovedOutright() {
+        let model = modelWithSections()
+        let site = model.document!.sections[1]
+        model.beginFieldEdit(section: site, field: site.fields[1]) // Safety
+        model.removeEditingField()
+
+        XCTAssertEqual(model.document?.sections[1].fields.map(\.key), ["access"])
+        XCTAssertEqual(model.document?.sections.count, 2, "the section survives its sibling")
+        XCTAssertNil(model.editingField)
+    }
+
+    func testASectionGoesWithItsLastField() {
+        let model = modelWithSections()
+        let scope = model.document!.sections[0]
+        model.beginFieldEdit(section: scope, field: scope.fields[0])
+        model.removeEditingField()
+
+        XCTAssertEqual(
+            model.document?.sections.map(\.key), ["site"],
+            "an empty heading is the one thing the operator cannot fix any other way"
+        )
+    }
+
+    func testTheTwoEditorsAreMutuallyExclusive() {
+        // Both sheets are bound to their own property; leaving the other set
+        // presents them on top of each other.
+        let model = modelWithSections()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        XCTAssertNil(model.editingRowID)
+
+        model.beginEdit(model.document!.rows[0])
+        XCTAssertNil(model.editingField)
+    }
+
     func testTheTotalFollowsEveryEdit() {
         let model = model()
         XCTAssertEqual(model.document?.totalValue, "$200")

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -92,6 +92,53 @@ pub(crate) fn seed_schemas(conn: &Connection, schemas: &[DocumentSchema]) -> Res
                 schema.device_id,
             ],
         )?;
+        // ...and UPGRADE a row that is still the seeded one.
+        //
+        // Insert-if-absent alone is a trap, and it sprang on 2026-08-09: the
+        // built-in ids are fixed constants, so once a device has seeded them
+        // ONE TIME, no later app version can ever change what those documents
+        // are. The release that gave every built-in its authored sections
+        // shipped to a device that already had the old rows and changed
+        // nothing at all — no scope paragraph, no line details, no AMOUNT DUE,
+        // because the schema the builder resolved was still the one from the
+        // previous version. Every test had used a fresh store, where the
+        // INSERT fires and everything works.
+        //
+        // Two things this must not touch, hence the WHERE clause:
+        //
+        // - `deleted_at IS NULL` — a built-in the operator deliberately
+        //   deleted stays deleted. Resurrecting it on every launch would make
+        //   the delete button a no-op (pinned by
+        //   `tombstoned_builtin_survives_a_fresh_seed_call`).
+        // - `device_id = 'builtin' AND updated_at = 0` — the two fixed
+        //   literals `builtin_schema()` stamps and nothing else writes. Any
+        //   operator save bumps `updated_at` to a real clock, so an edited
+        //   built-in stops matching and keeps their version. Their edit
+        //   outranks our update, always: silently reverting somebody's
+        //   customized document type on an app update is worse than leaving
+        //   them on an out-of-date one. (Both conditions, because they fail
+        //   independently — `save_document_schema`'s UPDATE path bumps the
+        //   clock without restamping the device.)
+        //
+        // The update deliberately does NOT bump `updated_at`: an upgraded row
+        // is still a seeded row, and must stay eligible for the next upgrade.
+        conn.execute(
+            "UPDATE document_schemas
+                SET kind = ?2, label = ?3, number_prefix = ?4, trade_key = ?5,
+                    sections = ?6, schema_version = ?7
+              WHERE id = ?1 AND deleted_at IS NULL AND device_id = ?8
+                AND updated_at = 0",
+            rusqlite::params![
+                schema.id,
+                schema.kind,
+                schema.label,
+                schema.number_prefix,
+                schema.trade_key,
+                sections,
+                schema.schema_version as i64,
+                schema.device_id,
+            ],
+        )?;
     }
     Ok(())
 }
@@ -455,6 +502,78 @@ mod tests {
                 b.kind
             );
         }
+    }
+
+    /// The app-update path, and the defect that shipped on 2026-08-09.
+    ///
+    /// Built-in ids are fixed constants, so insert-if-absent means a device
+    /// that seeded them once can NEVER receive a changed built-in. The release
+    /// that gave every built-in its authored sections landed on an existing
+    /// install and changed nothing: the estimate still had no scope section,
+    /// so the compose pass never ran and the document came out exactly as
+    /// before. Every test used a fresh store, where the INSERT fires.
+    #[test]
+    fn an_app_update_upgrades_the_seeded_builtins_in_place() {
+        let s = Store::open_in_memory("device-a").unwrap();
+        // Simulate the PREVIOUS version's row: no authored sections, no
+        // line_detail — exactly what a device seeded before the update holds.
+        let stale = DocumentSchema {
+            sections: vec![SchemaSection {
+                key: "line_items".into(),
+                kind: "line_items".into(),
+                label: "Items".into(),
+                priced: true,
+                line_detail: String::new(),
+                fields: vec![],
+            }],
+            label: "Old Estimate".into(),
+            ..crate::domain::builtin_schemas()
+                .into_iter()
+                .find(|b| b.id == BUILTIN_SCHEMA_ID_ESTIMATE)
+                .unwrap()
+        };
+        s.conn
+            .execute(
+                "UPDATE document_schemas SET sections = ?2, label = ?3 WHERE id = ?1",
+                rusqlite::params![
+                    BUILTIN_SCHEMA_ID_ESTIMATE,
+                    envelope_json(&stale).unwrap(),
+                    stale.label
+                ],
+            )
+            .unwrap();
+
+        seed_builtin_schemas(&s.conn).unwrap();
+
+        let fresh = s.get_document_schema(BUILTIN_SCHEMA_ID_ESTIMATE).unwrap();
+        assert_eq!(fresh.label, "Estimate", "the label caught up");
+        let line_items = fresh.sections.iter().find(|x| x.kind == "line_items").unwrap();
+        assert_eq!(line_items.line_detail, "inclusion", "the lines learned what to say");
+        assert!(
+            fresh.sections.iter().any(|x| x.key == "scope"),
+            "the scope section arrived — without this the compose pass never runs"
+        );
+        let count: i64 =
+            s.conn.query_row("SELECT COUNT(*) FROM document_schemas", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 7, "upgraded in place, not duplicated");
+    }
+
+    /// The other half: an operator who customized a built-in keeps their
+    /// version. Silently reverting somebody's edited document type on an app
+    /// update is worse than leaving them on an out-of-date one.
+    #[test]
+    fn an_operator_edited_builtin_is_never_overwritten_by_a_seed() {
+        let s = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(|| 1000));
+        let mut edited = s.get_document_schema(BUILTIN_SCHEMA_ID_ESTIMATE).unwrap();
+        edited.label = "My Estimate".into();
+        edited.number_prefix = "QUO".into();
+        s.save_document_schema(&edited).unwrap();
+
+        seed_builtin_schemas(&s.conn).unwrap();
+
+        let after = s.get_document_schema(BUILTIN_SCHEMA_ID_ESTIMATE).unwrap();
+        assert_eq!(after.label, "My Estimate", "their edit outranks our update");
+        assert_eq!(after.number_prefix, "QUO");
     }
 
     /// WE-A core — the guard exercised the way every real launch exercises it.


### PR DESCRIPTION
Isaac exported a real estimate off build 105 (#320) and there was no scope paragraph and no line details. Both come from the compose pass, so the pass never ran.

## Thinking

### The seed was insert-only, and built-in ids are constants

`seed_schemas` was `INSERT ... WHERE NOT EXISTS (SELECT 1 ... WHERE id = ?1)` over a list of **fixed** ids. Which means: a device that seeded the built-ins **once** can never receive a changed built-in, ever.

So #320 landed on his install and changed nothing. The estimate schema the builder resolved was still the previous version's — no `scope` section, no `line_detail` — so `walk_fields` was empty, `line_brief("")` was `None`, and `build()` correctly skipped a pass that had nothing to write. Not just the scope paragraph: **every schema-driven thing in that release was inert on every existing install** — the per-line details, AMOUNT DUE on invoices, the move-out report becoming a money document. Which is every tester, including him.

**Why I didn't catch it.** Every Rust test uses `Store::open_in_memory`, and every simulator check I ran used a fresh install (I'd been uninstalling to reset onboarding state). Both are precisely the case where the INSERT fires and everything works. The bug lives only on the upgrade path, and nothing exercised the upgrade path. That's the gap, and the new test closes it by construction: it writes a previous-version row and then seeds over it.

### Upgrading without stepping on the operator

Seeding now also UPDATEs — but only a row that is *still the seeded one*, guarded on the two fixed literals `builtin_schema()` stamps and nothing else writes:

```sql
WHERE id = ?1 AND deleted_at IS NULL AND device_id = 'builtin' AND updated_at = 0
```

- **`deleted_at IS NULL`** — a built-in the operator deleted stays deleted. Resurrecting it on every launch would make the delete button a no-op (already pinned by `tombstoned_builtin_survives_a_fresh_seed_call`).
- **`device_id = 'builtin' AND updated_at = 0`** — an operator-edited built-in is never overwritten. Their edit outranks our update, always: silently reverting somebody's customized document type on an app update is worse than leaving them on an out-of-date one.
- The update deliberately **does not bump `updated_at`**, so an upgraded row is still a seeded row and stays eligible for the next upgrade.

`device_id` alone was not enough, which the test caught: `save_document_schema`'s UPDATE path bumps the clock without restamping the device, so an edited built-in still looked seeded. Both conditions, because they fail independently.

**One thing for dam.** Built-ins were designed to be byte-identical on every device (fixed `created_at`/`updated_at`, sentinel `device_id`) as the sync merge key. Two devices on different app versions now hold different `sections` for the same id at the same `updated_at = 0`. That is the same "built-ins are per-app-version" situation the `schema_version` column exists for, but the merge behaviour is your call — flagging rather than redesigning.

### Blocks are removable, not just editable

Isaac: *"this should also be editable and removable."*

Clearing and removing are different and both are wanted. **Clearing** says "this belongs here and I still owe it a value" — the field stays as a gap you can come back to, and prints as nothing. **Removing** takes the block off this document, because a one-line fence repair does not want a SAFETY paragraph on it. A section that loses its last field goes with it: an empty heading over nothing is the one thing the operator could not fix any other way.

## Testing

- 536 Rust tests, clippy clean, 151 iOS tests.
- The new upgrade test writes a previous-version row and seeds over it — the exact path that was untested.
- Real-API work order rebuilt end to end; the details now ADD ("Strip down to soil.") rather than restate the title.
