### PR TITLE
fix: line items are labor or materials — and a price is never invented

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1562,6 +1562,31 @@ final class AppModel {
         editingRowIsNew = false
     }
 
+    /// Takes the block off this document entirely.
+    ///
+    /// Distinct from clearing it, and both are wanted: clearing says "this
+    /// belongs here and I still owe it a value", so the field stays visible as
+    /// a gap you can come back to. Removing says "this document doesn't need
+    /// this block" — a one-line fence repair does not want a SAFETY paragraph
+    /// on it, and leaving an empty heading there is the "heading over an empty
+    /// box" problem the operator can't fix any other way.
+    ///
+    /// A section that loses its last field goes with it, for the same reason.
+    func removeEditingField() {
+        guard let target = editingField, var doc = document,
+              let sectionIndex = doc.sections.firstIndex(where: { $0.key == target.section })
+        else {
+            editingField = nil
+            return
+        }
+        doc.sections[sectionIndex].fields.removeAll { $0.key == target.key }
+        if doc.sections[sectionIndex].fields.isEmpty {
+            doc.sections.remove(at: sectionIndex)
+        }
+        document = doc
+        editingField = nil
+    }
+
     /// Writes the field back. An emptied value returns it to a truthful gap —
     /// the same rule as an emptied amount, for the same reason.
     func commitFieldEdit() {

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -357,6 +357,17 @@ struct ReviewView: View {
                 BlockLabel("SET")
             }
             .buttonStyle(RaisedBlockStyle(height: Theme.S.buttonHeight, leadingDot: false))
+
+            // Removing is not the same as clearing, and the copy has to say
+            // so: clearing leaves a gap you owe a value to, this takes the
+            // block off the document. Ink rather than red, and last —
+            // the same call DISCARD makes on this screen.
+            Button { model.removeEditingField() } label: {
+                Text("Remove this block")
+                    .font(Theme.F.ui(13, .semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.wellChip)
             Spacer(minLength: 0)
         }
         .padding(Theme.S.screenPad)

--- a/apps/ios/Tests/DocumentLineEditTests.swift
+++ b/apps/ios/Tests/DocumentLineEditTests.swift
@@ -223,6 +223,97 @@ final class DocumentLineEditTests: XCTestCase {
         XCTAssertEqual(model.document?.rows[0].amount, "$125.50")
     }
 
+    // MARK: The authored blocks
+
+    private func modelWithSections() -> AppModel {
+        let model = model()
+        model.document?.sections = [
+            DocSectionFixture(key: "scope", label: "SCOPE OF WORK", fields: [
+                DocFieldFixture(
+                    key: "scope_summary", label: "Scope of work",
+                    value: "Refresh the front beds.", isGap: false, isParagraph: true
+                ),
+            ]),
+            DocSectionFixture(key: "site", label: "SITE NOTES", fields: [
+                DocFieldFixture(
+                    key: "access", label: "Access", value: "Gate code 4412.",
+                    isGap: false, isParagraph: true
+                ),
+                DocFieldFixture(
+                    key: "safety", label: "Safety", value: nil, isGap: true, isParagraph: true
+                ),
+            ]),
+        ]
+        return model
+    }
+
+    func testASummaryBlockIsEditable() {
+        let model = modelWithSections()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        XCTAssertEqual(model.editTitle, "Refresh the front beds.")
+
+        model.editTitle = "Refresh the front beds and re-cut the edging."
+        model.commitFieldEdit()
+
+        XCTAssertEqual(
+            model.document?.sections[0].fields[0].value,
+            "Refresh the front beds and re-cut the edging."
+        )
+        XCTAssertFalse(model.document!.sections[0].fields[0].isGap)
+        XCTAssertNil(model.editingField, "the sheet closes")
+    }
+
+    func testAnEmptiedBlockGoesBackToAGapRatherThanVanishing() {
+        let model = modelWithSections()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        model.editTitle = "   "
+        model.commitFieldEdit()
+
+        XCTAssertNil(model.document?.sections[0].fields[0].value)
+        XCTAssertTrue(
+            model.document!.sections[0].fields[0].isGap,
+            "cleared means 'I still owe this a value', not 'delete it'"
+        )
+        XCTAssertEqual(model.document?.sections.count, 2, "the block is still on the document")
+    }
+
+    func testABlockCanBeRemovedOutright() {
+        let model = modelWithSections()
+        let site = model.document!.sections[1]
+        model.beginFieldEdit(section: site, field: site.fields[1]) // Safety
+        model.removeEditingField()
+
+        XCTAssertEqual(model.document?.sections[1].fields.map(\.key), ["access"])
+        XCTAssertEqual(model.document?.sections.count, 2, "the section survives its sibling")
+        XCTAssertNil(model.editingField)
+    }
+
+    func testASectionGoesWithItsLastField() {
+        let model = modelWithSections()
+        let scope = model.document!.sections[0]
+        model.beginFieldEdit(section: scope, field: scope.fields[0])
+        model.removeEditingField()
+
+        XCTAssertEqual(
+            model.document?.sections.map(\.key), ["site"],
+            "an empty heading is the one thing the operator cannot fix any other way"
+        )
+    }
+
+    func testTheTwoEditorsAreMutuallyExclusive() {
+        // Both sheets are bound to their own property; leaving the other set
+        // presents them on top of each other.
+        let model = modelWithSections()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        XCTAssertNil(model.editingRowID)
+
+        model.beginEdit(model.document!.rows[0])
+        XCTAssertNil(model.editingField)
+    }
+
     func testTheTotalFollowsEveryEdit() {
         let model = model()
         XCTAssertEqual(model.document?.totalValue, "$200")

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -172,11 +172,29 @@ pub(crate) async fn price_items(
     } else {
         format!("\n\nWhat you know about this user:\n{memory_prompt}")
     };
+    // R6 / CORE.md #4, stated as narrowly as it can be: a price comes from
+    // what THIS operator has charged, or it does not exist.
+    //
+    // The previous wording — "an item whose value you can reasonably infer
+    // from its text" — was a licence to price from general market knowledge,
+    // and it took it: on Isaac's own walk (2026-08-10) the operator stated
+    // four prices totalling $1,250 and the pass returned $3,300, having
+    // invented $750 for pruning, $750 for tomato plants and $1,250 for
+    // artichokes. Numbers he never said, on a document a client signs, in the
+    // product whose core promise is "unheard ≠ invented, ever".
+    //
+    // A gap is recoverable in five seconds — the operator taps it and types
+    // the number they already know. An invented price is recoverable only if
+    // somebody notices it, and the person best placed to notice is the client.
     let system = format!(
         "You price items from a field-work session for a tradesperson's estimate/invoice. \
-         Put a price only on an item whose value you can reasonably infer from its text and \
-         what you know about this user's pricing history — never guess wildly. You may price \
-         only items from the given list, by their exact item_id.{memory_block}"
+         Put a price on an item ONLY when this specific operator's own pricing history tells \
+         you what they charge for it. You have no other source of prices: you do not know this \
+         trade's going rate, this region's rates, or what these materials cost, and a plausible \
+         number is worse than no number — it is a commitment the operator never made, on a \
+         document their client may sign. Leave everything else unpriced; they will fill it in \
+         themselves in seconds. Omitting an item is always correct. You may price only items \
+         from the given list, by their exact item_id.{memory_block}"
     );
     let hint_block = spoken_total_cents
         .map(|cents| {
@@ -223,7 +241,14 @@ pub(crate) async fn price_items(
             };
             // First-wins dedup; unknown/hallucinated ids are dropped — never
             // fail the whole pass over one bad row.
-            if valid_ids.contains(id) && !map.contains_key(id) {
+            //
+            // Zero and negative are dropped too. A model that returns 0 has no
+            // price for that line, and rendering "$0" states a price to the
+            // client — Isaac's EST-0005 went out with a "$0" line on it. An
+            // honest gap says "this needs a number"; "$0" says "this is free",
+            // which is a commitment nobody made. An operator who really means
+            // no-charge can type it on the line.
+            if amount > 0 && valid_ids.contains(id) && !map.contains_key(id) {
                 map.insert(id.to_string(), amount);
             }
         }
@@ -2103,6 +2128,37 @@ mod tests {
             v["lines"][1]["is_gap"], true,
             "an unpriced deduction is an open question, not a free pass"
         );
+    }
+
+    /// "$0" on a client's estimate states a price nobody committed to.
+    #[tokio::test]
+    async fn a_zero_price_is_no_price_not_a_free_line() {
+        let (store, sid) =
+            processed_session_with_items(&[("todo", "mulch three beds"), ("todo", "prune")]);
+        let ids: Vec<String> =
+            store.list_items_for_session(&sid).unwrap().into_iter().map(|i| i.id).collect();
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![
+            tool_use(
+                "price_items",
+                serde_json::json!({"prices": [
+                    {"item_id": ids[0], "amount_cents": 30000},
+                    {"item_id": ids[1], "amount_cents": 0}
+                ]}),
+            ),
+            compose_response(serde_json::json!([]), serde_json::json!([])),
+        ]));
+        let b = builder(store.clone(), provider);
+
+        let outcome = b.build(&sid, "estimate").await.unwrap();
+        let v = decoded_document(&store, &outcome.document_artifact_id);
+        assert_eq!(v["lines"][0]["amount_cents"], 30000);
+        assert_eq!(
+            v["lines"][1]["amount_cents"],
+            serde_json::Value::Null,
+            "a zero is the model having no price — not a free line"
+        );
+        assert_eq!(v["lines"][1]["is_gap"], true, "so it stays an honest gap");
     }
 
     /// A flat output budget is a cliff for a pass that writes prose: the

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -30,6 +30,18 @@ pub(crate) fn extraction_system_prompt(memory_prompt: &str) -> String {
          guessed ones — one invented assignee or price costs more trust than three \
          missed todos. When unsure, skip it.\n\
          - Use add_item for todos, decisions, notes, safety issues, parts, prices.\n\
+         - An item is ONE PIECE OF WORK OR ONE MATERIAL, named the way it would \
+         appear as a line on paperwork: a short noun phrase. \"Mulch, three beds\", \
+         \"Weed and compost, three beds\", \"Ten pepper plants\", \"Prune five pear \
+         trees\". NOT a sentence about the job: not \"Juan is going to do the \
+         mulching\", not \"we should probably weed those beds first\".\n\
+         - WHO does the work is never an item. A person assigned to a task belongs \
+         in the notes (scope_of_work), not on a line of its own — a line reading \
+         \"Juan to do the mulching\" duplicates the work item it refers to and lands \
+         on a client's estimate. Same for WHEN it happens.\n\
+         - Site conditions and access details are never items either — gate codes, \
+         parking, dogs, working hours, hazards. They belong in the notes. An item is \
+         something the operator does or buys.\n\
          - Use upsert_contact for people mentioned with a role (sub, client, supplier).\n\
          - Call write_report at most once, and only if the session has enough \
          substance for a report worth sharing.\n\
@@ -185,6 +197,10 @@ pub(crate) fn live_extraction_system_prompt(memory_prompt: &str) -> String {
          transcript: when a thought is mid-sentence, cut off, or unclear, SKIP it — \
          the end-of-session pass is the source of truth and will catch it. Bias hard \
          toward fewer items.\n\
+         - An item is ONE PIECE OF WORK OR ONE MATERIAL, named as a short noun \
+         phrase, the way it would appear as a line on paperwork: \"Mulch, three \
+         beds\", \"Ten pepper plants\". Never a sentence about the job, never WHO is \
+         doing it, never a site or access detail.\n\
          - NEVER repeat anything under 'already captured'. When unsure whether it is \
          a duplicate, skip it.\n\
          - Never invent assignees, prices, dates, or details that were not spoken.\n\
@@ -211,6 +227,36 @@ mod tests {
         assert!(p.contains("at most once"), "report budget");
         assert!(p.contains("french drain"), "memory is injected");
         assert!(p.contains("update_memory"));
+    }
+
+    /// An item becomes a LINE on a client's estimate, so it has to be shaped
+    /// like one. Isaac's EST-0005 went out with "Juan to do mulching and
+    /// composting" as a priced line — an assignment sentence, duplicating the
+    /// mulch and compost lines above it, with a person's name on the copy the
+    /// client reads.
+    #[test]
+    fn both_extraction_prompts_ask_for_line_shaped_items() {
+        for p in [
+            extraction_system_prompt(""),
+            live_extraction_system_prompt(""),
+        ] {
+            assert!(p.contains("noun phrase"), "items must be shaped like lines");
+            assert!(
+                p.contains("ONE PIECE OF WORK OR ONE MATERIAL"),
+                "an item is labor or materials, not commentary"
+            );
+        }
+    }
+
+    /// Who does the work, and the site's own facts, have their own homes now
+    /// — an assignee column and the notes buckets. Left as items they become
+    /// duplicate lines on the paperwork.
+    #[test]
+    fn the_end_of_session_prompt_keeps_people_and_site_facts_off_the_lines() {
+        let p = extraction_system_prompt("");
+        assert!(p.contains("WHO does the work is never an item"));
+        assert!(p.contains("scope_of_work"), "it says where they go instead");
+        assert!(p.contains("gate codes"), "site and access details are named");
     }
 
     #[test]

--- a/crates/murmur-core/src/pipeline/tools.rs
+++ b/crates/murmur-core/src/pipeline/tools.rs
@@ -107,7 +107,7 @@ impl Tool for AddItemTool {
     }
 
     fn description(&self) -> &str {
-        "Record one clearly-stated item from the session. Only extract what was actually said — fewer, confident items beat many guessed ones. Never invent assignees, prices, or dates."
+        "Record ONE piece of work or ONE material from the session, named as a short noun phrase the way it would read as a line on paperwork (\"Mulch, three beds\", \"Ten pepper plants\"). Not a sentence about the job, not who is doing it, not a site or access detail. Only what was actually said — fewer, confident items beat many guessed ones. Never invent assignees, prices, or dates."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -117,7 +117,11 @@ impl Tool for AddItemTool {
                 // Built from the shared const (Plan 16 Task 2) — the advertised
                 // enum can never drift from the `execute` validation below.
                 "kind": { "type": "string", "enum": VALID_ITEM_KINDS, "minLength": 1 },
-                "text": { "type": "string", "minLength": 1, "description": "one short item, in the speaker's own terms" }
+                // "in the speaker's own terms" still governs the WORDS — their
+                // trade vocabulary, never ours. What changed on 2026-08-10 is
+                // the FORM: a line on a client's estimate is a noun phrase, and
+                // "Juan to do the mulching" was reaching one (Isaac's EST-0005).
+                "text": { "type": "string", "minLength": 1, "description": "one piece of work or one material, as a short noun phrase in the speaker's own trade words — \"Mulch, three beds\", not \"Juan is going to mulch the beds\"" }
             },
             "required": ["kind", "text"]
         })

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -92,6 +92,53 @@ pub(crate) fn seed_schemas(conn: &Connection, schemas: &[DocumentSchema]) -> Res
                 schema.device_id,
             ],
         )?;
