### PR TITLE
fix: match the grain of the operator's pricing, and stop the total leaking onto a line

### DIFF
--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -196,10 +196,25 @@ pub(crate) async fn price_items(
          themselves in seconds. Omitting an item is always correct. You may price only items \
          from the given list, by their exact item_id.{memory_block}"
     );
+    // The total is a CEILING TO CHECK AGAINST, never a budget to allocate.
+    //
+    // It used to say "allocate line prices consistent with this", which is an
+    // instruction to invent: on Isaac's walk (2026-08-10) the operator stated
+    // four line prices summing to $1,250 and the pass put $1,250 — the whole
+    // total — on "Prune five pear trees", a line he never priced. It defeated
+    // the narrowed rule above single-handedly, because the rule says where
+    // prices come from and this sentence said to make some up.
+    //
+    // A stated total is still worth sending: it catches a line priced far
+    // beyond what the whole job was quoted at. It just must not become a pot
+    // to distribute.
     let hint_block = spoken_total_cents
         .map(|cents| {
             format!(
-                "\n\nOperator's stated target total: ${:.2} — allocate line prices consistent with this.",
+                "\n\nThe operator quoted ${:.2} for the whole job. Use this ONLY as a \
+                 sanity check on prices you already have grounds for — never as a budget to \
+                 distribute across the lines, and never as a reason to price a line you would \
+                 otherwise leave alone.",
                 cents as f64 / 100.0
             )
         })
