### PR TITLE
ci: the proxy that holds the API key is tested and deployed by merging

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -1,0 +1,289 @@
+# Cloudflare Worker CI + continuous deploy (services/proxy).
+#
+# WHY THIS FILE EXISTS: the proxy is the thing that keeps the real sk-ant- key
+# out of every shipped IPA, and until now it had neither of the two properties
+# that makes that trustworthy:
+#   - nothing tested it. ci.yml is Rust + iOS only, so the 74 vitest tests ran
+#     only when a human remembered to run them.
+#   - nothing deployed it. It shipped by hand via `wrangler deploy` from a
+#     maintainer's laptop, so code could merge to main while the live worker
+#     kept running an older version — silently, with no signal anywhere.
+#
+# PRIVACY: request bodies carry walk transcripts (customer job-site data). The
+# same rule that governs src/index.ts governs this file: nothing here may log,
+# store, or forward a request or response body. The smoke check below therefore
+# asserts on STATUS CODES only, and the one body it ever prints is /health's,
+# which is a two-field constant emitted by a handler that never reads a request
+# body. See the smoke step for the per-assertion justification.
+#
+# Required GitHub secrets:
+#   CLOUDFLARE_API_TOKEN   Cloudflare API token used by `wrangler deploy`.
+#                          Scopes: Workers Scripts: Edit
+#                                  Workers KV Storage: Edit  (the METER binding)
+#                          SAFE WHEN UNSET — see the deploy job.
+#   CLOUDFLARE_ACCOUNT_ID  Optional. Only needed when the token can see more
+#                          than one account; with a single-account token
+#                          wrangler infers it. Empty is harmless.
+#
+# Optional repo variables:
+#   JEFE_PROXY_URL                     Worker base URL for the smoke check.
+#                                      Already used by release.yml for the app
+#                                      build; reused here rather than adding a
+#                                      second source of truth. Falls back to the
+#                                      known production URL when unset.
+#   PROXY_SMOKE_REQUIRE_STREAM_REJECT  "true" makes the streaming-rejection
+#                                      assertion blocking. See that step.
+
+name: Proxy
+
+on:
+  pull_request:
+    paths:
+      - 'services/proxy/**'
+      - '.github/workflows/proxy.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/proxy/**'
+      - '.github/workflows/proxy.yml'
+
+# Cancel superseded PR runs — they are pure checks and the newest push is the
+# only one anyone reads. Do NOT cancel a main run: that one deploys, and killing
+# `wrangler deploy` partway is how you get a live worker in a state no commit
+# describes. Same reasoning release.yml uses for its own `cancel-in-progress`.
+concurrency:
+  group: proxy-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: Proxy (typecheck + vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/proxy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          # setup-node's built-in npm cache. The lockfile is not at the repo
+          # root (this is the only Node project in the tree), so the path has
+          # to be named explicitly or the cache silently never hits.
+          cache: 'npm'
+          cache-dependency-path: services/proxy/package-lock.json
+
+      # `ci` not `install`: it installs exactly the committed lockfile and
+      # fails if package.json and package-lock.json have drifted apart.
+      - name: npm ci
+        run: npm ci
+
+      - name: npm run typecheck
+        run: npm run typecheck
+
+      # `vitest run` — 74 tests across test/proxy.test.ts (pricing, credential
+      # parsing, the credential-for-key swap, byte-identical forwarding, both
+      # caps refusing before upstream, fail-closed misconfiguration) and
+      # test/attest.test.ts (App Attest, inert in production but pinned here).
+      # No network, no miniflare: they run on a plain runner in well under a
+      # second, which is why this job has no cache warm-up beyond npm's.
+      - name: npm test
+        run: npm test
+
+  deploy:
+    name: Deploy to Cloudflare
+    needs: test
+    # Push-to-main only. `needs: test` is what makes a red suite block the
+    # deploy; without it a failing test would merge and ship in the same minute.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    env:
+      # Trailing slash stripped in the smoke step — a var ending in `/` would
+      # otherwise produce `//health`, which Cloudflare routes differently.
+      PROXY_URL: ${{ vars.JEFE_PROXY_URL || 'https://jefe-proxy.damsac-app.workers.dev' }}
+    steps:
+      # SAFE WHEN UNSET — the same idiom release.yml uses for absent secrets,
+      # for the same reason: this workflow has to be able to land BEFORE the
+      # secret exists.
+      #
+      # GitHub does not expand `secrets.*` in a job-level `if:` (the secrets
+      # context is not available there), so the presence test has to happen in
+      # a step and be re-exported as a step output that later steps gate on.
+      #
+      # It SKIPS rather than fails. A permanently-red main is worse than no
+      # deploy job at all: it trains everyone to ignore the badge, and then the
+      # badge stops meaning anything on the day it does matter. A skipped job
+      # is green-with-a-notice, which is the honest report — "nothing deployed,
+      # here is exactly what to configure."
+      - name: Check for CLOUDFLARE_API_TOKEN
+        id: gate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Not configured — skipping deploy
+        if: ${{ steps.gate.outputs.configured != 'true' }}
+        run: |
+          echo "::notice::CLOUDFLARE_API_TOKEN is not set — the proxy was NOT deployed. The live worker is still running whatever was last pushed by hand. To turn this on: mint a Cloudflare API token with 'Workers Scripts: Edit' and 'Workers KV Storage: Edit' (the latter for the METER namespace binding), then add it as the repo secret CLOUDFLARE_API_TOKEN. Re-run this workflow, or push any change under services/proxy/, to deploy. See services/proxy/README.md."
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.gate.outputs.configured == 'true' }}
+
+      - uses: actions/setup-node@v4
+        if: ${{ steps.gate.outputs.configured == 'true' }}
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: services/proxy/package-lock.json
+
+      # wrangler is a devDependency, so `npx wrangler` below resolves to the
+      # pinned local copy rather than downloading whatever is newest today.
+      - name: npm ci
+        if: ${{ steps.gate.outputs.configured == 'true' }}
+        working-directory: services/proxy
+        run: npm ci
+
+      # Secrets (ANTHROPIC_API_KEY, APP_SECRET) and the KV namespace are NOT
+      # managed here — they were set once with `wrangler secret put` and live in
+      # Cloudflare. `wrangler deploy` uploads code and wrangler.toml config and
+      # leaves existing secrets alone. This job therefore never handles the
+      # Anthropic key at all, which is the point of the service.
+      - name: wrangler deploy
+        if: ${{ steps.gate.outputs.configured == 'true' }}
+        working-directory: services/proxy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy
+
+      # Wrangler's exit code says "Cloudflare accepted an upload", not "the
+      # thing now answering requests is the code in this commit and it still
+      # has its secrets". Those come apart in exactly the ways that matter:
+      # a deploy can land against the wrong environment, and a worker can go
+      # live having lost ANTHROPIC_API_KEY/APP_SECRET, which src/index.ts turns
+      # into a blanket 500 on every call. So: probe the live URL.
+      #
+      # CI holds no valid APP_SECRET, so everything past /health is probed with
+      # a deliberately-invalid credential. That is not a limitation to work
+      # around — the 401-vs-500 distinction it produces is the single most
+      # useful thing this check can assert (see below).
+      - name: Smoke check the live worker
+        if: ${{ steps.gate.outputs.configured == 'true' }}
+        env:
+          # "true" makes the streaming assertion blocking. See that block.
+          REQUIRE_STREAM_REJECT: ${{ vars.PROXY_SMOKE_REQUIRE_STREAM_REJECT }}
+        run: |
+          set -euo pipefail
+          BASE="${PROXY_URL%/}"
+          echo "Smoke-checking $BASE"
+
+          # A well-formed credential carrying a secret that is definitively not
+          # the real one. Well-formed matters: a malformed credential is
+          # rejected by shape before the secret is ever compared, which would
+          # make the 401 prove less than it looks like it proves.
+          BAD_CRED='jefe.ci-smoke-check.not-the-real-app-secret'
+
+          # ---- 1. GET /health is 200 and says {"ok":true} -------------------
+          # Retried: a fresh deploy takes a moment to propagate to every edge,
+          # and a cold miss here would fail a deploy that is in fact fine.
+          HEALTH_CODE=""
+          for attempt in 1 2 3 4 5; do
+            HEALTH_CODE=$(curl -sS -o "$RUNNER_TEMP/health.json" -w '%{http_code}' \
+              --max-time 20 "$BASE/health" || echo "000")
+            [ "$HEALTH_CODE" = "200" ] && break
+            echo "  /health attempt $attempt returned $HEALTH_CODE — retrying in 5s"
+            sleep 5
+          done
+          if [ "$HEALTH_CODE" != "200" ]; then
+            echo "::error::GET $BASE/health returned $HEALTH_CODE, expected 200. The deploy uploaded but the worker is not serving."
+            exit 1
+          fi
+          # Printing THIS body is safe and is the only body printed anywhere in
+          # this workflow: the /health handler in src/index.ts returns a fixed
+          # two-field literal and never reads the request body, so it cannot
+          # carry a transcript. Every other assertion below discards its body
+          # to /dev/null.
+          HEALTH_BODY=$(cat "$RUNNER_TEMP/health.json")
+          if [ "$HEALTH_BODY" != '{"ok":true}' ]; then
+            echo "::error::GET $BASE/health returned 200 but the body was '$HEALTH_BODY', expected '{\"ok\":true}'. Something other than this worker is answering that URL."
+            exit 1
+          fi
+          echo "  ok  GET /health -> 200 {\"ok\":true}"
+
+          # ---- 2. A wrong credential is 401, NOT 500 ------------------------
+          # This is the assertion that catches a worker which deployed cleanly
+          # but lost its configuration. src/index.ts checks APP_SECRET and
+          # ANTHROPIC_API_KEY BEFORE it authenticates, and returns 500 "proxy is
+          # not configured" when either is missing. So:
+          #   401 -> both secrets are present and the credential was compared
+          #   500 -> the worker is live and broken; every real call is failing
+          #   200 -> alarming: an obviously-wrong secret was accepted
+          # Auth fails before any body is read or any spend is metered, so this
+          # probe costs nothing and touches no counter.
+          AUTH_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+            -X POST "$BASE/v1/messages" \
+            -H 'content-type: application/json' \
+            -H "x-api-key: $BAD_CRED" \
+            --data '{"model":"claude-3-5-haiku-20241022","max_tokens":1,"messages":[{"role":"user","content":"ci smoke check"}]}' \
+            || echo "000")
+          if [ "$AUTH_CODE" = "500" ]; then
+            echo "::error::POST /v1/messages returned 500 — the worker deployed but is missing ANTHROPIC_API_KEY and/or APP_SECRET. Every real call is failing right now. Re-set them with 'wrangler secret put' (see services/proxy/README.md); they are NOT managed by this workflow."
+            exit 1
+          fi
+          if [ "$AUTH_CODE" != "401" ]; then
+            echo "::error::POST /v1/messages with a deliberately-invalid credential returned $AUTH_CODE, expected 401. A wrong secret must be refused."
+            exit 1
+          fi
+          echo "  ok  POST /v1/messages (invalid credential) -> 401"
+
+          # ---- 3. A streaming request is refused ---------------------------
+          # The rejection lands in the metering-fix PR
+          # (pr/dam/proxy-only-and-metering-fixes). It is asserted here as a
+          # SET of acceptable codes rather than a single one, because from CI
+          # the two passing shapes are genuinely indistinguishable:
+          #
+          #   400 -> the guard ran and refused the stream. Proven.
+          #   401 -> the credential was refused FIRST, so the request never
+          #          reached the guard. On main today src/index.ts authenticates
+          #          before it reads the body at all, so unless that PR places
+          #          the stream check ahead of the credential check, 401 is what
+          #          a correct worker returns here and no unauthenticated probe
+          #          can ever see the 400. This is NOT proof the guard exists.
+          #   else -> a real failure, including 200 (a stream was accepted).
+          #
+          # This is deliberately not a check that cannot fail: 200/404/500/5xx
+          # all fail it unconditionally. What it cannot do is distinguish
+          # "guard absent" from "guard unreachable without a valid APP_SECRET",
+          # and it says so out loud rather than reporting a pass it did not earn.
+          # Set the repo variable PROXY_SMOKE_REQUIRE_STREAM_REJECT=true once
+          # that PR lands with the guard ahead of auth, and 401 becomes fatal.
+          STREAM_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+            -X POST "$BASE/v1/messages" \
+            -H 'content-type: application/json' \
+            -H "x-api-key: $BAD_CRED" \
+            --data '{"model":"claude-3-5-haiku-20241022","max_tokens":1,"stream":true,"messages":[{"role":"user","content":"ci smoke check"}]}' \
+            || echo "000")
+          case "$STREAM_CODE" in
+            400)
+              echo "  ok  POST /v1/messages (stream:true) -> 400, streaming refused"
+              ;;
+            401)
+              if [ "${REQUIRE_STREAM_REJECT:-}" = "true" ]; then
+                echo "::error::POST /v1/messages with stream:true returned 401, not 400. PROXY_SMOKE_REQUIRE_STREAM_REJECT is set, which asserts the streaming guard runs BEFORE the credential check — it did not. Either the guard regressed, or it moved behind auth (in which case unset that variable; the guard is then only pinned by the vitest suite)."
+                exit 1
+              fi
+              echo "::warning::POST /v1/messages with stream:true returned 401, so the streaming rejection was NOT observed. The credential is checked before the body is read, so this is what a correct worker returns to an unauthenticated probe whether the guard exists or not — CI has no valid APP_SECRET and cannot tell the two apart. UNPROVEN, not passed. Once pr/dam/proxy-only-and-metering-fixes lands, check where it put the guard: if ahead of the credential check, set the repo variable PROXY_SMOKE_REQUIRE_STREAM_REJECT=true to make this blocking; if behind it, the vitest suite is the only place this behaviour is pinned and this probe stays advisory."
+              ;;
+            *)
+              echo "::error::POST /v1/messages with stream:true returned $STREAM_CODE, expected 400 (streaming refused) or 401 (credential refused first). A 200 here means the worker accepted a streaming request."
+              exit 1
+              ;;
+          esac
+
+          echo "Smoke check complete."

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -24,6 +24,11 @@
 #   CLOUDFLARE_ACCOUNT_ID  Optional. Only needed when the token can see more
 #                          than one account; with a single-account token
 #                          wrangler infers it. Empty is harmless.