+        // ...and UPGRADE a row that is still the seeded one.
+        //
+        // Insert-if-absent alone is a trap, and it sprang on 2026-08-09: the
+        // built-in ids are fixed constants, so once a device has seeded them
+        // ONE TIME, no later app version can ever change what those documents
+        // are. The release that gave every built-in its authored sections
+        // shipped to a device that already had the old rows and changed
+        // nothing at all — no scope paragraph, no line details, no AMOUNT DUE,
+        // because the schema the builder resolved was still the one from the
+        // previous version. Every test had used a fresh store, where the
+        // INSERT fires and everything works.
+        //
+        // Two things this must not touch, hence the WHERE clause:
+        //
+        // - `deleted_at IS NULL` — a built-in the operator deliberately
+        //   deleted stays deleted. Resurrecting it on every launch would make
+        //   the delete button a no-op (pinned by
+        //   `tombstoned_builtin_survives_a_fresh_seed_call`).
+        // - `device_id = 'builtin' AND updated_at = 0` — the two fixed
+        //   literals `builtin_schema()` stamps and nothing else writes. Any
+        //   operator save bumps `updated_at` to a real clock, so an edited
+        //   built-in stops matching and keeps their version. Their edit
+        //   outranks our update, always: silently reverting somebody's
+        //   customized document type on an app update is worse than leaving
+        //   them on an out-of-date one. (Both conditions, because they fail
+        //   independently — `save_document_schema`'s UPDATE path bumps the
+        //   clock without restamping the device.)
+        //
+        // The update deliberately does NOT bump `updated_at`: an upgraded row
+        // is still a seeded row, and must stay eligible for the next upgrade.
+        conn.execute(
+            "UPDATE document_schemas
+                SET kind = ?2, label = ?3, number_prefix = ?4, trade_key = ?5,
+                    sections = ?6, schema_version = ?7
+              WHERE id = ?1 AND deleted_at IS NULL AND device_id = ?8
+                AND updated_at = 0",
+            rusqlite::params![
+                schema.id,
+                schema.kind,
+                schema.label,
+                schema.number_prefix,
+                schema.trade_key,
+                sections,
+                schema.schema_version as i64,
+                schema.device_id,
+            ],
+        )?;
     }
     Ok(())
 }
