### PR TITLE
fix: an estimate carries only what an estimate needs

### DIFF
--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -368,27 +368,48 @@ fn line_brief(line_detail: &str) -> Option<String> {
          a document that pads is one a reader stops trusting. Never restate the title in other \
          words. Write only where you are ADDING something the title does not say.";
 
+    // Two things a second line must never contain, whatever the document.
+    //
+    // MONEY, because the amount has its own column two inches to the right.
+    // A figure here can only repeat it or contradict it, and on Isaac's
+    // estimate (2026-08-10) it did both: "$200 material" under a $200 line,
+    // and — worse — "William on weed whacker, $200 labor plus $10 gas" printed
+    // against an amount of $10. A client reading that cannot tell what the
+    // line costs, which is the one thing a line exists to say.
+    const NO_MONEY: &str = " NEVER write a price, a rate, or any dollar figure. The amount has \
+         its own column beside this text; a figure here either repeats it or contradicts it. A \
+         work order carries no money at all.";
+
+    // WHO, because that is a work-order fact. Isaac: *"I don't want them to
+    // include names of the laborers in the report, that should only be
+    // included in work orders."* A client is buying an outcome and does not
+    // need the crew list; the work order has an assignee column for exactly
+    // this, and putting names on the client's copy is how a private staffing
+    // decision becomes something to negotiate about.
+    const NO_CREW: &str = " NEVER name the person doing the work — that belongs on a work \
+         order, not on this document.";
+
     let brief = match line_detail {
-        "inclusion" => {
-            "For each line, write what that line COVERS — quantity, material, and what is \
-             included in its price (delivered? hauled away? how many coats?). A short phrase, \
-             not a sentence. It is read by a client deciding whether the number beside it is \
-             fair, so it must justify the number without repeating it."
-        }
-        "directive" => {
+        "inclusion" => format!(
+            "For each line, write only what a client needs in order to judge the number beside \
+             it: what the line covers and what is included in it (delivered? hauled away? how \
+             many coats? what area?). A short phrase, not a sentence, and only where it is not \
+             already obvious from the title.{NO_MONEY}{NO_CREW}"
+        ),
+        "directive" => format!(
             "This is a WORK ORDER: the crew reads it, standing at the site, to do the job \
              without calling anyone. For each line write ONLY what the title does not already \
              tell them — the order to work in, the technique, the thing to watch out for, the \
              spec to match. One short imperative sentence, in trade language. Where the \
-             operator named a person for a line, set `assignee` to that name exactly as \
-             spoken; a line nobody was named for gets no assignee."
-        }
-        "observation" => {
+             operator named a person for a line, set `assignee` to that name exactly as spoken \
+             (NOT in the text) — a line nobody was named for gets no assignee.{NO_MONEY}"
+        ),
+        "observation" => format!(
             "For each line, write what was actually OBSERVED — where it is, how bad, how much, \
              what condition. One or two short phrases. This is a record that may be read months \
              from now by someone who was not there (a tenant disputing a deduction, a buyer, an \
-             adjuster), so specifics beat adjectives."
-        }
+             adjuster), so specifics beat adjectives.{NO_MONEY}{NO_CREW}"
+        ),
         _ => return None,
     };
     Some(format!("{brief}{NOTHING_TO_ADD}"))

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -41,13 +41,22 @@ pub(crate) fn extraction_system_prompt(memory_prompt: &str) -> String {
          tomatoes, 5 artichokes\"), not three. Splitting it puts their one price on \
          one line and leaves the others blank, which is worse paperwork than the way \
          they said it. Match the grain of their pricing.\n\
-         - ALWAYS KEEP A SPOKEN AMOUNT IN THE TEXT, exactly as a figure: \"$200 \
-         weeding and compost\", \"$500 labor\". This is the one place the noun-phrase \
-         rule does not shorten anything — the amount is the whole content of that \
-         item, and a later step reads the figure out of the text and attaches it to \
-         the work it names. An item that drops the number loses the price entirely: \
-         nothing downstream can recover it, and the operator's own stated price never \
-         reaches their estimate.\n\
+         - When the operator states a PRICE, record it as its own item with the \
+         figure kept exactly as spoken: \"$200 weeding and compost\", \"$500 labor\", \
+         \"$300 flagstone\". This is the one place the noun-phrase rule does not \
+         shorten anything — the amount is the whole content of that item, and a later \
+         step reads the figure out and attaches it to the work it names. An item that \
+         drops the number loses the price entirely; nothing downstream can recover it.\n\
+         - But a WORK or MATERIAL item never carries a price in its own title. \
+         \"Poison oak removal\" — not \"Poison oak removal, $200 regular + $100 hazard \
+         pay\". The money is a separate price item; the work item is just the work, or \
+         the amount ends up printed twice on the paperwork, once in the description \
+         and once in the amount column.\n\
+         - A material the operator names IS an item, even when they mention it only \
+         while pricing it. \"Three hundred for the flagstone, two hundred for the \
+         gravel\" names two materials: record \"Flagstone\" and \"Gravel\" as items \
+         alongside the two price items, or their prices have no line to land on and \
+         attach themselves to whatever else happens to mention that word.\n\
          - WHO does the work is never an item. A person assigned to a task belongs \
          in the notes (scope_of_work), not on a line of its own — a line reading \
          \"Juan to do the mulching\" duplicates the work item it refers to and lands \

--- a/crates/murmur-core/src/pipeline/spoken_price.rs
+++ b/crates/murmur-core/src/pipeline/spoken_price.rs
@@ -115,6 +115,28 @@ pub(crate) fn fold_spoken_prices(items: &[CapturedItem]) -> FoldedPrices {
             Reading::SelfPriced { cents, title } => {
                 amounts.insert(items[index].id.clone(), *cents);
                 titles.insert(items[index].id.clone(), title.clone());
+                // A self-priced line that fully COVERS a bare line already on
+                // the board absorbs it.
+                //
+                // Isaac's flagstone estimate (2026-08-10) had the pair:
+                // "Poison oak removal" (no price) sitting orphaned directly
+                // above "Regular poison oak removal — $200". Extraction is
+                // asked for both the work and the price, and the fold merges
+                // them — except this price's label ran to four words, so it
+                // read as a line item in its own right rather than a price
+                // statement, and no merge happened. The client sees the same
+                // job twice, once with a gap.
+                //
+                // Only when the bare line adds NOTHING the priced one lacks
+                // (every one of its words is already there), and the RICHER
+                // title survives — so "5 yards of mulch installed, $450"
+                // absorbing a bare "Mulch" keeps the yards and the installed.
+                if let Some(covered) =
+                    fully_covered_by(&tokenize(title), items, &readings, &claimed)
+                {
+                    claimed.insert(covered);
+                    folded_away.insert(items[covered].id.clone());
+                }
             }
             Reading::Statement { cents, title, label_tokens } => {
                 match target_for(label_tokens, items, &readings, &claimed) {
@@ -149,14 +171,23 @@ pub(crate) fn fold_spoken_prices(items: &[CapturedItem]) -> FoldedPrices {
 }
 
 /// The item a price statement belongs to: the FIRST unclaimed work line that
-/// shares a content word with the price's label.
+/// shares a content word with the price's label — and, among those, the line
+/// the price is most ABOUT.
 ///
-/// First rather than best-scoring, on purpose. Items are in spoken order, and
-/// a tradesperson pricing a walk goes down the list in the order they walked
-/// it; when two lines both say "mulch", the earlier one is the one being
-/// priced. A similarity score would be more clever and less predictable, and
-/// the failure it buys — the price on the wrong mulch line — is invisible on
-/// the finished paper.
+/// This was "the first line that shares a word", earliest-wins, on the theory
+/// that items are in spoken order and the earlier mention is the intended one.
+/// Isaac's estimate (2026-08-10) is the counter-example: he said "three
+/// hundred for the flagstone", and the earliest line mentioning flagstone was
+/// **"Grade and weed path area for flagstones"** — a prep task that merely
+/// referred to the material. His $300 for stone landed on grading, and the
+/// stone itself had no price at all.
+///
+/// So: score each candidate by how much of it the label accounts for
+/// (shared tokens ÷ the line's own tokens). "Flagstone" is the whole of a line
+/// called "Flagstone" (1.0) and one word in six of "Grade and weed path area
+/// for flagstones" (0.17). The most-about line wins; spoken order breaks ties,
+/// which preserves the old behaviour exactly whenever candidates are equally
+/// about the thing (two lines both simply called "mulch").
 fn target_for(
     label_tokens: &[String],
     items: &[CapturedItem],
@@ -167,11 +198,52 @@ fn target_for(
         return None;
     }
     let wanted: HashSet<&str> = label_tokens.iter().map(String::as_str).collect();
+    let mut best: Option<(usize, f64)> = None;
+    for (index, item) in items.iter().enumerate() {
+        if claimed.contains(&index) || !matches!(readings[index], Reading::Plain) {
+            continue;
+        }
+        let tokens = tokenize(&item.text);
+        if tokens.is_empty() {
+            continue;
+        }
+        let shared = tokens.iter().filter(|t| wanted.contains(t.as_str())).count();
+        if shared == 0 {
+            continue;
+        }
+        let aboutness = shared as f64 / tokens.len() as f64;
+        // Strictly greater: the earliest of equally-about lines keeps winning.
+        if best.is_none_or(|(_, top)| aboutness > top) {
+            best = Some((index, aboutness));
+        }
+    }
+    best.map(|(index, _)| index)
+}
+
+/// The first unclaimed bare line whose every word already appears in
+/// `tokens` — i.e. one that would add nothing to the document that the
+/// caller's own line does not already say.
+///
+/// Deliberately total containment, not the `target_for` "most about" score: a
+/// partial overlap means the bare line carries something of its own, and
+/// absorbing it would delete that. "Poison oak removal" ⊆ "Regular poison oak
+/// removal" absorbs; "Front bed mulch" ⊄ "5 yards of mulch" does not.
+fn fully_covered_by(
+    tokens: &[String],
+    items: &[CapturedItem],
+    readings: &[Reading],
+    claimed: &HashSet<usize>,
+) -> Option<usize> {
+    if tokens.is_empty() {
+        return None;
+    }
+    let have: HashSet<&str> = tokens.iter().map(String::as_str).collect();
     items.iter().enumerate().position(|(index, item)| {
         if claimed.contains(&index) || !matches!(readings[index], Reading::Plain) {
             return false;
         }
-        tokenize(&item.text).iter().any(|t| wanted.contains(t.as_str()))
+        let theirs = tokenize(&item.text);
+        !theirs.is_empty() && theirs.iter().all(|t| have.contains(t.as_str()))
     })
 }
 
@@ -410,6 +482,46 @@ mod tests {
         assert_eq!(folded.amounts.get("i3"), None, "the beds were never priced — still a gap");
     }
 
+    /// Isaac's flagstone estimate, 2026-08-10: "Poison oak removal" sat
+    /// orphaned and unpriced directly above "Regular poison oak removal —
+    /// $200". Same job, twice, one of them looking like a gap.
+    #[test]
+    fn a_self_priced_line_absorbs_the_bare_line_it_already_covers() {
+        let items = vec![
+            item("i1", "todo", "Poison oak removal"),
+            item("i2", "price", "$200 regular poison oak removal"),
+            item("i3", "price", "$100 hazard pay poison oak"),
+        ];
+        let folded = fold_spoken_prices(&items);
+        let titles: Vec<&str> = folded.items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(
+            titles,
+            vec!["Regular poison oak removal", "Hazard pay poison oak"],
+            "the bare duplicate is gone; hazard pay stays its own line"
+        );
+        assert_eq!(folded.amounts.get("i2"), Some(&20000));
+        assert_eq!(folded.amounts.get("i3"), Some(&10000));
+    }
+
+    /// Absorption must never delete detail: a bare line is only absorbed when
+    /// every word of it is already present in the priced line.
+    #[test]
+    fn absorption_keeps_the_richer_title_and_spares_a_line_with_its_own_words() {
+        let items = vec![
+            item("i1", "part", "Mulch"),
+            item("i2", "part", "Front bed edging"),
+            item("i3", "price", "$450 five yards of mulch installed"),
+        ];
+        let folded = fold_spoken_prices(&items);
+        let titles: Vec<&str> = folded.items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(
+            titles,
+            vec!["Front bed edging", "Five yards of mulch installed"],
+            "bare Mulch absorbed into the richer line; the edging is untouched"
+        );
+        assert_eq!(folded.amounts.get("i3"), Some(&45000));
+    }
+
     #[test]
     fn an_item_that_carries_its_own_price_keeps_its_line() {
         let items = vec![item("i1", "part", "5 yards of mulch installed $450")];
@@ -442,11 +554,42 @@ mod tests {
     }
 
     #[test]
-    fn earliest_matching_line_wins_in_spoken_order() {
+    fn earliest_matching_line_wins_when_they_are_equally_about_it() {
         let items = vec![
             item("i1", "part", "front bed mulch"),
             item("i2", "part", "back bed mulch"),
             item("i3", "price", "$200 mulch"),
+        ];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.amounts.get("i1"), Some(&20000));
+        assert_eq!(folded.amounts.get("i2"), None);
+    }
+
+    /// Isaac's estimate, 2026-08-10: "three hundred for the flagstone" landed
+    /// on "Grade and weed path area for flagstones" — the earliest line that
+    /// merely MENTIONED the material — and the stone itself went unpriced.
+    #[test]
+    fn a_price_lands_on_the_line_it_is_most_about_not_the_first_mention() {
+        let items = vec![
+            item("i1", "todo", "Grade and weed path area for flagstones"),
+            item("i2", "part", "Flagstone"),
+            item("i3", "todo", "Flagstone path labor"),
+            item("i4", "price", "$300 flagstone"),
+        ];
+        let folded = fold_spoken_prices(&items);
+        assert_eq!(folded.amounts.get("i2"), Some(&30000), "the stone is priced");
+        assert_eq!(folded.amounts.get("i1"), None, "not the prep task that mentions it");
+        assert_eq!(folded.amounts.get("i3"), None, "and not the labor line either");
+    }
+
+    /// The tie-break still runs in spoken order, so a walk with no
+    /// distinguishing line behaves exactly as it did before.
+    #[test]
+    fn aboutness_never_beats_an_exact_single_word_line() {
+        let items = vec![
+            item("i1", "part", "Gravel"),
+            item("i2", "todo", "Spread gravel over the graded path area"),
+            item("i3", "price", "$200 gravel"),
         ];
         let folded = fold_spoken_prices(&items);
         assert_eq!(folded.amounts.get("i1"), Some(&20000));

--- a/crates/murmur-core/tests/document_smoke.rs
+++ b/crates/murmur-core/tests/document_smoke.rs
@@ -71,6 +71,85 @@ composting. Christos is going to prune the five pear trees in the backyard. Two 
 for the weeding and compost, three hundred for the mulch, two fifty for the plants, and \
 five hundred labor.";
 
+/// Isaac's flagstone walk (2026-08-10), the one that produced the estimate
+/// with "Jose and John, $300" under a line and his $300 of stone attached to
+/// the grading task. Every price here is stated; nothing should be invented,
+/// no crew name should reach the page, and no dollar figure should appear in
+/// a description.
+const FLAGSTONE_TRANSCRIPT: &str = "We're putting a flagstone path in the existing area \
+here. Grade and weed the path area first to get it flat, then lay the gravel down, then \
+the flagstone goes in. Three hundred for the flagstone, two hundred for the gravel, three \
+hundred for the labor — Jose and John are on the flagstone path. Then the backyard \
+perimeter needs weed whacking, William's on the weed whacker, two hundred labor plus ten \
+dollars of gas. And the poison oak has to come out, that's two hundred regular plus a \
+hundred hazard pay.";
+
+#[tokio::test]
+#[ignore = "hits the real API; set ANTHROPIC_API_KEY and run with --ignored"]
+async fn a_real_estimate_carries_only_what_an_estimate_needs() {
+    let api_key = std::env::var("ANTHROPIC_API_KEY").expect("set ANTHROPIC_API_KEY");
+    let provider = Arc::new(AnthropicProvider::from_env(api_key, model()));
+
+    let store = Store::open_in_memory("smoke-device").unwrap();
+    let session = store.start_session_with_template(None, "landscape").unwrap();
+    store.append_transcript(&session.id, FLAGSTONE_TRANSCRIPT).unwrap();
+    store.end_and_record_session(&session.id).unwrap();
+    let store = Arc::new(Mutex::new(store));
+
+    SessionProcessor::new(
+        provider.clone(),
+        store.clone(),
+        Arc::new(Mutex::new(Memory::default())),
+        Arc::new(NullMemoryStore),
+    )
+    .process(&session.id)
+    .await
+    .expect("processing failed");
+
+    let outcome = DocumentBuilder::new(
+        provider,
+        store.clone(),
+        Arc::new(Mutex::new(Memory::default())),
+        Arc::new(NullMemoryStore),
+    )
+    .build(&session.id, "estimate")
+    .await
+    .expect("build failed");
+
+    let guard = store.lock().unwrap();
+    let artifact = guard.get_artifact(&outcome.document_artifact_id).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&artifact.body).unwrap();
+
+    println!("\n===== FLAGSTONE ESTIMATE =====");
+    let mut total = 0i64;
+    for line in doc["lines"].as_array().unwrap() {
+        let cents = line["amount_cents"].as_i64();
+        total += cents.unwrap_or(0);
+        println!(
+            "  {:<46} {}\n      {}",
+            line["title"].as_str().unwrap_or(""),
+            cents.map_or("——".to_string(), |c| format!("${}", c / 100)),
+            line["detail"].as_str().unwrap_or("")
+        );
+    }
+    println!("  TOTAL ${}\n==============================\n", total / 100);
+
+    for line in doc["lines"].as_array().unwrap() {
+        let title = line["title"].as_str().unwrap();
+        let detail = line["detail"].as_str().unwrap_or("");
+        // A crew name is a work-order fact — never on the client's copy.
+        for name in ["Jose", "John", "William"] {
+            assert!(!detail.contains(name), "a crew name reached the estimate: {detail:?}");
+            assert!(!title.contains(name), "a crew name reached a line title: {title:?}");
+        }
+        // The amount has its own column; a figure in the text repeats or
+        // contradicts it (Isaac saw "$200 labor plus $10 gas" against $10).
+        assert!(!detail.contains('$'), "a dollar figure in a description: {detail:?}");
+        assert!(!title.contains('$'), "a dollar figure in a line title: {title:?}");
+        assert_ne!(line["amount_cents"], serde_json::json!(0), "a zero-dollar line: {title:?}");
+    }
+}
+
 #[tokio::test]
 #[ignore = "hits the real API; set ANTHROPIC_API_KEY and run with --ignored"]
 async fn a_real_estimates_lines_read_like_line_items() {


### PR DESCRIPTION
Isaac's flagstone estimate, four defects in one screenshot:

```
Grade and weed path area for flagstones            $300   ← his STONE money, on a prep task
Gravel   / "$200 material"                         $200   ← the figure, said twice
Flagstone path labor / "Jose and John, $300"       $300   ← crew names on the client's copy
Weed backyard perimeter /
  "William on weed whacker, $200 labor plus $10 gas" $10   ← text contradicts the amount
Poison oak removal, $200 regular + $100 hazard pay $300   ← money in the TITLE
                                                 $1,110   ← $200 short of what he said
```

## Thinking

### What belongs on a document is decided by who reads it

Isaac: *"things should only be included if they are relevant to the report that is getting created. If it's an estimate, lines should be split out sensibly and not include unneeded details such as who is doing the labor."*

The `inclusion` brief asked for "what is included in its price" and forbade nothing, so it volunteered the crew. Two rules are now explicit on `inclusion` and `observation`:

- **Never a crew name.** A client is buying an outcome. The work order has an `assignee` column for exactly this, and putting names on the client's copy turns a private staffing decision into something to negotiate about.
- **Never a dollar figure.** The amount has its own column two inches right. A figure in the text can only repeat it or contradict it — and it did both, most damagingly *"$200 labor plus $10 gas"* printed against an amount of **$10**, which leaves a client unable to tell what the line costs.

The work order keeps names in the `assignee` FIELD (never the text) and carries no money at all.

### A price should land on the line it is most ABOUT

"Three hundred for the flagstone" went to **"Grade and weed path area for flagstones"** — the earliest line that merely *mentioned* the stone — and the stone itself went unpriced.

That was my "first token match wins" rule from #319, which I'd justified on the grounds that items are in spoken order. This is the counter-example: the earliest mention was incidental. The fold now scores shared tokens against the line's own length, so `Flagstone` (1.0) beats a prep task that name-drops it (0.17). **Spoken order still breaks ties**, so two lines equally about the thing behave exactly as before — the old test still passes unchanged.

Two supporting extraction rules: a work item never carries a price in its own title (that produced "Poison oak removal, $200 regular + $100 hazard pay"), and a material the operator prices gets its own line — "three hundred for the flagstone" names a material that has to exist for the price to land on.

### Absorption, for the duplicate pair

"Poison oak removal" sat orphaned and unpriced directly above "Regular poison oak removal — $200". Same job twice, one of them looking like a gap, because that price label ran to four words and so read as a line item rather than a price statement.

A self-priced line now absorbs a bare line it **fully covers** — total containment, not similarity — and keeps the **richer** title, so "5 yards of mulch installed, $450" absorbing a bare "Mulch" loses neither the yards nor the installed.

## Result

Same walk, three real runs on the shipped model:

```
Grade and weed path area              ——
Gravel                              $200
Flagstone                           $300     ← the stone, priced
Flagstone path                      $300
Weed whacking, backyard perimeter   $200     ← the labor his build dropped
Gas                                  $10
Regular poison oak removal          $200
Hazard pay poison oak               $100
                                  $1,310     ← every price he stated
```

No crew names, no dollar figures in any description, nothing invented.

## Known residual

Absorption is phrasing-dependent. When extraction happens to say "Regular **labor** poison oak" (no "removal"), the bare line is not fully covered and survives as an extra gap row — roughly **one run in three**.

I stopped there deliberately. Loosening containment to a similarity threshold fixes this sample and starts merging genuinely different lines — "poison oak removal" vs "poison oak spraying" share two words of three. Tuning a threshold against three examples is how you get something that works on this walk and breaks on the next one.

## Testing

- 543 Rust tests, clippy clean, 151 iOS tests.
- Three real-API document tests green; six runs of the flagstone walk.
- Isaac's walk is now a committed real-API case asserting no crew name, no `$` in any title or description, and no zero-dollar line.