+#   JEFE_APP_SECRET        Already set — release.yml bakes it into the shipped
+#                          app, and it must equal the worker's APP_SECRET or
+#                          every build would 401. Reused here so the smoke
+#                          check can make an AUTHENTICATED probe. Not required:
+#                          without it the authenticated assertions skip.
 #
 # Optional repo variables:
 #   JEFE_PROXY_URL                     Worker base URL for the smoke check.
@@ -31,8 +36,11 @@
 #                                      build; reused here rather than adding a
 #                                      second source of truth. Falls back to the
 #                                      known production URL when unset.
-#   PROXY_SMOKE_REQUIRE_STREAM_REJECT  "true" makes the streaming-rejection
-#                                      assertion blocking. See that step.
+#   PROXY_SMOKE_REQUIRE_STREAM_REJECT  "true" escalates the request-validation
+#                                      assertions from advisory to blocking.
+#                                      See that step for exactly what it does
+#                                      and — just as important — what it does
+#                                      NOT make fatal.
 
 name: Proxy
 
@@ -169,15 +177,22 @@ jobs:
       # live having lost ANTHROPIC_API_KEY/APP_SECRET, which src/index.ts turns
       # into a blanket 500 on every call. So: probe the live URL.
       #
-      # CI holds no valid APP_SECRET, so everything past /health is probed with
-      # a deliberately-invalid credential. That is not a limitation to work
-      # around — the 401-vs-500 distinction it produces is the single most
-      # useful thing this check can assert (see below).
+      # It probes twice over, because the two credentials prove different
+      # things. An INVALID credential proves the worker still has its secrets
+      # (401 means it compared them; 500 means it lost them). A VALID one —
+      # JEFE_APP_SECRET, which release.yml already bakes into the app and which
+      # must equal the worker's APP_SECRET — reaches past auth to the request
+      # validation the app actually depends on.
       - name: Smoke check the live worker
         if: ${{ steps.gate.outputs.configured == 'true' }}
         env:
-          # "true" makes the streaming assertion blocking. See that block.
+          # "true" escalates the request-validation assertions. See that block.
           REQUIRE_STREAM_REJECT: ${{ vars.PROXY_SMOKE_REQUIRE_STREAM_REJECT }}
+          # The same secret release.yml bakes into the app. It MUST equal the
+          # worker's APP_SECRET or every shipped build would 401, which is what
+          # lets CI make an authenticated probe without holding a new secret.
+          # GitHub masks it in logs; nothing below ever echoes it.
+          JEFE_APP_SECRET: ${{ secrets.JEFE_APP_SECRET }}
         run: |
           set -euo pipefail
           BASE="${PROXY_URL%/}"
@@ -242,48 +257,131 @@ jobs:
           fi
           echo "  ok  POST /v1/messages (invalid credential) -> 401"
 
-          # ---- 3. A streaming request is refused ---------------------------
-          # The rejection lands in the metering-fix PR
-          # (pr/dam/proxy-only-and-metering-fixes). It is asserted here as a
-          # SET of acceptable codes rather than a single one, because from CI
-          # the two passing shapes are genuinely indistinguishable:
+          # ---- 3. Request validation, via an AUTHENTICATED probe ------------
+          # The `stream: true` and model-allowlist guards both sit AFTER
+          # `authenticate()` — deliberately, and the reasoning is worth keeping
+          # here because it is what shapes this block. `/v1/messages` has no
+          # body size cap, so putting body-dependent checks ahead of auth would
+          # expose an uncapped text()+JSON.parse to unauthenticated scanners,
+          # break the file's invariant that every body read is post-auth, and
+          # hand the allowlist contents to anyone who asks. The observability
+          # those checks would have bought is available a cheaper way: give the
+          # probe a real credential. CI already holds JEFE_APP_SECRET, which
+          # must equal the worker's APP_SECRET or every shipped build would
+          # 401 — so there is no new secret to mint and no new trust to grant.
           #
-          #   400 -> the guard ran and refused the stream. Proven.
-          #   401 -> the credential was refused FIRST, so the request never
-          #          reached the guard. On main today src/index.ts authenticates
-          #          before it reads the body at all, so unless that PR places
-          #          the stream check ahead of the credential check, 401 is what
-          #          a correct worker returns here and no unauthenticated probe
-          #          can ever see the 400. This is NOT proof the guard exists.
-          #   else -> a real failure, including 200 (a stream was accepted).
+          # An authenticated probe is cheap BY CONSTRUCTION, not by luck: both
+          # guards return before the upstream `fetch`, and `addSpend` runs only
+          # on a successful upstream response. A rejected probe therefore makes
+          # no Anthropic call and moves no spend counter.
           #