@@ -455,6 +502,78 @@ mod tests {
                 b.kind
             );
         }
+    }
+
+    /// The app-update path, and the defect that shipped on 2026-08-09.
+    ///
+    /// Built-in ids are fixed constants, so insert-if-absent means a device
+    /// that seeded them once can NEVER receive a changed built-in. The release
+    /// that gave every built-in its authored sections landed on an existing
+    /// install and changed nothing: the estimate still had no scope section,
+    /// so the compose pass never ran and the document came out exactly as
+    /// before. Every test used a fresh store, where the INSERT fires.
+    #[test]
+    fn an_app_update_upgrades_the_seeded_builtins_in_place() {
+        let s = Store::open_in_memory("device-a").unwrap();
+        // Simulate the PREVIOUS version's row: no authored sections, no
+        // line_detail — exactly what a device seeded before the update holds.
+        let stale = DocumentSchema {
+            sections: vec![SchemaSection {
+                key: "line_items".into(),
+                kind: "line_items".into(),
+                label: "Items".into(),
+                priced: true,
+                line_detail: String::new(),
+                fields: vec![],
+            }],
+            label: "Old Estimate".into(),
+            ..crate::domain::builtin_schemas()
+                .into_iter()
+                .find(|b| b.id == BUILTIN_SCHEMA_ID_ESTIMATE)
+                .unwrap()
+        };
+        s.conn
+            .execute(
+                "UPDATE document_schemas SET sections = ?2, label = ?3 WHERE id = ?1",
+                rusqlite::params![
+                    BUILTIN_SCHEMA_ID_ESTIMATE,
+                    envelope_json(&stale).unwrap(),
+                    stale.label
+                ],
+            )
+            .unwrap();
+
+        seed_builtin_schemas(&s.conn).unwrap();
+
+        let fresh = s.get_document_schema(BUILTIN_SCHEMA_ID_ESTIMATE).unwrap();
+        assert_eq!(fresh.label, "Estimate", "the label caught up");
+        let line_items = fresh.sections.iter().find(|x| x.kind == "line_items").unwrap();
+        assert_eq!(line_items.line_detail, "inclusion", "the lines learned what to say");
+        assert!(
+            fresh.sections.iter().any(|x| x.key == "scope"),
+            "the scope section arrived — without this the compose pass never runs"
+        );
+        let count: i64 =
+            s.conn.query_row("SELECT COUNT(*) FROM document_schemas", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 7, "upgraded in place, not duplicated");
+    }
+
+    /// The other half: an operator who customized a built-in keeps their
+    /// version. Silently reverting somebody's edited document type on an app
+    /// update is worse than leaving them on an out-of-date one.
+    #[test]
+    fn an_operator_edited_builtin_is_never_overwritten_by_a_seed() {
+        let s = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(|| 1000));
+        let mut edited = s.get_document_schema(BUILTIN_SCHEMA_ID_ESTIMATE).unwrap();
+        edited.label = "My Estimate".into();
+        edited.number_prefix = "QUO".into();
+        s.save_document_schema(&edited).unwrap();
+
+        seed_builtin_schemas(&s.conn).unwrap();
+
+        let after = s.get_document_schema(BUILTIN_SCHEMA_ID_ESTIMATE).unwrap();
+        assert_eq!(after.label, "My Estimate", "their edit outranks our update");
+        assert_eq!(after.number_prefix, "QUO");
     }
 
     /// WE-A core — the guard exercised the way every real launch exercises it.

