### PR TITLE
feat: optional fields the operator fills before sending — starting with PREPARED FOR

### DIFF
--- a/apps/ios/Sources/App/AppModel.swift
+++ b/apps/ios/Sources/App/AppModel.swift
@@ -1600,7 +1600,11 @@ final class AppModel {
         }
         let value = editTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         doc.sections[sectionIndex].fields[fieldIndex].value = value.isEmpty ? nil : value
-        doc.sections[sectionIndex].fields[fieldIndex].isGap = value.isEmpty
+        // An emptied OPTIONAL field goes back to "TAP TO ADD", not to a
+        // warning gap — the operator declining to name a client has not left
+        // the document incomplete.
+        doc.sections[sectionIndex].fields[fieldIndex].isGap =
+            value.isEmpty && !doc.sections[sectionIndex].fields[fieldIndex].isOptional
         document = doc
         editingField = nil
     }

--- a/apps/ios/Sources/Components/Document.swift
+++ b/apps/ios/Sources/Components/Document.swift
@@ -218,12 +218,22 @@ struct DocSectionView: View {
 
     @ViewBuilder
     private func valueText(_ field: DocFieldFixture) -> some View {
-        if let value = field.value, !field.isGap {
+        if let value = field.value, !value.isEmpty {
             Text(value)
                 .font(Theme.F.ui(12, .medium))
                 .foregroundStyle(Theme.C.ink)
                 .lineSpacing(2)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if field.isOptional {
+            // An INVITATION, not a warning. Nothing was expected to fill this
+            // but the operator, so blank is a perfectly good final state and
+            // the yellow gap treatment would be nagging about a defect that
+            // does not exist. Amber, the app's "you can act here" colour.
+            Text("TAP TO ADD")
+                .font(Theme.F.mono(8, .semibold))
+                .tracking(1.0)
+                .foregroundStyle(Theme.C.amberInk)
                 .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             Text(OperatorNote.gap)

--- a/apps/ios/Sources/Engine/DemoWalkEngine.swift
+++ b/apps/ios/Sources/Engine/DemoWalkEngine.swift
@@ -458,16 +458,27 @@ final class DemoWalkEngine: WalkEngine {
                 key: key, label: label, value: value, isGap: value == nil, isParagraph: false
             )
         }
+        /// The operator fills this one at review — never the walk.
+        func optional(_ key: String, _ label: String) -> DocFieldFixture {
+            DocFieldFixture(
+                key: key, label: label, value: nil, isGap: false, isOptional: true,
+                isParagraph: true
+            )
+        }
+        let preparedFor = DocSectionFixture(
+            key: "client", label: "PREPARED FOR",
+            fields: [optional("prepared_for", "Prepared for")]
+        )
         switch kind {
         case "estimate":
-            return [DocSectionFixture(key: "scope", label: "SCOPE OF WORK", fields: [para(
+            return [preparedFor, DocSectionFixture(key: "scope", label: "SCOPE OF WORK", fields: [para(
                 "scope_summary", "Scope of work",
                 "Refresh the front beds and walkway line: three yards of premium bark mulch "
                     + "delivered and installed, boxwood trimmed and clippings hauled, sixty feet "
                     + "of bed edging re-cut, and the zone 2 irrigation head replaced."
             )])]
         case "invoice":
-            return [DocSectionFixture(key: "work", label: "WORK PERFORMED", fields: [para(
+            return [preparedFor, DocSectionFixture(key: "work", label: "WORK PERFORMED", fields: [para(
                 "work_summary", "Work performed",
                 "Installed three yards of premium bark mulch across the front beds, trimmed the "
                     + "boxwood along the walkway and hauled the clippings, re-cut sixty feet of "

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -163,7 +163,10 @@ extension MurmurEngine {
                 key: field.key,
                 label: field.label,
                 value: field.value,
-                isGap: field.isGap,
+                // A manual field is never "missing" — nothing was expected to
+                // fill it but the operator.
+                isGap: field.isGap && field.fill != "manual",
+                isOptional: field.fill == "manual",
                 isParagraph: field.kind == "long_text"
             ))
         }

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -55,7 +55,12 @@ struct DocSectionFixture: Identifiable {
     /// A section with nothing written in it at all is not rendered — an
     /// all-gap block is a heading over an empty box, which reads as a broken
     /// screen rather than as an honest blank.
-    var hasContent: Bool { fields.contains { !$0.isGap } }
+    ///
+    /// Keyed on a real VALUE rather than the gap flag: an unfilled OPTIONAL
+    /// field is not a gap (blank is a fine final state for it) but it is also
+    /// not content, and a PREPARED FOR heading over nothing is exactly the
+    /// empty box this guard exists to prevent.
+    var hasContent: Bool { fields.contains { !($0.value ?? "").isEmpty } }
 }
 
 struct DocFieldFixture: Identifiable {
@@ -65,6 +70,14 @@ struct DocFieldFixture: Identifiable {
     /// `nil` = a truthful gap: nothing about this was said on the walk.
     var value: String?
     var isGap: Bool
+    /// The operator fills this one, not the walk (`fill: "manual"`).
+    ///
+    /// Blank is a perfectly good FINAL state for these, which is why they are
+    /// not gaps: a gap says the document is incomplete and nags accordingly,
+    /// while an optional field is just somewhere to type. Isaac, 2026-08-10:
+    /// *"have the AI fill in everything it's confident in and present optional
+    /// fields to be filled in by the user before sending."*
+    var isOptional: Bool = false
     /// `long_text` sets its own paragraph; `text` sits inline beside its label.
     var isParagraph: Bool
 }

--- a/apps/ios/Sources/Flow/DocumentPDF.swift
+++ b/apps/ios/Sources/Flow/DocumentPDF.swift
@@ -11,7 +11,10 @@ enum DocumentPDF {
     /// is a message to the operator, and the operator is not who reads this.
     static func printableSection(_ section: DocSectionFixture) -> DocSectionFixture {
         var out = section
-        out.fields = section.fields.filter { !$0.isGap }
+        // Anything with no value comes off, whether it is a gap the walk left
+        // or an optional the operator chose not to fill. "TAP TO ADD" is an
+        // instruction to the person holding the phone.
+        out.fields = section.fields.filter { !($0.value ?? "").isEmpty }
         return out
     }
 

--- a/apps/ios/Tests/DocumentLineEditTests.swift
+++ b/apps/ios/Tests/DocumentLineEditTests.swift
@@ -314,6 +314,84 @@ final class DocumentLineEditTests: XCTestCase {
         XCTAssertNil(model.editingField)
     }
 
+    // MARK: Optional fields — the operator fills these, not the walk
+
+    private func modelWithOptional() -> AppModel {
+        let model = model()
+        model.document?.sections = [
+            DocSectionFixture(key: "client", label: "PREPARED FOR", fields: [
+                DocFieldFixture(
+                    key: "prepared_for", label: "Prepared for", value: nil,
+                    isGap: false, isOptional: true, isParagraph: true
+                ),
+            ]),
+        ]
+        return model
+    }
+
+    /// Isaac, 2026-08-10: *"have the AI fill in everything it's confident in
+    /// and present optional fields to be filled in by the user before
+    /// sending."* Blank is a perfectly good FINAL state for those, so an
+    /// unfilled optional is not a gap and must not nag like one.
+    func testAnUnfilledOptionalIsNotAGap() {
+        let model = modelWithOptional()
+        let field = model.document!.sections[0].fields[0]
+        XCTAssertFalse(field.isGap, "nothing was expected to fill it but the operator")
+        XCTAssertTrue(field.isOptional)
+        XCTAssertEqual(
+            model.document?.gapCount, 1,
+            "only the walk's own unpriced line counts as a gap"
+        )
+    }
+
+    func testAnOptionalFieldTakesAValueAndGivesItBack() {
+        let model = modelWithOptional()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        model.editTitle = "Mary Hollis\n1418 Alder Ct, Denver CO"
+        model.commitFieldEdit()
+
+        XCTAssertEqual(
+            model.document?.sections[0].fields[0].value,
+            "Mary Hollis\n1418 Alder Ct, Denver CO"
+        )
+        XCTAssertFalse(model.document!.sections[0].fields[0].isGap)
+    }
+
+    func testClearingAnOptionalReturnsItToTapToAddNotToAGap() {
+        let model = modelWithOptional()
+        let section = model.document!.sections[0]
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        model.editTitle = "Mary Hollis"
+        model.commitFieldEdit()
+
+        let filled = model.document!.sections[0]
+        model.beginFieldEdit(section: filled, field: filled.fields[0])
+        model.editTitle = ""
+        model.commitFieldEdit()
+
+        let after = model.document!.sections[0].fields[0]
+        XCTAssertNil(after.value)
+        XCTAssertFalse(after.isGap, "declining to name a client is not an incomplete document")
+        XCTAssertTrue(after.isOptional)
+    }
+
+    /// An unfilled optional must not print a heading over nothing, and must
+    /// never print "TAP TO ADD" — that is an instruction to the operator.
+    func testAnUnfilledOptionalSectionIsNotPrinted() {
+        let model = modelWithOptional()
+        let section = model.document!.sections[0]
+        XCTAssertFalse(section.hasContent, "a PREPARED FOR heading over nothing is an empty box")
+        XCTAssertTrue(DocumentPDF.printableSection(section).fields.isEmpty)
+
+        model.beginFieldEdit(section: section, field: section.fields[0])
+        model.editTitle = "Mary Hollis"
+        model.commitFieldEdit()
+        let filled = model.document!.sections[0]
+        XCTAssertTrue(filled.hasContent, "once filled it is real content and prints")
+        XCTAssertEqual(DocumentPDF.printableSection(filled).fields.count, 1)
+    }
+
     func testTheTotalFollowsEveryEdit() {
         let model = model()
         XCTAssertEqual(model.document?.totalValue, "$200")

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -374,6 +374,25 @@ fn walk_field(key: &str, kind: &str, label: &str, hint: &str) -> SchemaField {
     }
 }
 
+/// One field the OPERATOR completes at review. Never offered to the model,
+/// and blank is a perfectly good final state.
+///
+/// Isaac, 2026-08-10: *"have the AI fill in everything it's confident in and
+/// present optional fields to be filled in by the user before sending."* That
+/// is this fill mode, which Plan 19 defined and nothing had used — the
+/// difference between a document that is INCOMPLETE and one that simply has
+/// somewhere for you to type.
+fn manual_field(key: &str, kind: &str, label: &str) -> SchemaField {
+    SchemaField {
+        key: key.into(),
+        kind: kind.into(),
+        label: label.into(),
+        fill: "manual".into(),
+        static_value: None,
+        hint: None,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn builtin_schema(
     id: &str,
@@ -444,12 +463,17 @@ pub fn builtin_schemas() -> Vec<DocumentSchema> {
         builtin_schema(
             BUILTIN_SCHEMA_ID_ESTIMATE, "estimate", "Estimate", "EST", None, true,
             ("sum", "total"), "inclusion",
-            vec![filled("scope", "Scope of Work", vec![walk_field(
+            vec![
+                filled("client", "Prepared For", vec![manual_field(
+                    "prepared_for", "long_text", "Prepared for",
+                )]),
+                filled("scope", "Scope of Work", vec![walk_field(
                 "scope_summary", "long_text", "Scope of work",
                 "2-3 plain sentences a client can read, in FUTURE tense: what will be done, \
                  where on the property, and anything notable about how or in what order. \
                  No prices — they are on the lines.",
-            )])],
+                )]),
+            ],
         ),
         // INVOICE — the same document after the fact, and the difference is
         // not cosmetic: an estimate offers, an invoice demands. Past tense,
@@ -457,11 +481,16 @@ pub fn builtin_schemas() -> Vec<DocumentSchema> {
         builtin_schema(
             BUILTIN_SCHEMA_ID_INVOICE, "invoice", "Invoice", "INV", None, true,
             ("sum", "amount_due"), "inclusion",
-            vec![filled("work", "Work Performed", vec![walk_field(
+            vec![
+                filled("client", "Prepared For", vec![manual_field(
+                    "prepared_for", "long_text", "Prepared for",
+                )]),
+                filled("work", "Work Performed", vec![walk_field(
                 "work_summary", "long_text", "Work performed",
                 "2-3 plain sentences in PAST tense: what was actually done, where, and \
                  anything the client should know about the finished work. No prices.",
-            )])],
+                )]),
+            ],
         ),
         // WORK ORDER — the only one of these written for the crew, and the
         // reason it carries no money: a sub who sees the client price bids


### PR DESCRIPTION
Isaac: *"Can we just add a field (optional) for the user to fill in after the document generates? I think that's a good way of doing things generally, have the AI fill in everything it's confident in and present optional fields to be filled in by the user before sending."*

## Thinking

### The mode already existed

`fill: "manual"` — *"operator completes at review (always a gap in v1)"* — has been in the schema since Plan 19 and nothing has ever used it. Isaac's proposal is that mode, so this makes it real rather than inventing a parallel concept.

### A blank optional is NOT a gap, and that distinction is the feature

| | Gap | Optional |
|---|---|---|
| Means | the walk should have caught this and didn't | nobody but the operator was ever going to fill it |
| Reads | `NOT HEARD — TAP OR SAY IT`, yellow | `TAP TO ADD`, amber |
| Counts toward `+N GAP` | yes | no |
| Blank is a valid final state | no | **yes** |
| Cleared by the operator | back to a warning | back to an invitation |

Conflating them would mean every estimate nagging that it is incomplete because the operator chose not to name a client — which would train people to ignore the gap badge, and the gap badge is load-bearing.

Note the plumbing needed no FFI change: `DocField.fill` already crosses the boundary, so the app derives `isOptional` from it.

### PREPARED FOR

Estimates and invoices get the block every trade document carries opposite the letterhead. An invoice without a named payer is a weak accounting record; an estimate is an offer *to a specific person*, which is what makes accepting one mean anything.

**Manual rather than walk-filled, deliberately.** A client's name is the single most expensive thing on the document to mishear, it is typed once per job, and the operator is standing right there. The seam is one field away from being AI-filled if that turns out to be the wrong call — and the existing `Job.client` / `Job.site` columns (which sync today and are never collected) are the obvious place to pre-fill it from later.

### Blank ones never print

Same rule the authored sections already follow, now keyed on having a VALUE rather than on the gap flag — so an unfilled optional cannot leave a heading over an empty box on screen, and cannot print "TAP TO ADD" at a client.

## Verified

- 543 Rust tests, clippy clean, 155 iOS tests (4 new, covering all four states: unfilled, filled, cleared, printed).
- Rendered on iPhone 17: `PREPARED FOR / TAP TO ADD` in amber, visually distinct from the yellow `NOT HEARD` warning three lines below it.
- Exported the PDF and confirmed the unfilled block is absent.

## For dam

`manual` fill is now load-bearing rather than reserved. `assemble_fields` was already correct for it; the only core change is the two schema rows.