-          # This is deliberately not a check that cannot fail: 200/404/500/5xx
-          # all fail it unconditionally. What it cannot do is distinguish
-          # "guard absent" from "guard unreachable without a valid APP_SECRET",
-          # and it says so out loud rather than reporting a pass it did not earn.
-          # Set the repo variable PROXY_SMOKE_REQUIRE_STREAM_REJECT=true once
-          # that PR lands with the guard ahead of auth, and 401 becomes fatal.
-          STREAM_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
-            -X POST "$BASE/v1/messages" \
-            -H 'content-type: application/json' \
-            -H "x-api-key: $BAD_CRED" \
-            --data '{"model":"claude-3-5-haiku-20241022","max_tokens":1,"stream":true,"messages":[{"role":"user","content":"ci smoke check"}]}' \
-            || echo "000")
-          case "$STREAM_CODE" in
-            400)
-              echo "  ok  POST /v1/messages (stream:true) -> 400, streaming refused"
-              ;;
-            401)
-              if [ "${REQUIRE_STREAM_REJECT:-}" = "true" ]; then
-                echo "::error::POST /v1/messages with stream:true returned 401, not 400. PROXY_SMOKE_REQUIRE_STREAM_REJECT is set, which asserts the streaming guard runs BEFORE the credential check — it did not. Either the guard regressed, or it moved behind auth (in which case unset that variable; the guard is then only pinned by the vitest suite)."
-                exit 1
-              fi
-              echo "::warning::POST /v1/messages with stream:true returned 401, so the streaming rejection was NOT observed. The credential is checked before the body is read, so this is what a correct worker returns to an unauthenticated probe whether the guard exists or not — CI has no valid APP_SECRET and cannot tell the two apart. UNPROVEN, not passed. Once pr/dam/proxy-only-and-metering-fixes lands, check where it put the guard: if ahead of the credential check, set the repo variable PROXY_SMOKE_REQUIRE_STREAM_REJECT=true to make this blocking; if behind it, the vitest suite is the only place this behaviour is pinned and this probe stays advisory."
-              ;;
-            *)
-              echo "::error::POST /v1/messages with stream:true returned $STREAM_CODE, expected 400 (streaming refused) or 401 (credential refused first). A 200 here means the worker accepted a streaming request."
+          # Each probe is built so that exactly ONE guard can produce its 400,
+          # which matters because we never read response bodies and 400 is the
+          # shared status:
+          #   - stream probe: ALLOWED model + `stream: true` -> only the stream
+          #     guard can reject it (the JSON is valid, the model is fine).
+          #   - model probe: disallowed model + NO `stream` field -> the stream
+          #     guard cannot fire, so only the allowlist can reject it.
+          PROBE_INSTALL='ci-smoke-check'
+          ALLOWED_MODEL='claude-haiku-4-5'
+          # Deliberately not a real model and deliberately not a near-miss of an
+          # allowed prefix — the allowlist is prefix-matched, so a name like
+          # `claude-haiku-4-5-x` would be ACCEPTED and this probe would be
+          # asserting the opposite of what it looks like it asserts.
+          DISALLOWED_MODEL='claude-fable-5'
+
+          # Whether the deployed code even contains the guards. This is read
+          # from the checkout we just deployed, so it is a fact about the
+          # shipped commit rather than a guess: it turns "we could not observe
+          # the guard" into the two genuinely different states, "the guard is
+          # not in this build" and "the guard is in this build but the live
+          # worker did not apply it" — and only the second is a deploy failure.
+          #
+          # It also prevents a real hazard while these two PRs are in flight.
+          # If this workflow deploys a commit WITHOUT the guards, an
+          # authenticated `stream: true` probe would be forwarded to Anthropic:
+          # a live SSE call that spends money and, being unparseable as JSON,
+          # meters as zero. Probing for a guard must not exercise the very
+          # bypass the guard exists to close.
+          GUARDS_PRESENT=true
+          grep -q 'stream === true' services/proxy/src/index.ts || GUARDS_PRESENT=false
+          grep -q 'isAllowedModel' services/proxy/src/index.ts || GUARDS_PRESENT=false
+
+          SKIP_REASON=''
+          if [ -z "${JEFE_APP_SECRET:-}" ]; then
+            SKIP_REASON='the JEFE_APP_SECRET secret is not set, so no authenticated probe can be made'
+          elif [ "$GUARDS_PRESENT" != "true" ]; then
+            SKIP_REASON='the deployed commit does not contain the stream/allowlist guards (services/proxy/src/index.ts), so there is nothing to observe — probing anyway would forward a streaming request to Anthropic and spend real money unmetered'
+          fi
+
+          if [ -n "$SKIP_REASON" ]; then
+            if [ "${REQUIRE_STREAM_REJECT:-}" = "true" ]; then
+              echo "::error::Request-validation probes did NOT run: $SKIP_REASON. PROXY_SMOKE_REQUIRE_STREAM_REJECT is set, which asserts these checks actually run — a smoke check that quietly stops checking is the failure this switch exists to catch."
               exit 1