--- a/crates/murmur-core/tests/document_smoke.rs
+++ b/crates/murmur-core/tests/document_smoke.rs
@@ -48,6 +48,81 @@ impl MemoryStore for NullMemoryStore {
     }
 }
 
+/// Isaac's own EST-0005 walk, verbatim in shape: he names people against
+/// tasks and rattles off materials. The line titles are what this pins —
+/// that build produced "Juan to do mulching and composting" as a priced
+/// line on a client's estimate.
+const ESTIMATE_TRANSCRIPT: &str = "Alright, three beds here. We're going to weed them, \
+compost them, and mulch them, get them ready for planting. Ten peppers, ten tomatoes, \
+five artichokes going into those beds. Juan is going to do the mulching and the \
+composting. Christos is going to prune the five pear trees in the backyard. Two hundred \
+for the weeding and compost, three hundred for the mulch, two fifty for the plants, and \
+five hundred labor.";
+
+#[tokio::test]
+#[ignore = "hits the real API; set ANTHROPIC_API_KEY and run with --ignored"]
+async fn a_real_estimates_lines_read_like_line_items() {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .expect("set ANTHROPIC_API_KEY to run the real-provider document smoke test");
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, MODEL));
+
+    let store = Store::open_in_memory("smoke-device").unwrap();
+    let session = store.start_session_with_template(None, "landscape").unwrap();
+    store.append_transcript(&session.id, ESTIMATE_TRANSCRIPT).unwrap();
+    store.end_and_record_session(&session.id).unwrap();
+    let store = Arc::new(Mutex::new(store));
+
+    SessionProcessor::new(
+        provider.clone(),
+        store.clone(),
+        Arc::new(Mutex::new(Memory::default())),
+        Arc::new(NullMemoryStore),
+    )
+    .process(&session.id)
+    .await
+    .expect("processing failed");
+
+    let builder = DocumentBuilder::new(
+        provider,
+        store.clone(),
+        Arc::new(Mutex::new(Memory::default())),
+        Arc::new(NullMemoryStore),
+    );
+    let outcome = builder.build(&session.id, "estimate").await.expect("build failed");
+
+    let guard = store.lock().unwrap();
+    let artifact = guard.get_artifact(&outcome.document_artifact_id).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&artifact.body).unwrap();
+
+    println!("\n===== ESTIMATE =====");
+    for field in doc["fields"].as_array().unwrap() {
+        println!("[{}] {}", field["label"].as_str().unwrap_or(""), field["value"].as_str().unwrap_or("—— (gap)"));
+    }
+    for line in doc["lines"].as_array().unwrap() {
+        println!(
+            "  {:<52} {}",
+            line["title"].as_str().unwrap_or(""),
+            line["amount_cents"]
+        );
+    }
+    println!("====================\n");
+
+    for line in doc["lines"].as_array().unwrap() {
+        let title = line["title"].as_str().unwrap();
+        // A person's name on a line means an assignment sentence became a
+        // line item — the EST-0005 defect.
+        for name in ["Juan", "Christos"] {
+            assert!(
+                !title.contains(name),
+                "an assignment sentence became a line item: {title:?}"
+            );
+        }
+        assert!(!title.contains(" to "), "a line reads as a sentence: {title:?}");
+        // "$0" on a client's estimate states a price nobody committed to.
+        assert_ne!(line["amount_cents"], serde_json::json!(0), "a zero-dollar line: {title:?}");
+    }
+}
+
 #[tokio::test]
 #[ignore = "hits the real API; set ANTHROPIC_API_KEY and run with --ignored"]
 async fn real_walk_becomes_a_work_order() {

--- a/crates/murmur-core/tests/document_smoke.rs
+++ b/crates/murmur-core/tests/document_smoke.rs
@@ -26,7 +26,19 @@ use std::sync::{Arc, Mutex};
 use harness::{AnthropicProvider, HarnessError, Memory, MemoryStore};
 use murmur_core::{DocumentBuilder, SessionProcessor, Store};
 
-const MODEL: &str = "claude-haiku-4-5";
+/// The model under test, defaulting to the one the SHIPPED app builds
+/// documents with — `EngineResolution.modelProcessing` → `providers.processing`
+/// → `DocumentBuilder`.
+///
+/// It defaults to the real thing on purpose, and the purpose was learned the
+/// hard way: this test first ran on haiku (cheaper, and the sibling smoke
+/// test's choice) and reported a pricing failure that was then quoted as
+/// production behaviour. Sonnet failed differently and by a different amount.
+/// A smoke test pointed at a model nobody ships tells you about that model.
+/// Override with `SMOKE_MODEL=` when you specifically want to compare.
+fn model() -> String {
+    std::env::var("SMOKE_MODEL").unwrap_or_else(|_| "claude-sonnet-4-5".to_string())
+}
 
 /// A walk that names people against tasks — the thing Isaac asked for, and
 /// the case a mock cannot evaluate.
@@ -64,7 +76,7 @@ five hundred labor.";
 async fn a_real_estimates_lines_read_like_line_items() {
     let api_key = std::env::var("ANTHROPIC_API_KEY")
         .expect("set ANTHROPIC_API_KEY to run the real-provider document smoke test");
-    let provider = Arc::new(AnthropicProvider::from_env(api_key, MODEL));
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, model()));
 
     let store = Store::open_in_memory("smoke-device").unwrap();
     let session = store.start_session_with_template(None, "landscape").unwrap();
