### PR TITLE
fix: an unpriced document carries no money and no total (+ CI runs the iOS tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,27 @@ jobs:
         working-directory: apps/ios
         run: xcodegen generate
 
-      - name: Build for simulator
+      # Build AND test. It used to build only, against a generic destination —
+      # which is why `DocumentIdentityTests` sat red on main for a day after
+      # #325 added the optional CLIENT block: nothing on CI ever ran the suite,
+      # and the iOS tests are where the document rules are actually pinned.
+      #
+      # A concrete simulator is required to run tests (a generic destination
+      # cannot), and it is RESOLVED rather than pinned: the runner image
+      # changes which iPhones exist, and a hardcoded name fails the whole job
+      # the day it disappears. Building for the concrete device also covers
+      # what the generic build covered, so this stays one compile.
+      - name: Build and test on simulator
         working-directory: apps/ios
         run: |
           set -o pipefail
+          DEVICE=$(xcrun simctl list devices available -j | python3 -c \
+            "import json,sys; d=json.load(sys.stdin)['devices']; \
+             print(next(x['name'] for k in d for x in d[k] if x['name'].startswith('iPhone')))")
+          echo "Testing on: $DEVICE"
           xcodebuild \
             -project SitewalkGallery.xcodeproj \
             -scheme SitewalkGallery \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination "platform=iOS Simulator,name=$DEVICE" \
             CODE_SIGNING_ALLOWED=NO \
-            build
+            test

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,15 @@
 .DS_Store
 
 # local secrets
+# Cover the variants too: editors write .env.save / .env.bak / .env~ next to it,
+# and a bare `.env` rule does not match those — nano wrote a .env.save holding a
+# live key on 2026-08-10 and it was commit-able until this line changed.
 .env
+.env.*
+!.env.example
+
+# direnv's local cache (the flake is committed; this is the materialized copy)
+.direnv/
 
 # simulator/QA capture evidence
 /screenshots/

--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -200,7 +200,7 @@ extension MurmurEngine {
         DocumentModel(
             rows: payload.lines.map(row),
             totalKey: totalLabel(payload.totalLabelKey),
-            staticTotal: payload.staticTotalCents.map(amountString) ?? "——",
+            staticTotal: payload.staticTotalCents.map(amountString) ?? DocumentModel.noTotal,
             note: note(for: payload.docKind, queued: payload.queued),
             send: sendLabel(for: payload.docKind),
             sections: sections(payload),
@@ -221,7 +221,7 @@ extension MurmurEngine {
 
     static func emptyDocument() -> DocumentModel {
         DocumentModel(
-            rows: [], totalKey: "TOTAL", staticTotal: "——", note: "", send: "SEND",
+            rows: [], totalKey: "TOTAL", staticTotal: DocumentModel.noTotal, note: "", send: "SEND",
             pricesShown: false
         )
     }

--- a/apps/ios/Sources/Engine/WalkEngine.swift
+++ b/apps/ios/Sources/Engine/WalkEngine.swift
@@ -117,6 +117,20 @@ struct DocumentModel {
     /// a crew with prices on it is the wrong document.
     var pricesShown: Bool = true
 
+    /// What `staticTotal` says when a document has no total of its own.
+    static let noTotal = "——"
+
+    /// Whether to print a total row at all.
+    ///
+    /// A priced document always shows one, even before the prices land — an
+    /// estimate's empty total is a gap the operator is meant to close. An
+    /// unpriced document only shows one if it has a static total to show
+    /// (an inspection's "1 SAFETY · 3 REPAIR"). Otherwise the row is a
+    /// heading over an em dash, which is what WO-0002 printed under a crew's
+    /// assignment: `TOTAL ——`. Same rule the optional fields already follow —
+    /// nothing to say, nothing printed.
+    var showsTotal: Bool { pricesShown || staticTotal != Self.noTotal }
+
     var gapCount: Int { rows.filter(\.isGap).count }
 
     /// Sum of $-parseable amounts; falls back to the template total.

--- a/apps/ios/Sources/Flow/DocumentPDF.swift
+++ b/apps/ios/Sources/Flow/DocumentPDF.swift
@@ -140,8 +140,13 @@ private struct PDFPageView: View {
             // `gaps: 0` — the "+3 GAP" badge is the app nudging the operator
             // before they send. Once they have sent, it is a note to the
             // client that the estimate is incomplete.
-            TotalRow(key: document.totalKey, value: document.totalValue, gaps: 0)
-                .padding(.top, 2)
+            //
+            // A document with nothing to total prints no total row — WO-0002
+            // went to a crew with `TOTAL ——` under the assignment.
+            if document.showsTotal {
+                TotalRow(key: document.totalKey, value: document.totalValue, gaps: 0)
+                    .padding(.top, 2)
+            }
             // Structure basics (DocumentLayout): operator terms + signature line.
             if !layout.termsText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 TermsBlock(text: layout.termsText)

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -84,8 +84,10 @@ struct ReviewView: View {
                                 .accessibilityHint("Edit this line")
                         }
                         addLineButton
-                        TotalRow(key: doc.totalKey, value: doc.totalValue, gaps: doc.gapCount)
-                            .padding(.top, 2)
+                        if doc.showsTotal {
+                            TotalRow(key: doc.totalKey, value: doc.totalValue, gaps: doc.gapCount)
+                                .padding(.top, 2)
+                        }
                         // Empty note = no bar. An empty amber block reads as a
                         // rendering failure, and a non-priced document has no
                         // pricing gap to talk about (#222).

--- a/apps/ios/Tests/DocumentIdentityTests.swift
+++ b/apps/ios/Tests/DocumentIdentityTests.swift
@@ -97,19 +97,42 @@ final class DocumentIdentityTests: XCTestCase {
     /// assignment. A document whose sections all said the same thing would be
     /// the old "every document looks like an estimate" bug wearing a hat.
     func testEachKindCarriesItsOwnAuthoredBlocks() async throws {
+        // `client` (PREPARED FOR) leads the money documents: an estimate is an
+        // offer to a named person and an invoice without a payer is a weak
+        // accounting record. It is `fill: "manual"` — the operator types it —
+        // so on a walk that never named a client it is legitimately EMPTY.
         let cases: [(kind: String, sections: [String])] = [
-            ("estimate", ["scope"]),
-            ("invoice", ["work"]),
+            ("estimate", ["client", "scope"]),
+            ("invoice", ["client", "work"]),
             ("work_order", ["assignment", "site"]),
             ("report", ["summary"]),
         ]
         for row in cases {
             let doc = try await build(row.kind)
             XCTAssertEqual(doc.sections.map(\.key), row.sections, "\(row.kind) sections")
+
+            // Walk-filled blocks must say something — a heading over an empty
+            // box reads as a broken document. An all-optional block is the
+            // exception and the reason this filter exists: blank is a fine
+            // final state for one, and `hasContent` false is precisely what
+            // keeps it off the printed page.
+            let authored = doc.sections.filter { !$0.fields.allSatisfy(\.isOptional) }
             XCTAssertTrue(
-                doc.sections.allSatisfy(\.hasContent),
+                authored.allSatisfy(\.hasContent),
                 "\(row.kind): a heading over an empty box reads as a broken document"
             )
         }
+    }
+
+    /// The optional block is present to be typed into and absent from the page
+    /// until it is. Pinned here because the two halves live apart — the schema
+    /// decides it exists, `hasContent` decides it prints — and a regression in
+    /// either one is silent: a PREPARED FOR heading over nothing, sent.
+    func testTheClientBlockIsOfferedButEmptyUntilTyped() async throws {
+        let estimate = try await build("estimate")
+        let client = try XCTUnwrap(estimate.sections.first { $0.key == "client" })
+        XCTAssertTrue(client.fields.allSatisfy(\.isOptional), "the operator types it, not the walk")
+        XCTAssertFalse(client.fields.contains { $0.isGap }, "an optional field is not a gap")
+        XCTAssertFalse(client.hasContent, "and nothing was typed, so nothing prints")
     }
 }

--- a/apps/ios/Tests/PrintableDocumentTests.swift
+++ b/apps/ios/Tests/PrintableDocumentTests.swift
@@ -141,4 +141,43 @@ final class PrintableDocumentTests: XCTestCase {
             "a heading over an empty box reads as a broken document, so the block is omitted"
         )
     }
+
+    // MARK: A document with nothing to total prints no total row
+
+    private func model(pricesShown: Bool, staticTotal: String) -> DocumentModel {
+        DocumentModel(
+            rows: [], totalKey: "TOTAL", staticTotal: staticTotal,
+            note: "", send: "SEND", pricesShown: pricesShown
+        )
+    }
+
+    /// The same rule the authored sections above already follow, applied to
+    /// the last row on the page. WO-0002 (2026-08-10) went to a crew with
+    /// `TOTAL ——` under the assignment — a heading over an em dash on a
+    /// document that has no money by design.
+    func testUnpricedDocumentWithNothingToTotalShowsNoTotalRow() {
+        XCTAssertFalse(
+            model(pricesShown: false, staticTotal: DocumentModel.noTotal).showsTotal,
+            "a work order has no money by design; an em dash is not a total"
+        )
+    }
+
+    /// A priced document keeps its total even while it is empty: on an
+    /// estimate that blank is a gap the operator is meant to close before
+    /// sending, not an absence.
+    func testPricedDocumentShowsItsTotalEvenWhenEmpty() {
+        XCTAssertTrue(
+            model(pricesShown: true, staticTotal: DocumentModel.noTotal).showsTotal,
+            "an estimate's empty total is a prompt, not noise"
+        )
+    }
+
+    /// Unpriced does not mean total-less. An inspection's total row carries
+    /// its findings count, and that is the summary line of the document.
+    func testUnpricedDocumentKeepsAStaticTotalItActuallyHas() {
+        XCTAssertTrue(
+            model(pricesShown: false, staticTotal: "1 SAFETY · 3 REPAIR").showsTotal,
+            "a findings summary is a total by another name"
+        )
+    }
 }

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -368,14 +368,27 @@ fn compose_document_tool_spec(wants_lines: bool, wants_assignee: bool) -> ToolSp
 /// - A client buying work (`inclusion`) is paying for labor and materials. A
 ///   gate code is not a line item on an estimate.
 /// - A crew executing (`directive`) needs the tasks; the site facts are
-///   already in the block above their heads.
+///   already in the block above their heads, and the money is not theirs to
+///   see — see below.
 /// - A record (`observation`) is the one document where a condition, a note
 ///   and a safety finding ARE the content — that is the whole point of an
 ///   inspection report.
+///
+/// `price` draws on `inclusion` only. A work order is handed to a crew, and a
+/// crew sheet carrying "$500 labor" is the wrong document — the app already
+/// says so twice (`DocumentModel.pricesShown`, and the review sheet refusing
+/// to offer an amount field on an unpriced document); this is the third place,
+/// and the one that was leaking. WO-0002 shipped a bare `$500 labor` line:
+/// unpriced documents never run `price_items`, so the item was rendered raw,
+/// with the figure still in its title — the one thing the extraction prompt
+/// forbids ("a work item never carries a price in its title"). On the estimate
+/// built from the same walk the same item read `Labor` / `$500`, correctly.
 fn draws_kind(line_detail: &str, kind: &str) -> bool {
     match line_detail {
         // Work, materials, and the money for them.
-        "inclusion" | "directive" => matches!(kind, "todo" | "part" | "price"),
+        "inclusion" => matches!(kind, "todo" | "part" | "price"),
+        // Work and materials. Not money.
+        "directive" => matches!(kind, "todo" | "part"),
         // Everything: a report exists to record what was seen.
         _ => true,
     }
@@ -1367,9 +1380,16 @@ mod tests {
         assert!(!asked.contains("Labor"));
     }
 
-    /// The same walk as an INSPECTION (no amount column). Lifting a price out
-    /// of a title would delete it from the only place it can appear, so the
-    /// fold sits out entirely.
+    /// The same walk as a RECORD (no amount column). Lifting a price out of a
+    /// title would delete it from the only place it can appear, so the fold
+    /// sits out entirely.
+    ///
+    /// Built as a report, which is the kind this test's comment always
+    /// described ("an inspection"; `report` is the record kind legal for the
+    /// landscape template). It used to build a `work_order`, and that made it
+    /// the guardian of the WO-0002 bug — asserting that a crew sheet keeps
+    /// `$200 mulch` as a line. A record keeps it (nowhere else to put it); a
+    /// crew sheet no longer draws the kind at all (`draws_kind`).
     #[tokio::test]
     async fn an_unpriced_kind_keeps_every_line_and_every_dollar_in_its_title() {
         let (store, sid) =
@@ -1379,7 +1399,7 @@ mod tests {
             Arc::new(MockProvider::new(vec![compose_response(serde_json::json!([]), serde_json::json!([]))]));
         let b = builder(store.clone(), provider.clone());
 
-        let outcome = b.build(&sid, "work_order").await.unwrap();
+        let outcome = b.build(&sid, "report").await.unwrap();
         let store = store.lock().unwrap();
         let art = store.get_artifact(&outcome.document_artifact_id).unwrap();
         let v: serde_json::Value = serde_json::from_str(&art.body).unwrap();
@@ -2276,6 +2296,7 @@ mod tests {
             ("note", "gate code 4412"),
             ("safety", "loose railing"),
             ("decision", "going with dark mulch"),
+            ("price", "$500 labor"),
         ];
 
         // A work order is for a crew: work and materials, not site trivia —
@@ -2291,7 +2312,12 @@ mod tests {
         let v = decoded_document(&store, &outcome.document_artifact_id);
         let titles: Vec<&str> =
             v["lines"].as_array().unwrap().iter().map(|l| l["title"].as_str().unwrap()).collect();
-        assert_eq!(titles, vec!["mulch the beds", "bark mulch"]);
+        assert_eq!(
+            titles,
+            vec!["mulch the beds", "bark mulch"],
+            "work and materials only — WO-0002 shipped a bare `$500 labor` line, \
+             and money is not a crew directive"
+        );
 
         // …but the FULL item list still reaches the compose pass, or a hazard
         // recorded only as an item would vanish from the safety block too.
@@ -2310,9 +2336,26 @@ mod tests {
         let v2 = decoded_document(&store2, &outcome2.document_artifact_id);
         assert_eq!(
             v2["lines"].as_array().unwrap().len(),
-            5,
+            6,
             "a report records everything — that is what it is for"
         );
+    }
+
+    /// The money rule, stated directly: a price is a line on the document the
+    /// client signs and on nothing else. An estimate and a work order built
+    /// from the SAME walk therefore disagree about one item, on purpose.
+    #[test]
+    fn only_a_document_that_sells_work_draws_its_price() {
+        assert!(draws_kind("inclusion", "price"), "an estimate is the money document");
+        assert!(!draws_kind("directive", "price"), "a crew sheet is not");
+        assert!(draws_kind("observation", "price"), "a record records what was said");
+
+        // Unchanged by this: both still carry the work itself.
+        for detail in ["inclusion", "directive"] {
+            assert!(draws_kind(detail, "todo"));
+            assert!(draws_kind(detail, "part"));
+            assert!(!draws_kind(detail, "note"));
+        }
     }
 
     /// A walk that captured only site conditions has nothing to sell, and

--- a/docs/store/SUBMISSION-KIT.md
+++ b/docs/store/SUBMISSION-KIT.md
@@ -256,3 +256,10 @@ Tell the testers before flipping it, not after.
   a `v1.0.0` tag will be rejected as a duplicate.
 - **A real device pass on the current build** — nothing here has been through a
   sandbox purchase.
+- **Move the proxy's Anthropic key into its own Console workspace with a spend
+  limit** (Isaac) — every tester's traffic bills through that one key, and today
+  the only cost bound is the proxy's own $25/day global cap. A workspace limit is
+  a second backstop that holds even if the proxy's caps are wrong or bypassed,
+  and it makes Console's Usage/Cost pages filterable to Jefe alone instead of
+  mixing with everything else on the account. Month-to-date spend at the time of
+  writing was $0.23, so the limit can start low.


### PR DESCRIPTION
fix: an unpriced document carries no money and no total

Isaac ran a walk on the rotated key and sent EST-0007 and WO-0002. The
estimate was right. The work order carried two things it should not:

    Yard cleanup: trees, trash, excess furniture, gutter cleaning
    $500 labor
    ─────────────────────────────────────────────────────────────
    TOTAL                                                      ——

## Thinking

Both defects are the same mistake seen from two ends: a document that has
no money by design was still being handed money to render.

**`$500 labor` as a line.** `draws_kind` let `price` draw on `directive`
as well as `inclusion`. But a work order goes to a crew, and the app
already says twice that a crew sheet carries no money —
`DocumentModel.pricesShown`, and the review sheet refusing to offer an
amount field on an unpriced document. This was the third place, and the
one that leaked. It leaked badly, too: unpriced documents never run
`price_items`, so the item rendered RAW, with the figure still in its
title — the one thing the extraction prompt explicitly forbids ("a work
item never carries a price in its title"). The estimate built from the
same walk rendered the same item correctly as `Labor` / `$500`, which is
the tell: the fold works, and only the unpriced path was showing its
working. So `price` now draws on `inclusion` only.

**`TOTAL ——`.** `totalValue` falls back to `staticTotal`, which is the
em dash when core sends no static total. Every schema declares
`("sum", "total")`, including the five that set `priced: false`, so an
unpriced document printed a heading over a dash under the crew's
assignment.

The fix is NOT "unpriced documents have no total". An inspection's total
row carries its findings count, and that is the summary line of the
document. The rule is the one the authored sections already follow, and
the one behind optional fields: nothing to say, nothing printed. Hence
`showsTotal` — priced (where an empty total is a gap the operator should
close before sending), or holding a static total it actually has.

Isaac confirmed both: *"any document that shouldn't have prices should
not be showing a total"* and *"yes that should not be there"*. The
`SAFETY: Gloves` line I also flagged turned out to be his own manual
input testing the optional-field path — rendered faithfully, nothing to
fix.

## The test that had to change

`an_unpriced_kind_keeps_every_line_and_every_dollar_in_its_title` failed.
Its doc comment says it builds "an INSPECTION"; it built a `work_order`
— so it was the guardian of exactly this bug, asserting a crew sheet
keeps `$200 mulch` as a line. The invariant it protects is real for
RECORDS (lifting a price out of a title deletes it from the only place
it can appear), so it moves to the kind it always described. `report`,
not `inspection`: inspection is not legal for the landscape template the
fixture uses.

## Verified

546 Rust tests, clippy clean, iOS build + 158 tests on iPhone 17.

Four iOS failures in `DocumentIdentityTests` are PRE-EXISTING on main —
reproduced with this branch stashed. They are #325's CLIENT block not
being reflected in that test's expectations. Not fixed here; flagged
separately, since main is red on a suite CI does not run.

Also folded in: `.gitignore` now covers `.env.*` (nano wrote a
`.env.save` holding a live key today, and a bare `.env` rule does not
match it) and `.direnv/`; SUBMISSION-KIT §7 gains the pre-release item
to move the proxy's key into its own Console workspace with a spend cap.

---

fix: CI runs the iOS tests, and the CLIENT block stops failing them

`DocumentIdentityTests` had been red on main since #325. Nothing noticed
because the iOS job built and never tested.

## Thinking

The test asserted every authored section `hasContent`. #325 added the
optional CLIENT block (PREPARED FOR) to estimates and invoices, and an
unfilled optional block having no content is not a defect — it is the
rule we shipped that day: blank is a fine final state, and `hasContent`
false is exactly what keeps it off the printed page. So the assertion
was asking for the opposite of the intended behavior, and the expected
section lists were simply stale.

Split rather than loosened: walk-filled blocks must still say something
(a heading over an empty box reads as broken), while an all-optional
block is allowed to be empty. Loosening the assertion for every section
would have thrown away the check that catches a genuinely empty SCOPE OF
WORK.

Added `testTheClientBlockIsOfferedButEmptyUntilTyped`, because the two
halves of that behavior live apart — the schema decides the block
exists, `hasContent` decides it prints — and a regression in either is
silent in the worst way: a PREPARED FOR heading over nothing, sent to a
client.

## CI

The iOS job now runs `test`, not `build`. The suite is where the
document rules are actually pinned, and it was the one thing CI never
ran — a day of red on main is the proof.

The simulator is resolved from `simctl` rather than pinned by name: the
runner image changes which iPhones exist, and a hardcoded name fails the
whole job the day it disappears. Building for a concrete device also
covers what the old generic-destination build covered, so this remains a
single compile rather than a build plus a test build.

Folded into this PR rather than sent separately on purpose: landing the
CI change alone would have turned these same pre-existing failures into
a red mark on this PR.

## Verified

159 iOS tests, 0 failures (was 158 with 4). Device-resolution snippet
run locally: resolves "iPhone 17 Pro" on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)