-              ;;
-          esac
+            fi
+            echo "::warning::Request-validation probes skipped: $SKIP_REASON. /health and the 401-vs-500 assertion above still ran."
+          else
+            FAILED=0
+
+            # Classifies one probe. The status set is not arbitrary — every arm
+            # corresponds to a specific path through src/index.ts.
+            #   400 -> the guard fired. Proven.
+            #   200 -> the guard did NOT fire and upstream served the request.
+            #          This is the regression worth paging for, and it is fatal
+            #          whether or not the escalation switch is set.
+            #   503 -> the GLOBAL daily cap is tripped. The cap check runs
+            #   429    before the body is ever read, so it shadows both guards:
+            #          the probe never reached them and proves nothing either
+            #          way. 429 is the per-install twin, reachable now that
+            #          PER_INSTALL_DAILY_CAP_USD="0" is a legitimate blanket
+            #          kill switch. INCONCLUSIVE, never fatal — a spend
+            #          incident is precisely when a spurious page is most
+            #          expensive and least informative.
+            #   401 -> the probe's own credential was refused. Either
+            #          JEFE_APP_SECRET has drifted from the worker's APP_SECRET
+            #          (in which case the shipped app is also 401ing and that is
+            #          the real emergency), or ATTEST_MODE has left `off` and a
+            #          plain `jefe.` credential can no longer satisfy it. Loud,
+            #          but not fatal: like 503, it means unreachable, not
+            #          regressed, and failing the deploy would not fix either.
+            #   else -> a real failure (404, 5xx, a network 000).
+            classify() {
+              case "$2" in
+                400) echo "  ok  $1 -> 400 ($3)" ;;
+                200)
+                  echo "::error::$1 returned 200 — the request was NOT rejected and was served upstream. $3 is not being enforced by the live worker."
+                  FAILED=1
+                  ;;
+                503|429)
+                  echo "::warning::$1 returned $2 — a daily spend cap is tripped, and the cap check runs before the body is read, so the probe never reached the guard. INCONCLUSIVE, not a pass and not a failure. Re-run after the cap resets (or after raising it) to actually exercise $3."
+                  ;;
+                401)
+                  echo "::warning::$1 returned 401 — the probe's credential was refused, so it never reached the guard. INCONCLUSIVE. Two causes worth checking in this order: (1) JEFE_APP_SECRET no longer equals the worker's APP_SECRET, which means every shipped build is also failing right now; (2) ATTEST_MODE has left 'off', which a plain jefe. credential cannot satisfy. Not treated as a deploy failure either way — it means unreachable, not regressed."
+                  ;;
+                *)
+                  echo "::error::$1 returned $2, expected 400. If this is a 404 or a 5xx the request went upstream instead of being rejected, which means the live worker is not running the code that was just deployed."
+                  FAILED=1
+                  ;;
+              esac
+            }
+
+            STREAM_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+              -X POST "$BASE/v1/messages" \
+              -H 'content-type: application/json' \
+              -H "x-api-key: jefe.$PROBE_INSTALL.$JEFE_APP_SECRET" \
+              --data "{\"model\":\"$ALLOWED_MODEL\",\"max_tokens\":1,\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"ci smoke check\"}]}" \
+              || echo "000")
+            classify 'POST /v1/messages (authenticated, stream:true)' "$STREAM_CODE" 'streaming refused'
+
+            MODEL_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+              -X POST "$BASE/v1/messages" \
+              -H 'content-type: application/json' \
+              -H "x-api-key: jefe.$PROBE_INSTALL.$JEFE_APP_SECRET" \
+              --data "{\"model\":\"$DISALLOWED_MODEL\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ci smoke check\"}]}" \
+              || echo "000")
+            classify "POST /v1/messages (authenticated, model:$DISALLOWED_MODEL)" "$MODEL_CODE" 'the model allowlist'
+
+            [ "$FAILED" -eq 0 ] || exit 1
+          fi
 
           echo "Smoke check complete."

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -134,6 +134,69 @@ a transcript warehouse. This is asserted by the file header in `src/index.ts`.
 
 ## Deploy
 