@@ -788,7 +803,24 @@ impl DocumentBuilder {
             .cloned()
             .collect();
         if priced && !unpriced.is_empty() {
-            let hint = self.session_spoken_total(session_id)?;
+            // The stated grand total is deliberately NOT sent (Plan 13 D5a's
+            // hint, retired 2026-08-10). Its only job was allocation — "spread
+            // line prices consistent with this" — and allocation is exactly
+            // the invention Isaac ruled out: *"the prices should only get
+            // filled in if it's spoken by the user or we have the price the
+            // user has used in the past."*
+            //
+            // Rewording it to "sanity check only" was not enough: across four
+            // real runs of the same walk it still put the entire $1,250 total
+            // onto a line the operator never priced, once. A number that wrong
+            // on a client's estimate one time in four is not a hint, and no
+            // prompt sentence outranks a number sitting in the context.
+            //
+            // The capture itself stays (`session_spoken_total` /
+            // `session_meta`): it is honest data, and a future ceiling check —
+            // "this line alone exceeds the whole quoted job" — is a real use
+            // that does not create prices.
+            let hint = None;
             let memory_prompt = self
                 .memory
                 .lock()
@@ -899,6 +931,13 @@ impl DocumentBuilder {
     /// on success and returns its `spoken_total_cents` scalar. `None` when no
     /// meta artifact exists, or it exists but the field is absent (no total
     /// was clearly stated, R6).
+    ///
+    /// Caller-less since the pricing hint was retired (2026-08-10) — kept, not
+    /// deleted, because the CAPTURE is still live: `process()` writes the
+    /// artifact, and reading it back is the seam a future ceiling check would
+    /// use ("this one line exceeds the whole quoted job"). That is a real use
+    /// that does not create prices, unlike the hint that was removed.
+    #[allow(dead_code)]
     fn session_spoken_total(&self, session_id: &str) -> Result<Option<i64>, CoreError> {
         let artifacts = self.locked()?.list_artifacts_for_session(session_id)?;
         let meta: Option<&Artifact> = artifacts.iter().rev().find(|a| a.kind == "session_meta");
@@ -1416,19 +1455,33 @@ mod tests {
         assert!(docs.is_empty(), "empty walk must not persist a document artifact");
     }
 
+    /// The stated grand total never reaches the pricing prompt (Plan 13 D5a's
+    /// hint, retired 2026-08-10 — see the call site). It was an instruction to
+    /// allocate, and allocation is invention: across four real runs of the
+    /// same walk it put the operator's whole $1,250 quote onto a line he never
+    /// priced, once. The capture itself is untouched and still readable.
     #[tokio::test]
-    async fn build_threads_the_spoken_total_hint_and_absence_when_no_meta_artifact() {
-        let (store, sid) = processed_session_with_items(&[("todo", "mulch"), ("safety", "loose railing")]);
+    async fn the_stated_total_never_reaches_the_pricing_prompt() {
+        let (store, sid) =
+            processed_session_with_items(&[("todo", "mulch"), ("safety", "loose railing")]);
         let a1 = store.list_items_for_session(&sid).unwrap()[0].id.clone();
         store
-            .add_artifact(&sid, "session_meta", "meta", &serde_json::json!({"spoken_total_cents": 120000}).to_string())
+            .add_artifact(
+                &sid,
+                "session_meta",
+                "meta",
+                &serde_json::json!({"spoken_total_cents": 120000}).to_string(),
+            )
             .unwrap();
         let store = Arc::new(Mutex::new(store));
 
-        let provider = Arc::new(MockProvider::new(vec![tool_use(
-            "price_items",
-            serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 95000}]}),
-        )]));
+        let provider = Arc::new(MockProvider::new(vec![
+            tool_use(
+                "price_items",
+                serde_json::json!({"prices": [{"item_id": a1, "amount_cents": 95000}]}),
+            ),
+            compose_response(serde_json::json!([]), serde_json::json!([])),
+        ]));
         let b = builder(store.clone(), provider.clone());
         b.build(&sid, "estimate").await.unwrap();
 
@@ -1436,23 +1489,19 @@ mod tests {
         let ContentBlock::Text { text } = &reqs[0].messages[0].content[0] else {
             panic!("expected text content");
         };
-        assert!(text.contains("1200.00"), "the spoken total hint reaches the pricing prompt: {text}");
+        assert!(!text.contains("1200.00"), "the total must not reach the pricing prompt: {text}");
+        assert!(!text.to_lowercase().contains("total"), "nor any framing of it: {text}");
 
-        // A session with no session_meta artifact gets no hint line at all.
-        let (store2, sid2) = processed_session_with_items(&[("todo", "haul")]);
-        let a2 = store2.list_items_for_session(&sid2).unwrap()[0].id.clone();
-        let store2 = Arc::new(Mutex::new(store2));
-        let provider2 = Arc::new(MockProvider::new(vec![tool_use(
-            "price_items",
-            serde_json::json!({"prices": [{"item_id": a2, "amount_cents": 5000}]}),
-        )]));
-        let b2 = builder(store2, provider2.clone());
-        b2.build(&sid2, "estimate").await.unwrap();
-        let reqs2 = provider2.requests();
-        let ContentBlock::Text { text: text2 } = &reqs2[0].messages[0].content[0] else {
-            panic!("expected text content");
-        };
-        assert!(!text2.contains("stated target total"), "no hint line without a meta artifact: {text2}");
+        // The capture still works — it is honest data, and a future ceiling
+        // check is a real use that does not create prices.
+        let guard = store.lock().unwrap();
+        let meta = guard
+            .list_artifacts_for_session(&sid)
+            .unwrap()
+            .into_iter()
+            .find(|a| a.kind == "session_meta")
+            .expect("the artifact is still written");
+        assert!(meta.body.contains("120000"));
     }
 
     // ---- Plan 19 Stage 4: schema-driven build (launch-safety) -----------

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -32,9 +32,22 @@ pub(crate) fn extraction_system_prompt(memory_prompt: &str) -> String {
          - Use add_item for todos, decisions, notes, safety issues, parts, prices.\n\
          - An item is ONE PIECE OF WORK OR ONE MATERIAL, named the way it would \
          appear as a line on paperwork: a short noun phrase. \"Mulch, three beds\", \
-         \"Weed and compost, three beds\", \"Ten pepper plants\", \"Prune five pear \
-         trees\". NOT a sentence about the job: not \"Juan is going to do the \
-         mulching\", not \"we should probably weed those beds first\".\n\
+         \"Weed and compost, three beds\", \"Prune five pear trees\". NOT a sentence \
+         about the job: not \"Juan is going to do the mulching\", not \"we should \
+         probably weed those beds first\".\n\
+         - Group what the operator groups. If they name several things together and \
+         give them ONE price — \"ten peppers, ten tomatoes and five artichokes… two \
+         fifty for the plants\" — that is ONE item (\"Plants: 10 peppers, 10 \
+         tomatoes, 5 artichokes\"), not three. Splitting it puts their one price on \
+         one line and leaves the others blank, which is worse paperwork than the way \
+         they said it. Match the grain of their pricing.\n\
+         - ALWAYS KEEP A SPOKEN AMOUNT IN THE TEXT, exactly as a figure: \"$200 \
+         weeding and compost\", \"$500 labor\". This is the one place the noun-phrase \
+         rule does not shorten anything — the amount is the whole content of that \
+         item, and a later step reads the figure out of the text and attaches it to \
+         the work it names. An item that drops the number loses the price entirely: \
+         nothing downstream can recover it, and the operator's own stated price never \
+         reaches their estimate.\n\
          - WHO does the work is never an item. A person assigned to a task belongs \
          in the notes (scope_of_work), not on a line of its own — a line reading \
          \"Juan to do the mulching\" duplicates the work item it refers to and lands \


### PR DESCRIPTION
Isaac: *"why is it not accurate now? It was before"* — and, separately, the rule he wants: *"the prices should only get filled in if it's spoken by the user or we have the price the user has used in the past."*

He was right, and the cause was #322's own line-item fix. Three defects, all downstream of it.

## Thinking

### I over-split his lines

He prices a group with one number: *"ten peppers, ten tomatoes and five artichokes… two fifty for the plants."* The OLD extraction kept that as one item, so his one price landed on it cleanly — which is why his estimates were accurate before. My noun-phrase rule split it into three items, so $250 covered one line and **manufactured two blanks that never existed**. Those blanks are what the pricing pass then filled with invented numbers.

The rule now says to match the grain of the pricing: what the operator prices as one thing is one item. `Plants: 10 peppers, 10 tomatoes, 5 artichokes — $250`.

### The noun-phrase rule was deleting his prices

Worse, and only visible by running it repeatedly. "$200 for the weeding and compost" became the item **"Weeding and compost"** — the shortening rule stripped the figure. But the spoken-price fold (#319) works by parsing that figure out of the item text, so no figure means no price, and the narrowed pricing pass correctly refuses to invent one.

One run in three produced **an estimate with no prices at all**, plus duplicate lines the fold could no longer recognize and remove. A spoken amount now always stays in the text as a figure — the one place the shortening rule explicitly does not apply.

This is the clearest argument for the real-API test existing: three consecutive runs gave three different documents, and the worst one only appeared on the third.

### The stated total was a budget to allocate

Plan 13 D5a hands the operator's spoken grand total to the pricing pass with *"allocate line prices consistent with this"* — which is an instruction to invent, and directly contrary to the rule Isaac stated.

I first tried rewording it to "sanity check only, never a budget". **Not enough**: across four real runs of the same walk it still put the entire $1,250 quote onto a line he never priced, once. No prompt sentence outranks a number sitting in the context, so the hint is no longer sent at all.

The capture stays untouched — `process()` still writes it, and reading it back is the seam for a future *ceiling* check ("this one line exceeds the whole quoted job"), which is a real use that does not create prices.

## Result

Same walk, same shipped model (`claude-sonnet-4-5`), **five consecutive runs, identical**, every price one he actually spoke:

```
Weeding and compost, three beds                 $200
Mulch, three beds                               $300
Plants: 10 peppers, 10 tomatoes, 5 artichokes   $250
Prune five pear trees                             ——
Labor                                           $500
                                              $1,250   ← exactly what he said
```

## Testing

- 539 Rust tests, clippy clean, 151 iOS tests.
- Twelve real-API runs across the diagnosis and the fix.
- The retired hint is pinned by its inverse: the total must not reach the pricing prompt, and the artifact must still be written.

## For dam

Retiring the D5a hint is your call to overturn — I removed it because it is the only remaining path by which a price can be invented, and it demonstrably fired 1-in-4. The capture and its reader are intact and documented for a ceiling check.