@@ -128,7 +140,7 @@ async fn a_real_estimates_lines_read_like_line_items() {
 async fn real_walk_becomes_a_work_order() {
     let api_key = std::env::var("ANTHROPIC_API_KEY")
         .expect("set ANTHROPIC_API_KEY to run the real-provider document smoke test");
-    let provider = Arc::new(AnthropicProvider::from_env(api_key, MODEL));
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, model()));
 
     let store = Store::open_in_memory("smoke-device").unwrap();
     let session = store.start_session_with_template(None, "landscape").unwrap();


### PR DESCRIPTION
Isaac on EST-0005: *"the individual line items should be more direct. Instead of saying 'Juan to mulch the beds' it should be 'Mulching for the beds' … Everything should just be a short descriptive thing of either the labor or the materials."*

That estimate went out with **"Juan to do mulching and composting"** and **"Christos to prune five pear trees in the backyard"** as line items — assignment sentences, duplicating the mulch and compost lines directly above them, with the crew's names on the copy the client reads. One of them priced **"$0"**.

## Thinking

### The titles are `item.text`, so this is an extraction fix

`render_lines` sets `title: item.text` verbatim, by design — the deterministic render has no opinion about wording. So a line reads however extraction phrased it, and extraction was asked for "one short item, in the speaker's own terms", which faithfully produces "Juan is going to do the mulching" when that is what was said.