+**Merging to `main` deploys this worker.** `.github/workflows/proxy.yml` runs
+the test suite on every PR that touches `services/proxy/**`, and on a push to
+`main` it runs the suite again and then `wrangler deploy`. The deploy `needs:`
+the test job, so a red suite stops the ship.
+
+That workflow exists because the alternative had already bitten: with deploys
+happening by hand from a laptop, code could merge to `main` while the live
+worker kept serving an older version, and nothing anywhere said so.
+
+### One-time setup for the CI deploy
+
+The workflow needs one repo secret. **Until it is set, the deploy job skips
+with a notice rather than failing** — the workflow is safe to have landed
+before the token existed, but nothing is being deployed while it is missing.
+
+| Name | Kind | Value |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | secret | Cloudflare API token (scopes below) |
+| `CLOUDFLARE_ACCOUNT_ID` | secret, optional | Only if the token can see more than one account; a single-account token is inferred |
+| `JEFE_PROXY_URL` | variable, optional | Worker base URL for the post-deploy smoke check. Already set for the app build; reused rather than duplicated |
+
+Mint the token at **My Profile → API Tokens → Create Token → Custom token**
+with exactly these permissions:
+
+| Permission | Level | Why |
+|---|---|---|
+| Account → **Workers Scripts** | **Edit** | Upload the worker itself |
+| Account → **Workers KV Storage** | **Edit** | The `METER` namespace binding in `wrangler.toml` — a deploy that binds KV is refused without it |
+
+Nothing broader is needed. In particular the token grants no access to the
+worker's *secrets*: `ANTHROPIC_API_KEY` and `APP_SECRET` are set once by hand
+(below) and `wrangler deploy` leaves them untouched, so CI never handles the
+Anthropic key. That is the whole point of the service, and it survives the
+move to CI.
+
+### Post-deploy smoke check
+
+CI does not trust wrangler's exit code — that says "Cloudflare accepted an
+upload", not "the running worker is this commit and still has its secrets".
+After each deploy it asserts, against the live URL:
+
+- `GET /health` → `200` `{"ok":true}`
+- `POST /v1/messages` with a deliberately-invalid credential → `401`, **not**
+  `500`. A `500` is `index.ts`'s "proxy is not configured" — a worker that
+  deployed cleanly and lost `ANTHROPIC_API_KEY`/`APP_SECRET`, which fails every
+  real call. That 401-vs-500 distinction is the most useful thing an
+  unauthenticated probe can tell you.
+- `POST /v1/messages` with `stream: true` → `400`. CI holds no valid
+  `APP_SECRET`, and the credential is checked before the body is read, so this
+  probe sees `401` unless the streaming guard runs ahead of authentication. It
+  treats `401` as *unproven* (a loud warning, not a pass) and fails on anything
+  else. Set the repo variable `PROXY_SMOKE_REQUIRE_STREAM_REJECT=true` to make
+  the `400` mandatory once the guard is known to run pre-auth.
+
+It asserts on status codes and never prints a `/v1/messages` response body —
+the privacy rule above governs CI output too.
+
+### First-time (or break-glass) manual deploy
+
+Still the path for standing up a new worker, and for shipping when GitHub is
+down. Steps 1 and 2 are one-time and are **not** automated: CI deliberately has
+no ability to read or write the worker's secrets.
+
 ```sh
 cd services/proxy
 npm install
@@ -218,5 +281,15 @@ pass.
 What the synthetic chain cannot prove is that we accept **Apple's** real root.
 That is the residual risk, and the reason the rollout starts in `monitor`.
 
-These are **not** wired into the repo's GitHub Actions CI, which is Rust +
-iOS only. Run them locally before deploying.
+These run in CI. `.github/workflows/proxy.yml` runs `npm ci`, `npm run
+typecheck`, and `npm test` on every pull request that touches
+`services/proxy/**`, and again on `main` before the deploy — the deploy
+`needs:` that job, so a red suite never ships. They need no network and no
+miniflare, so the whole gate finishes in seconds.
+
+The path filter cuts both ways, and it is worth knowing which way: a
+docs-only change does not run this workflow at all, which is the point (it
+cannot affect the worker). But it also means these checks are **absent**, not
+green, on such a PR — so do not mark them as *required* status checks without
+also adding a path-aware skip job, or every docs PR will sit forever waiting
+on a check that will never report.

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -154,6 +154,7 @@ before the token existed, but nothing is being deployed while it is missing.
 | `CLOUDFLARE_API_TOKEN` | secret | Cloudflare API token (scopes below) |
 | `CLOUDFLARE_ACCOUNT_ID` | secret, optional | Only if the token can see more than one account; a single-account token is inferred |
 | `JEFE_PROXY_URL` | variable, optional | Worker base URL for the post-deploy smoke check. Already set for the app build; reused rather than duplicated |
+| `JEFE_APP_SECRET` | secret, **already set** | Nothing to do. `release.yml` already bakes it into the app, and it must equal the worker's `APP_SECRET` or every build would 401 — which is exactly why the smoke check can borrow it for an authenticated probe |
 
 Mint the token at **My Profile → API Tokens → Create Token → Custom token**
 with exactly these permissions:
@@ -173,23 +174,79 @@ move to CI.
 
 CI does not trust wrangler's exit code — that says "Cloudflare accepted an
 upload", not "the running worker is this commit and still has its secrets".
-After each deploy it asserts, against the live URL:
+After each deploy it probes the live URL, with two credentials that prove
+different things.
 
-- `GET /health` → `200` `{"ok":true}`
+**Unauthenticated**, which proves the worker still *has* its configuration:
+
+- `GET /health` → `200` `{"ok":true}`.
 - `POST /v1/messages` with a deliberately-invalid credential → `401`, **not**
   `500`. A `500` is `index.ts`'s "proxy is not configured" — a worker that
   deployed cleanly and lost `ANTHROPIC_API_KEY`/`APP_SECRET`, which fails every
-  real call. That 401-vs-500 distinction is the most useful thing an
-  unauthenticated probe can tell you.
-- `POST /v1/messages` with `stream: true` → `400`. CI holds no valid
-  `APP_SECRET`, and the credential is checked before the body is read, so this
-  probe sees `401` unless the streaming guard runs ahead of authentication. It
-  treats `401` as *unproven* (a loud warning, not a pass) and fails on anything
-  else. Set the repo variable `PROXY_SMOKE_REQUIRE_STREAM_REJECT=true` to make
-  the `400` mandatory once the guard is known to run pre-auth.
+  real call. That 401-vs-500 distinction is the most useful thing a probe
+  without a credential can tell you.
 
-It asserts on status codes and never prints a `/v1/messages` response body —
-the privacy rule above governs CI output too.
+**Authenticated**, which reaches the request validation (the `stream: true`
+refusal and the model allowlist). Both guards sit *after* `authenticate()` —
+the right place, since
+`/v1/messages` has no body size cap and moving them ahead of auth would expose
+`text()` + `JSON.parse` to unauthenticated scanners and hand the allowlist to
+anyone who asks. CI does not need them moved: it already holds
+`JEFE_APP_SECRET`, so it can simply present `jefe.ci-smoke-check.<secret>`.
+
+- `stream: true` with an **allowed** model → `400`.
+- an **allowlisted-out** model (`claude-fable-5`), with no `stream` field → `400`.
+
+Each probe is shaped so only one guard can produce its `400`, since the check
+never reads response bodies. Neither costs anything: both guards return before
+the upstream `fetch`, and `addSpend` runs only on a successful upstream
+response — so a rejected probe makes no Anthropic call and moves no counter.
+
+#### What the smoke check will *not* fail on
+
+The cap check runs **before** the body is read, so a tripped cap shadows both
+guards — the probe never reaches them:
+
+| Status | Meaning | Treated as |
+|---|---|---|
+| `400` | The guard fired | **pass** |
+| `200` | Not rejected, served upstream | **hard fail** — the regression worth paging for |
+| `503` / `429` | Global / per-install daily cap tripped | **inconclusive**, warn and continue |
+| `401` | The probe's own credential was refused | **inconclusive**, warn loudly |
+| `404`, `5xx` | Went upstream instead of being rejected | **fail** — the live worker is not running the deployed code |
+
+`503` and `429` stay non-fatal on purpose. A spend incident is exactly when a
+spurious page is most expensive and least informative, and failing the deploy
+would not fix the cap. `429` is reachable in ordinary operation now that
+`PER_INSTALL_DAILY_CAP_USD = "0"` is a legitimate blanket kill switch.
+
+A `401` on the *authenticated* probe has two causes, worth checking in this
+order: `JEFE_APP_SECRET` has drifted from the worker's `APP_SECRET` (in which
+case the shipped app is also failing, and that is the real emergency), or
+`ATTEST_MODE` has left `off`, which a plain `jefe.` credential cannot satisfy.
+Both mean *unreachable*, not *regressed*.
+
+#### `PROXY_SMOKE_REQUIRE_STREAM_REJECT`
+
+Set this repo variable to `true` to escalate. It makes it fatal when the
+authenticated probes **do not run at all** — because `JEFE_APP_SECRET` is
+missing, or because the deployed commit does not contain the guards. A smoke
+check that quietly stops checking is the failure this switch exists to catch.
+
+It does **not** make `503`, `429`, or `401` fatal. Those are unreachable-guard
+states, and escalating them would page someone during an unrelated spend
+incident. A `200` is fatal with or without the switch.
+
+Before probing, the check greps the deployed checkout for the guards. That
+turns "we could not observe it" into two genuinely different states — *not in
+this build* versus *in this build but the live worker didn't apply it* — and
+only the second is a deploy failure. It also stops the check from exercising
+the very bypass it is testing for: against a build without the guards, an
+authenticated `stream: true` probe would be forwarded to Anthropic as a real
+SSE call that spends money and meters as zero.
+
+Everything is asserted on status codes; no `/v1/messages` response body is ever
+printed — the privacy rule above governs CI output too.
 
 ### First-time (or break-glass) manual deploy
 


### PR DESCRIPTION
## Thinking

`services/proxy/` is the piece of infrastructure whose entire job is to hold the real `sk-ant-…` key so it stops shipping inside every IPA. It is the highest-trust thing in the repo, and it was the least-verified: no workflow tested it, and no workflow deployed it.

The deploy gap is the sharper one, and it is not hypothetical — it is happening right now. Code merges to `main`; the live worker keeps serving whatever a laptop last pushed. There is no signal anywhere that the two have diverged. The metering fixes in #329 will merge and *not be live* until someone remembers to run `wrangler deploy` by hand. A deploy that depends on a person remembering is a deploy that has already silently failed some number of times you cannot enumerate.

Four things shaped the design.

**The token does not exist yet, so the job has to skip rather than fail.** Landing a workflow that goes red on every merge to `main` is worse than landing nothing: within about two days everyone learns to ignore the badge, and then the badge has no signal left on the day something real breaks. `release.yml` already solved this shape for the absent Apple secrets and labelled it `SAFE WHEN UNSET`; I used the same idiom and the same comment style. GitHub doesn't expand `secrets.*` in a job-level `if:`, so the presence test is a step that re-exports a step output the later steps gate on — and the skip path prints a notice saying exactly which secret, which scopes, and what happens until then.

**Wrangler's exit code is not evidence.** It says "Cloudflare accepted an upload," which is a different claim from "the thing now answering requests is this commit and it still has its secrets." Those come apart in exactly the way that hurts most: a worker can go live having lost `ANTHROPIC_API_KEY`/`APP_SECRET`, and `src/index.ts` turns that into a blanket 500 on every call while the deploy reports success. So the smoke check probes the live URL. With an *invalid* credential, **401 proves the worker has both secrets and compared them; 500 means it deployed clean and lost them** — the most useful thing a probe without a credential can say.

**The request guards are reachable, but only with a credential — and that's the better design.** #329 put the `stream: true` refusal and the model allowlist behind `authenticate()`, and I agree with the call: `/v1/messages` has no body size cap, so moving body-dependent checks ahead of auth would expose `text()` + `JSON.parse` to unauthenticated scanners, break the file's invariant that every body read is post-auth and size-capped, and hand the allowlist contents to anyone who asks. The observability comes cheaper from the other side: CI already holds `JEFE_APP_SECRET`, which *must* equal the worker's `APP_SECRET` or every shipped build would 401. So the probe carries `jefe.ci-smoke-check.<secret>` and observes the 400 directly. No new secret, no new trust — and cheap by construction rather than by luck, since both guards return before the upstream `fetch` and `addSpend` runs only on a successful upstream response. A rejected probe makes no Anthropic call and moves no counter.

**A tripped cap shadows both guards, and that has to be inconclusive rather than red.** Caps are evaluated before the body is ever read (L375/L385 vs L410), so a tripped cap means the probe never reached the guard — it proves nothing in either direction. Failing there would page someone during an unrelated spend incident, which is precisely when a spurious alarm costs the most and teaches the least. `429` gets the same treatment as `503`, and it is not hypothetical: #329 made `PER_INSTALL_DAILY_CAP_USD = "0"` a legitimate blanket kill switch, so an operator using it as intended would otherwise turn every deploy red. `401` on the *authenticated* probe joins them — a drifted `JEFE_APP_SECRET`, or `ATTEST_MODE` leaving `off` (a plain `jefe.` credential can't satisfy `enforce`), both mean *unreachable*, not *regressed*, and failing the deploy fixes neither. What stays fatal is `200`: a stream served upstream is the actual regression, and it is fatal with or without the escalation switch.

**One hazard I had to close.** These two PRs are in flight simultaneously. If #328 merges first, it deploys a commit with *no* guards — and an authenticated `stream: true` probe against that build would not be rejected. It would be forwarded to Anthropic as a live SSE call that spends real money and, being unparseable as JSON, meters as zero. The probe for a guard would have exercised the exact bypass the guard exists to close, and the allowlist probe would have come back 404 from Anthropic and turned `main` red on merge. So the check greps the deployed checkout for the guards *before* probing. That is more than a safety valve: it converts "could not observe" into two genuinely different states — *not in this build* versus *in this build but the live worker did not apply it* — and only the second is a deploy failure. It is what makes this a deploy-didn't-take detector rather than a liveness ping.

One thing I deliberately did **not** automate: the worker's secrets. `wrangler deploy` uploads code and `wrangler.toml` config and leaves existing secrets alone, so the CI token needs no access to them and this workflow never handles the Anthropic key. The property the whole service exists to establish survives the move to CI, and that seemed worth preserving explicitly rather than by accident.

Privacy: request bodies carry walk transcripts. Nothing added here logs, stores, or forwards a request or response body. The smoke check asserts on status codes and discards every `/v1/messages` body to `/dev/null`. The one body it prints is `/health`'s, which is a fixed two-field literal from a handler that never reads a request body — justified inline at the assertion.

---

## What this adds

`.github/workflows/proxy.yml`, two jobs:

- **`test`** — on `pull_request` and `push` to `main`, filtered to `services/proxy/**` and the workflow file itself. `npm ci` → `npm run typecheck` → `npm test` on Node 22 with setup-node's npm cache (`cache-dependency-path` pointed at `services/proxy/package-lock.json`, since the lockfile isn't at the repo root and the cache silently never hits otherwise). `actions/checkout@v4` / `actions/setup-node@v4`, matching the majors `ci.yml` and `release.yml` use.
- **`deploy`** — `push` to `main` only, same path filter, `needs: test`. `npx wrangler deploy` from `services/proxy/` (wrangler is a devDependency, so `npx` resolves the pinned local copy), then the smoke check.

`concurrency` cancels superseded **PR** runs but never a `main` run — killing `wrangler deploy` partway leaves a live worker in a state no commit describes. Same reasoning `release.yml` uses.

Plus `services/proxy/README.md`: the Deploy section led with manual `wrangler deploy` as the only path and the Tests section said the suite is "not wired into the repo's GitHub Actions CI." Both become false when this merges. Manual deploy is retained and re-framed as first-time-setup / break-glass, since steps 1–2 (KV namespace, `wrangler secret put`) are genuinely not automated and shouldn't be.

## Smoke check assertion matrix

Unauthenticated (proves the worker still *has* its configuration):

| Probe | Expected |
|---|---|
| `GET /health` | `200` `{"ok":true}` |
| `POST /v1/messages`, invalid credential | `401` — **not** `500` (`500` = deployed clean, lost its secrets) |

Authenticated with `JEFE_APP_SECRET`, reaching the request validation. Each probe is shaped so exactly one guard can produce its `400`, since bodies are never read: the stream probe uses an **allowed** model, the allowlist probe omits `stream` entirely.

| Probe | Status | Treated as |
|---|---|---|
| `stream: true` + allowed model | `400` | **pass** |
| model `claude-fable-5`, no `stream` | `400` | **pass** |
| either | `200` | **hard fail** — not rejected, served upstream |
| either | `503` / `429` | **inconclusive** — cap tripped, guard never reached; warn, continue |
| either | `401` | **inconclusive** — probe credential refused; warn loudly, continue |
| either | `404`, `5xx`, network | **fail** — went upstream instead of being rejected |

`claude-fable-5` is deliberately not a near-miss of an allowed prefix: the allowlist is prefix-matched, so `claude-haiku-4-5-x` would be *accepted* and that probe would assert the opposite of what it looks like it asserts.

**`PROXY_SMOKE_REQUIRE_STREAM_REJECT=true`** escalates exactly one thing: it makes it fatal when the authenticated probes **do not run at all** (no `JEFE_APP_SECRET`, or the guards absent from the deployed commit). A smoke check that quietly stops checking is the failure that switch exists to catch. It does **not** make `503`/`429`/`401` fatal — those are unreachable-guard states. `200` is fatal either way.

## What happens on the first merge, with `CLOUDFLARE_API_TOKEN` still absent

The `test` job runs and gates normally — full value from day one. The `deploy` job starts, finds the secret empty, and **skips every subsequent step with a green result plus a `::notice::`** naming the secret, the two scopes, and the fact that the live worker is still running whatever was last pushed by hand. Nothing deploys, nothing goes red, and the notice is a standing to-do on every proxy merge until the token is set. The first thing that happens after you add the secret is a real deploy on the next proxy change — worth knowing before you paste it.

## Exact token to mint

Cloudflare → My Profile → API Tokens → Create Token → **Custom token**:

| Permission | Level | Why |
|---|---|---|
| Account → **Workers Scripts** | **Edit** | Upload the worker |
| Account → **Workers KV Storage** | **Edit** | The `METER` namespace binding in `wrangler.toml` — a deploy that binds KV is refused without it |

Nothing broader. Add as repo secret `CLOUDFLARE_API_TOKEN`. Optional: `CLOUDFLARE_ACCOUNT_ID` (only if the token can see more than one account). `JEFE_APP_SECRET` and `JEFE_PROXY_URL` are **already set** for the app build and reused as-is — nothing to do.

## Merge order with #329

No conflict — `git merge-tree` against `origin/pr/dam/proxy-only-and-metering-fixes` is clean (both touch `README.md`, in different sections). Either order works:

- **#329 first** → this PR's first deploy probes a worker that already has the guards, and all four assertions are live immediately.
- **#328 first** → the guard grep finds nothing in the deployed commit, the authenticated probes skip with a warning, and `/health` + the 401-vs-500 assertion still run. No spend, no red main. They start asserting on the merge of #329.

## Follow-up recommendation (deliberately not done here)

`release.yml`'s `paths-ignore` lists `docs/**`, `meta/**`, `**.md`, `.gitignore`. It does **not** list `services/proxy/**` — so a proxy-only change currently fires a full iOS build, signs it, and **burns a TestFlight build-number and upload slot for a change that cannot affect the app**. Adding `- 'services/proxy/**'` fixes it.

I did not make that edit: #329 is editing `release.yml` right now, and that file is the only path to shipping — a conflict there is expensive. One-line follow-up once #329 settles.

## Verification

**Locally**, from a clean `node_modules` (`rm -rf node_modules && npm ci`): `npm run typecheck` → `tsc --noEmit`, exit 0, no diagnostics. `npm test` → **74 passed (74)**, 2 files. The 17 in `test/proxy.test.ts`:

```
✓ pricing > prices the three input classes at different rates
✓ pricing > treats missing cache fields as zero rather than NaN
✓ pricing > resolves dated model snapshots by prefix
✓ pricing > over-estimates an unknown model instead of under-estimating
✓ auth > accepts a well-formed credential and extracts the install id
✓ auth > reads the credential from either header the Rust provider sends
✓ auth > rejects a wrong secret, a missing one, and a foreign key shape
✓ auth > rejects an oversized install id
✓ worker > swaps the install credential for the real key and never forwards the caller's
✓ worker > forwards the body byte-identically so upstream prefix caching still matches
✓ worker > meters the call against both the global and per-install counters
✓ worker > refuses BEFORE forwarding once the global cap is reached
✓ worker > rate-limits one noisy install without stopping everyone else
✓ worker > rejects a bad credential without spending anything
✓ worker > fails closed when the worker is misconfigured
✓ worker > passes an upstream error through with its status intact
✓ worker > serves health without a credential and 404s anything else
```

The other 57 are `test/attest.test.ts` (App Attest — inert in production, untouched here, green).

**In CI**, the workflow ran on its own PR: `Proxy (typecheck + vitest)` **pass in 17s**, log shows `✓ test/proxy.test.ts (17 tests) 38ms` and `Test Files 2 passed (2)`. `Deploy to Cloudflare` correctly **skipped** (pull_request, not push-to-main).

**Workflow YAML**: `actionlint` 1.7.12 — 0 parse errors, 0 total errors. That includes shellcheck over every `run:` block.

**Smoke-check logic**: I extracted the `run:` script and executed all 16 branches against a stubbed `curl`, twice — once against a source tree without the guards (`origin/main`) and once against one with them (`origin/pr/dam/proxy-only-and-metering-fixes`). Confirmed: `400/400` passes; `200` fails (and does not short-circuit — the second probe still reports before exit); `404` fails; `503`, `429`, `401` warn and pass; `503` + strict still passes; `401` + strict still passes; guards-absent skips, and guards-absent + strict fails; missing secret skips, and missing secret + strict fails; `/health` non-200 and wrong-body both fail; invalid-credential `500` fails.

**Live worker**, unauthenticated assertions run by hand against `jefe-proxy.damsac-app.workers.dev`: `health=200 {"ok":true}`, invalid-credential `401` (not 500).

**Path filter**: `docs/**.md` matches neither pattern → does not trigger. `services/proxy/src/index.ts` matches `services/proxy/**` → triggers both jobs. The workflow file itself is included so a change to the gate is exercised by the gate. Corollary now in the README: on a PR this workflow doesn't match, these checks are **absent**, not green — don't mark them *required* without a path-aware skip job.

## What I could not verify

- **The deploy path itself has never run.** `npx wrangler deploy` under `CLOUDFLARE_API_TOKEN` is unexercised end-to-end because the token does not exist. Its first real execution will be the first proxy merge after the secret is added. Verified instead: the skip path, every smoke-check branch against a stubbed curl, and the unauthenticated assertions against the live worker.
- **The authenticated probes have never run against a live worker** — they need both `JEFE_APP_SECRET` (only available in Actions) and a deployed build carrying #329's guards. Their logic is branch-tested; their live behaviour is inferred from `index.ts` control flow.
- **Whether `CLOUDFLARE_ACCOUNT_ID` is needed** depends on how many accounts the eventual token can see. Passed through as optional; empty is harmless.
