### PR TITLE
fix: a document draws only the item kinds it is for

### DIFF
--- a/crates/ffi/src/items.rs
+++ b/crates/ffi/src/items.rs
@@ -452,15 +452,21 @@ mod tests {
         );
         // work_order: non-pricing, deterministic, zero LLM calls.
         let doc = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
-        assert_eq!(doc.lines.len(), 3, "the re-tag does NOT change the document structure");
+        // A2 is a SAFETY item and a work order no longer draws one as a line
+        // of work (`draws_kind`) — it reaches the crew through the site block
+        // instead. The invariant this test exists for is untouched: a
+        // todo -> part re-tag changes no structure, because a work order draws
+        // both.
+        assert_eq!(doc.lines.len(), 2, "the re-tag does NOT change the document structure");
         let titles: Vec<&str> = doc.lines.iter().map(|l| l.title.as_str()).collect();
-        assert_eq!(titles, vec!["Mower", "loose railing", "bark mulch"],
-            "order [A1, A2, A3]; only L1's title changed — the corrected text reached the document");
+        assert_eq!(titles, vec!["Mower", "bark mulch"],
+            "order [A1, A3]; only L1's title changed — the corrected text reached the document");
         let line_item_ids: Vec<Option<&str>> =
             doc.lines.iter().map(|l| l.item_id.as_deref()).collect();
         assert_eq!(
             line_item_ids,
-            ids.iter().map(|i| Some(i.as_str())).collect::<Vec<_>>()
+            vec![Some(ids[0].as_str()), Some(ids[2].as_str())],
+            "the drawn lines carry their own item ids; A2 (safety) draws none"
         );
         assert!(doc.lines.iter().all(|l| l.qty.is_empty()), "no right set yet — every qty empty");
 
@@ -469,9 +475,9 @@ mod tests {
             .update_item(sid.clone(), ids[2].clone(), None, None, Some("3 CU YD".into()))
             .unwrap();
         let doc = engine.build_document(sid, "work_order".into()).await.unwrap();
-        assert_eq!(doc.lines[2].qty, "3 CU YD", "the quantity edit reached the qty column");
+        // A3 is the SECOND drawn line now — A2 (safety) draws none.
+        assert_eq!(doc.lines[1].qty, "3 CU YD", "the quantity edit reached the qty column");
         assert_eq!(doc.lines[0].qty, "");
-        assert_eq!(doc.lines[1].qty, "");
     }
 
     #[tokio::test]
@@ -503,13 +509,23 @@ mod tests {
 
         // WE-D: add appends — the last line of the rebuilt document.
         let added = engine
-            .add_item(sid.clone(), "safety".into(), "cracked walkway".into(), "".into())
+            .add_item(sid.clone(), "todo".into(), "repair cracked walkway".into(), "".into())
             .unwrap();
         assert_eq!(item_ids(&engine, &sid), vec![b1, b3, added.id.clone()]);
-        let doc = engine.build_document(sid, "work_order".into()).await.unwrap();
+        let doc = engine.build_document(sid.clone(), "work_order".into()).await.unwrap();
         assert_eq!(doc.lines.len(), 3);
-        assert_eq!(doc.lines[2].title, "cracked walkway", "appended last");
+        assert_eq!(doc.lines[2].title, "repair cracked walkway", "appended last");
         assert_eq!(doc.lines[2].item_id.as_deref(), Some(added.id.as_str()));
+
+        // The contrast: a SAFETY item appends to the board exactly the same
+        // way and draws no line of work on a work order (`draws_kind`) — the
+        // crew meets it in the site block, not as a task.
+        let hazard = engine
+            .add_item(sid.clone(), "safety".into(), "cracked walkway".into(), "".into())
+            .unwrap();
+        assert!(item_ids(&engine, &sid).contains(&hazard.id), "it is on the board");
+        let doc = engine.build_document(sid, "work_order".into()).await.unwrap();
+        assert_eq!(doc.lines.len(), 3, "and not on the paperwork as work");
     }
 
     #[tokio::test]

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -346,6 +346,41 @@ fn compose_document_tool_spec(wants_lines: bool, wants_assignee: bool) -> ToolSp
     }
 }
 