An item is now defined as **one piece of work or one material, named as a short noun phrase the way it reads on paperwork**. Two exclusions are called out explicitly because they were the actual defects:

- **WHO does it is not an item.** That has an assignee column now, and the notes' `scope_of_work` bucket. Left as an item it becomes a duplicate line with a person's name on the client's copy.
- **Site and access facts are not items.** Gate codes, parking, dogs, hours, hazards. This is the same fix as the work-order junk lines I flagged on #320 — they belong in the notes, which is where the compose pass already reads them from.

"In the speaker's own terms" still governs the WORDS — their trade vocabulary, never ours. What changed is the FORM.

### A zero is not a price

`price_items` now drops `amount_cents <= 0`. A model returning 0 has no price for that line; rendering "$0" **states** one, and "this is free" is a commitment nobody made. An honest gap says "this needs a number". An operator who really means no-charge can type it.

### And a price is never invented

This is the one worth your attention. The pricing prompt said to price anything *"whose value you can reasonably infer from its text"* — a licence to price from general market knowledge, which it duly took.

On the same walk, the operator stated four prices totalling **$1,250**. The pass returned **$3,300**: it invented $750 for pruning, $750 for tomato plants, and $1,250 for artichokes. Numbers he never said, on a document a client signs, in the product whose stated core rule is *"Honest gaps, never confident guesses… Unheard ≠ invented. Ever."* (CORE.md #4).

My phrasing change made it more visible — splitting "the plants" into three lines gave the pass three more blanks to fill — but the licence was always there.

A price now comes from **this operator's own pricing history or it does not exist**. Everything else is a gap. The asymmetry is the whole argument: a gap is recoverable in five seconds by the person who knows the number, while an invented price is recoverable only if somebody notices, and the person best placed to notice is the client.

I'd flag this as the code catching up to the documented rule rather than new policy — but it does make estimates **deliberately gappier**, and that is a product call worth confirming.

## Real-API before/after, same transcript

```
before: Juan to do mulching and composting        $0
        Christos to prune five pear trees…        ——
        (total $3,300 — three invented prices)

after:  Weed and compost, three beds            $200
        Mulch, three beds                       $300
        Prune five pear trees                     ——
        Ten pepper plants                       $250
        Ten tomato plants                         ——
        Five artichoke plants                     ——
        Labor                                   $500
        (total $1,250 — exactly what he said)
```

## Testing

- 539 Rust tests, clippy clean, 151 iOS tests.
- `document_smoke.rs` gains Isaac's walk as a real-API case, asserting what can be asserted: no person's name in a title, no sentence-shaped line, no zero-dollar line.
- Three real-API runs end to end.

## For dam

This touches the extraction prompt and the pricing prompt, both yours. The eval corpus grades extraction *content*, not item phrasing, so the hermetic graders are unaffected — but a real eval run will shift, and the gappier pricing is the call I'd most like you to sanity-check.