+/// Whether a document written for this reader draws a line from an item of
+/// this kind.
+///
+/// Not every item belongs on every document, and the render used to put ALL
+/// of them on ALL of them. On Isaac's work order (2026-08-10) that meant
+/// "Gate code 4412", "Park on street", and "Dog in back until 8am" appearing
+/// as TASKS — while also, correctly, appearing in the SITE NOTES block right
+/// above. The same facts twice, once as work nobody is meant to do.
+///
+/// The obvious fix — tell extraction to stop recording them — is wrong twice
+/// over. It contradicts the extraction prompt's own earlier and more concrete
+/// rule ("use add_item for todos, decisions, notes, safety issues, parts,
+/// prices"), which is why the model kept doing it; and those items are RIGHT.
+/// The live board tags them SAFETY and NOTE, the notes screen groups them, and
+/// the compose pass reads them into a work order's site block. Deleting them
+/// to tidy a document would gut three things that work.
+///
+/// So the filter belongs here, keyed to who reads the document:
+///
+/// - A client buying work (`inclusion`) is paying for labor and materials. A
+///   gate code is not a line item on an estimate.
+/// - A crew executing (`directive`) needs the tasks; the site facts are
+///   already in the block above their heads.
+/// - A record (`observation`) is the one document where a condition, a note
+///   and a safety finding ARE the content — that is the whole point of an
+///   inspection report.
+fn draws_kind(line_detail: &str, kind: &str) -> bool {
+    match line_detail {
+        // Work, materials, and the money for them.
+        "inclusion" | "directive" => matches!(kind, "todo" | "part" | "price"),
+        // Everything: a report exists to record what was seen.
+        _ => true,
+    }
+}
+
 /// The per-line brief, keyed by the schema's `line_detail`. Each one names
 /// the READER, because that is what actually decides the writing: the same
 /// item becomes "delivered and installed, 3 cu yd" for a client weighing a
@@ -800,6 +835,37 @@ impl DocumentBuilder {
             .iter()
             .find(|s| s.kind == "line_items")
             .is_some_and(|s| s.priced);
+        let line_detail = schema
+            .sections
+            .iter()
+            .find(|s| s.kind == "line_items")
+            .map(|s| s.line_detail.clone())
+            .unwrap_or_default();
+
+        // Only the kinds this document is FOR (see `draws_kind`). A gate code
+        // is a real item and belongs on the board, in the notes, and in a work
+        // order's site block — but never as a line of work on the paperwork.
+        //
+        // The filter is on the RENDER, never on the CONTEXT: `all_items` still
+        // goes to the compose pass below. Filtering that too would mean a
+        // safety item recorded ONLY as an item — "loose railing" — vanishing
+        // from the work order's SAFETY block as well as from its lines, which
+        // is losing a hazard to tidy a page. The compose pass writes by
+        // `item_id` and simply cannot touch a line that was not rendered, so
+        // the extra context is free.
+        let all_items = items.clone();
+        let items: Vec<CapturedItem> =
+            items.into_iter().filter(|i| draws_kind(&line_detail, &i.kind)).collect();
+        if items.is_empty() {
+            // The same posture as the empty-walk guard above, for the same
+            // reason: mint nothing rather than a document with no content.
+            // An estimate off a walk that captured only site conditions has
+            // nothing to sell, and saying so beats a blank priced page.
+            return Err(CoreError::InvalidState(
+                "nothing to build — this walk captured no work or materials for this document"
+                    .into(),
+            ));
+        }
 
         // Fold spoken prices onto the work they describe, BEFORE the render
         // (Isaac's field report 2026-08-09 — "$200 mulch" was landing as its
@@ -875,12 +941,6 @@ impl DocumentBuilder {
             .filter(|s| s.kind == "filled")
             .flat_map(|s| s.fields.iter().filter(|f| f.fill == "walk").cloned())
             .collect();
-        let line_detail = schema
-            .sections
-            .iter()
-            .find(|s| s.kind == "line_items")
-            .map(|s| s.line_detail.clone())
-            .unwrap_or_default();
         let mut composed = Composition::default();
         if !walk_fields.is_empty() || line_brief(&line_detail).is_some() {
             // The coordination notes the walk already produced — free
@@ -893,7 +953,7 @@ impl DocumentBuilder {
                 &schema.label,
                 &line_detail,
                 &walk_fields,
-                &folded.items,
+                &all_items,
                 session.summary.as_deref().unwrap_or(""),
                 &notes,
                 self.max_tokens,
@@ -1193,7 +1253,11 @@ mod tests {
 
     #[tokio::test]
     async fn build_happy_path_prices_and_mints_a_document() {
-        let (store, sid) = processed_session_with_items(&[("todo", "mulch"), ("safety", "loose railing")]);
+        // Two DRAWABLE kinds: an estimate does not draw a `safety` item
+        // (`draws_kind`), and this test is about pricing, not about which
+        // kinds reach the page — that is pinned separately below.
+        let (store, sid) =
+            processed_session_with_items(&[("todo", "mulch"), ("part", "bark mulch")]);
         // Re-read the real minted ids so the scripted response can echo one.
         let a1 = store.list_items_for_session(&sid).unwrap()[0].id.clone();
         let store = Arc::new(Mutex::new(store));
@@ -2197,6 +2261,81 @@ mod tests {
         assert_eq!(
             v["lines"][1]["is_gap"], true,
             "an unpriced deduction is an open question, not a free pass"
+        );
+    }
+
+    /// Not every item belongs on every document. Isaac's work order
+    /// (2026-08-10) listed "Gate code 4412", "Park on street" and "Dog in back
+    /// until 8am" as TASKS, while the same facts sat correctly in the SITE
+    /// NOTES block above them.
+    #[tokio::test]
+    async fn a_document_draws_only_the_kinds_it_is_for() {
+        let fixture = &[
+            ("todo", "mulch the beds"),
+            ("part", "bark mulch"),
+            ("note", "gate code 4412"),
+            ("safety", "loose railing"),
+            ("decision", "going with dark mulch"),
+        ];
+
+        // A work order is for a crew: work and materials, not site trivia —
+        // the crew meets those in the site block.
+        let (store, sid) = processed_session_with_items(fixture);
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([]),
+            serde_json::json!([]),
+        )]));
+        let outcome =
+            builder(store.clone(), provider.clone()).build(&sid, "work_order").await.unwrap();
+        let v = decoded_document(&store, &outcome.document_artifact_id);
+        let titles: Vec<&str> =
+            v["lines"].as_array().unwrap().iter().map(|l| l["title"].as_str().unwrap()).collect();
+        assert_eq!(titles, vec!["mulch the beds", "bark mulch"]);
+
+        // …but the FULL item list still reaches the compose pass, or a hazard
+        // recorded only as an item would vanish from the safety block too.
+        let asked = format!("{:?}", provider.requests()[0].messages[0].content);
+        assert!(asked.contains("loose railing"), "the hazard is still context");
+        assert!(asked.contains("gate code 4412"), "and so is the access detail");
+
+        // A report is the document those observations are FOR.
+        let (store2, sid2) = processed_session_with_items(fixture);
+        let store2 = Arc::new(Mutex::new(store2));
+        let provider2 = Arc::new(MockProvider::new(vec![compose_response(
+            serde_json::json!([]),
+            serde_json::json!([]),
+        )]));
+        let outcome2 = builder(store2.clone(), provider2).build(&sid2, "report").await.unwrap();
+        let v2 = decoded_document(&store2, &outcome2.document_artifact_id);
+        assert_eq!(
+            v2["lines"].as_array().unwrap().len(),
+            5,
+            "a report records everything — that is what it is for"
+        );
+    }
+
+    /// A walk that captured only site conditions has nothing to sell, and
+    /// saying so beats minting a blank priced page.
+    #[tokio::test]
+    async fn an_estimate_off_a_walk_with_no_work_is_skipped_truthfully() {
+        let (store, sid) =
+            processed_session_with_items(&[("note", "gate code 4412"), ("safety", "loose rail")]);
+        let store = Arc::new(Mutex::new(store));
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let b = builder(store.clone(), provider.clone());
+
+        let err = b.build(&sid, "estimate").await.unwrap_err();
+        assert!(matches!(err, CoreError::InvalidState(_)), "{err:?}");
+        assert!(provider.requests().is_empty(), "and costs nothing");
+        let guard = store.lock().unwrap();
+        assert!(
+            guard
+                .list_artifacts_for_session(&sid)
+                .unwrap()
+                .iter()
+                .all(|a| a.kind != "document"),
+            "no ghost document minted"
         );
     }
 

--- a/meta/sac/STATE.md
+++ b/meta/sac/STATE.md
@@ -4,6 +4,76 @@ What sac is working on right now. Updated with every PR.
 
 ---
 
+## 2026-08-09/10 — the documents became documents (#319 – #326)
+
+Eight PRs off one field report. The short version: **every document type was
+the same list under a different heading**, and the parts to fix that were
+already built and unused — `DocLine.detail` had rendered as each row's second
+line since Plan 07 and was always `""`, `DocField` crossed the FFI and nothing
+displayed it, Plan 19's fill pass ran for zero built-ins.
+
+**What landed**
+
+- `fill_fields` → **`compose_document`**: one call returning authored field
+  values AND per-line detail + assignee, echo-validated by `item_id` exactly
+  like `price_items`. One call, not two — the scope paragraph summarises the
+  very lines being detailed. Pricing stays separate; money is a different risk
+  class. It reads the coordination notes `summarize()` already captured, so a
+  crew's gate code costs no extra call.
+- **All seven built-ins rebuilt** with authored sections: estimate = SCOPE OF
+  WORK, invoice = WORK PERFORMED + AMOUNT DUE, work order = ASSIGNMENT +
+  SITE NOTES + per-line directives + `DocLine.assignee` (additive on the FFI),
+  report/condition/inspection = summary + observations. **`move_out` became a
+  pricing kind** — its deduction total IS the document.
+- **`fill: "manual"` is now load-bearing** (Isaac's idea, your mode): a blank
+  optional field is NOT a gap. PREPARED FOR on estimates and invoices.
+- Additive schema fields `SchemaSection.line_detail` and `SchemaField.hint`,
+  both `#[serde(default)]`.
+
+**Three things worth your review, all yours by rights**
+
+1. **Seeding now UPGRADES built-ins in place** (#321). `seed_schemas` was
+   `INSERT … WHERE NOT EXISTS` over FIXED ids, so a device that seeded once
+   could never receive a changed built-in — #320 shipped and was 100% inert on
+   every existing install. Guarded on `device_id = 'builtin' AND updated_at =
+   0`; tombstones stay dead, operator edits win. **Note for sync:** two devices
+   on different app versions now hold different `sections` for the same id at
+   the same `updated_at = 0`. Flagging, not redesigning.
+2. **The D5a spoken-total hint is no longer sent to `price_items`** (#323). It
+   said "allocate line prices consistent with this", which is an instruction to
+   invent — across four real runs it put an operator's entire $1,250 quote onto
+   a line he never priced, once. Rewording to "sanity check only" was not
+   enough. The capture and `session_spoken_total` are intact for a future
+   ceiling check.
+3. **Pricing is narrowed to "this operator's own history, or nothing"** (#322).
+   The old wording licensed pricing anything "you can reasonably infer from its
+   text", and did: $3,300 returned against $1,250 stated. Deliberately gappier.
+
+**Extraction prompt changes** (#322 – #326, also yours): items are one piece of
+work or one material as a noun phrase; who does it and site facts are not
+items; a spoken price keeps its figure; group what the operator groups. The
+eval corpus grades extraction CONTENT not phrasing, so the hermetic graders are
+unaffected — **a real eval run will shift.**
+
+**New: `crates/murmur-core/tests/document_smoke.rs`** — env-gated, `#[ignore]`d,
+prints the document under `--nocapture`. It caught three defects mocks
+structurally cannot: the compose pass restating every title, an estimate coming
+back with NO prices at all, and site facts landing as work-order lines. It
+defaults to **`claude-sonnet-4-5`**, the model the app actually ships — it
+originally ran haiku and a haiku result got quoted as production behaviour.
+**Run it 3–5×; single runs hid a total-failure mode.**
+
+**Known and open**
+
+- Absorption of duplicate line pairs is phrasing-dependent (~1 run in 3). Not
+  tuned further on purpose — the only lever merges genuinely different lines.
+- No client capture: `Job.client` / `Job.site` exist and sync, and nothing
+  collects them. PREPARED FOR is typed per document until they do.
+- Builds 105–110 are on the INTERNAL lane; the external "Jefe Beta" group is
+  still on 2.0.0 (54) and needs a `vX.Y.Z` tag + Beta App Review.
+
+---
+
 ## → READ THIS FIRST: `meta/dam/BEFORE-THE-MONTH-AWAY.md`
 
 *(2026-08-02.)*


### PR DESCRIPTION
I said the work-order side of #322 was **unverified**. It was also wrong — site facts are still becoming work-order lines, in all three real runs:

```
Gate code 4412, side yard                        ← also in SITE NOTES above
Park on street, driveway being sealed Thursday   ← also in SITE NOTES
Dog in back until 8 AM                           ← also in SITE NOTES
Irrigation heads along walkway bed sit shallow   ← also in SAFETY
```

## Thinking

### The extraction rule never had a chance

#322 added *"site conditions and access details are never items — gate codes, parking, dogs, hazards."* The same prompt's **earlier and more concrete** rule says *"use add_item for todos, decisions, **notes**, **safety issues**, parts, prices."* A gate code is a note; a shallow irrigation head is a safety issue. The model followed the instruction that named the thing, which is the reasonable reading of a self-contradicting prompt.

### And the earlier rule is right

Those items are not junk. The live board tags them SAFETY and NOTE, the notes screen groups them, and the compose pass reads them into a work order's site block. Deleting them to tidy a document would gut three things that work.

The error was mine, one layer down: **`render_lines` turned every item into a document line**, and not every item belongs on every document.

### So the filter goes where the decision actually is — who reads it

| `line_detail` | Document | Draws |
|---|---|---|
| `inclusion` | estimate, invoice | work, materials, money |
| `directive` | work order | work, materials — site facts are in the block above the crew's heads |
| `observation` | report, condition, inspection | everything; a record exists to record |

### The filter is on the RENDER, never the CONTEXT

The compose pass still receives the **full** item list. Filtering that too would mean a hazard recorded only as an item — "loose railing" — vanishing from the SAFETY block as well as from the lines. That is losing a hazard in order to tidy a page, and it is the mistake I nearly shipped: the first version of this filtered `items` before the fold, and the compose pass reads `folded.items`.

The pass writes by `item_id` and cannot touch a line that was not rendered, so the extra context is free. There is a test asserting the hazard still reaches the prompt.

### One behavioural consequence, made explicit

A walk that captured only site conditions now **fails an estimate build truthfully** rather than minting a blank priced page — the empty-walk guard's posture, for the same reason: mint nothing rather than a document with no content.

## Result

Same walk, two real runs:

```
[assignment] Assigned to: Jose, Michael
[assignment] Scheduled:   Thursday first thing
[site] Access: Gate code 4412 side yard. Park on street… Dog in back until 8am.
[site] Safety: Irrigation heads sit shallow along walkway bed.

  Mulch, dark, five yards, front beds     Jose
  Compost, two bags, rose bed             —
  Strip old bark, front beds              Jose
  Edging, spade edge, sixty feet          Michael
```

## Tests

Two FFI tests encoded the old "every item is a line" contract and are updated. The invariant they exist for — a `todo` → `part` re-tag changes no structure — is untouched, and the contrast is now pinned explicitly: a safety item appends to the BOARD exactly as before and draws no line of work.

545 Rust tests, clippy clean, two real-API work-order runs.

## Also: `meta/sac/STATE.md`

I should have been updating it with every PR today and did not — the repo's own protocol says so. It now carries eight PRs of context for dam, including the three changes that are **his to overturn**: the built-in seed upgrade (and its sync implication), retiring the D5a spoken-total hint, and narrowing pricing to the operator's own history.