### PR TITLE
The attestation token is bound to the attested key, and signed with a secret the app does not have

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -157,9 +157,9 @@ jobs:
         working-directory: services/proxy
         run: npm ci
 
-      # Secrets (ANTHROPIC_API_KEY, APP_SECRET) and the KV namespace are NOT
-      # managed here — they were set once with `wrangler secret put` and live in
-      # Cloudflare. `wrangler deploy` uploads code and wrangler.toml config and
+      # Secrets (ANTHROPIC_API_KEY, APP_SECRET, ATTEST_TOKEN_SECRET) and the KV
+      # namespace are NOT managed here — they were set once with
+      # `wrangler secret put` and live in Cloudflare. `wrangler deploy` uploads code and wrangler.toml config and
       # leaves existing secrets alone. This job therefore never handles the
       # Anthropic key at all, which is the point of the service.
       - name: wrangler deploy

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -80,6 +80,27 @@ jefeA.<installId>.<attestToken>~<appSecret>      # Phase 2
 The app secret is still checked on attested credentials. Attestation adds a
 layer; it does not remove the one underneath.
 
+### What makes the token mean anything
+
+The token is `jat.<payload>.<mac>`; the payload names the install `i`, the
+attested key `k`, and an expiry `e`. Two properties carry all of its weight, and
+without either one the entire attestation path above is decorative:
+
+1. **It is signed with `ATTEST_TOKEN_SECRET`, which the app never sees.** Not
+   `APP_SECRET` — that ships inside the IPA, so signing with it would mean
+   anyone who unzipped a build could mint a token that verified, without ever
+   touching the Secure Enclave. A secret the client holds cannot certify
+   anything about the client. The worker refuses to run attestation at all if
+   `ATTEST_TOKEN_SECRET` is missing or equal to `APP_SECRET`.
+2. **`k` is looked up.** The MAC proves `k` is the key id the worker itself
+   wrote, but a name nobody resolves is not a binding. `verifyToken` loads that
+   key from KV and refuses a token naming a key that was never attested
+   (`unknown_key`) or that a different install attested (`key_install_mismatch`).
+   That lookup is the only thing connecting a `/v1/messages` request back to a
+   hardware key Apple's certificate chain vouched for — which is why
+   `verifyToken` takes the KV namespace as an argument rather than leaving the
+   check to its caller.
+
 ### Rolling it out
 
 Move one notch at a time, and never skip `monitor`:
@@ -95,9 +116,21 @@ Move one notch at a time, and never skip `monitor`:
 builds carrying the device half roll out. Going straight to `enforce` bricks
 every already-installed build the moment it lands, testers included.
 
+Before `ATTEST_MODE` can leave `off`, all four of these must be true:
+
+| | |
+|---|---|
+| `APP_ATTEST_APP_ID` set | `98GXNZ6NKZ.com.isaacwm.murmur` — team id and the shipped bundle id. Anything else is `app_id_mismatch` on every attestation |
+| `APP_ATTEST_ROOT_CA` set | Apple's App Attest root, PEM |
+| `ATTEST_TOKEN_SECRET` set | A fresh random string. **Never** the same value as `APP_SECRET`, and never given to the app |
+| A real-device `monitor` soak | The verifier has never seen a genuine Apple certificate chain. The tests build a synthetic one — see **Tests** |
+
 Anything unrecognised in `ATTEST_MODE` means `off`, so a typo cannot lock the
-fleet out. But `monitor`/`enforce` with missing config is a hard 500 — asking
-for enforcement and quietly getting none is worse than a visibly failed deploy.
+fleet out — but it is logged as `attest_mode_unrecognised`, because `off` is
+also what a correct deployment looks like and a silent fallback would leave a
+misspelled `enfroce` indistinguishable from working config. `monitor`/`enforce`
+with missing config is a hard 500 — asking for enforcement and quietly getting
+none is worse than a visibly failed deploy.
 
 ### What is deliberately not implemented
 
@@ -203,9 +236,9 @@ with exactly these permissions:
 | Account → **Workers KV Storage** | **Edit** | The `METER` namespace binding in `wrangler.toml` — a deploy that binds KV is refused without it |
 
 Nothing broader is needed. In particular the token grants no access to the
-worker's *secrets*: `ANTHROPIC_API_KEY` and `APP_SECRET` are set once by hand
-(below) and `wrangler deploy` leaves them untouched, so CI never handles the
-Anthropic key. That is the whole point of the service, and it survives the
+worker's *secrets*: `ANTHROPIC_API_KEY`, `APP_SECRET`, and `ATTEST_TOKEN_SECRET`
+are set once by hand (below) and `wrangler deploy` leaves them untouched, so CI
+never handles the Anthropic key. That is the whole point of the service, and it survives the
 move to CI.
 
 ### Post-deploy smoke check
@@ -300,9 +333,13 @@ npm install
 #    into wrangler.toml (replacing REPLACE_ME).
 npx wrangler kv namespace create METER
 
-# 2. Set the two secrets. Neither is committed.
+# 2. Set the secrets. None are committed.
 npx wrangler secret put ANTHROPIC_API_KEY   # the real sk-ant-… key
 npx wrangler secret put APP_SECRET          # a fresh random string; also goes in the iOS build
+# Only needed before ATTEST_MODE leaves `off`. A DIFFERENT random string —
+# the app must never see it, and the worker refuses to run attestation if it
+# equals APP_SECRET.
+npx wrangler secret put ATTEST_TOKEN_SECRET
 
 # 3. Ship it.
 npx wrangler deploy
@@ -386,8 +423,11 @@ prove one happy path, and every negative test against it degenerates into
 "garbage in, error out", which a verifier that rejects everything would also
 pass.
 
-What the synthetic chain cannot prove is that we accept **Apple's** real root.
-That is the residual risk, and the reason the rollout starts in `monitor`.
+What the synthetic chain cannot prove is that we accept **Apple's** real root —
+including the two strictness choices that are asserted only against our own
+certificates: that every issuing certificate carries `basicConstraints` with
+`cA` TRUE, and that `x5c` is at most four entries (Apple sends two). That is the
+residual risk, and it is the whole reason the rollout starts in `monitor`.
 
 These run in CI. `.github/workflows/proxy.yml` runs `npm ci`, `npm run
 typecheck`, and `npm test` on every pull request that touches

--- a/services/proxy/src/attest.ts
+++ b/services/proxy/src/attest.ts
@@ -77,6 +77,19 @@ export class AttestError extends Error {
 /** Apple's certificate extension carrying the attestation nonce. */
 const NONCE_EXTENSION_OID = '1.2.840.113635.100.8.2';
 
+/** X.509 basicConstraints. RFC 5280 §4.2.1.9 — the `cA` flag lives here. */
+const BASIC_CONSTRAINTS_OID = '2.5.29.19';
+
+/**
+ * How many certificates an `x5c` may carry. Apple sends exactly two — the
+ * credential certificate and `Apple App Attestation CA 1` — and the root is
+ * configured, not sent. Four leaves room for two more intermediates if Apple
+ * ever lengthens the chain, and it is a hard stop on a hostile client posting a
+ * thousand-certificate array: every entry costs a DER parse and, worse, an
+ * ECDSA verify. The bound is checked BEFORE anything is parsed.
+ */
+const MAX_X5C_CERTIFICATES = 4;
+
 /** The 16-byte aaguid Apple stamps into attested credential data. */
 const AAGUID_PRODUCTION = 'appattest\0\0\0\0\0\0\0';
 const AAGUID_DEVELOPMENT = 'appattestdevelop';
@@ -237,12 +250,45 @@ function nonceFromCertificate(cert: Certificate): Uint8Array {
 }
 
 /**
+ * True only for a certificate carrying basicConstraints with `cA` TRUE.
+ *
+ * `BasicConstraints ::= SEQUENCE { cA BOOLEAN DEFAULT FALSE, pathLenConstraint
+ * INTEGER OPTIONAL }`. Because `cA` is DEFAULT FALSE, a DER encoder omits it
+ * when it is false — so an absent extension, an empty SEQUENCE, and a SEQUENCE
+ * whose first element is the pathLen INTEGER all mean "not a CA". Only an
+ * explicit BOOLEAN 0xFF says otherwise, and DER admits no other spelling of
+ * true.
+ */
+function isCertificateAuthority(cert: Certificate): boolean {
+  const extension = cert.extensions.get(BASIC_CONSTRAINTS_OID);
+  if (!extension) return false;
+  try {
+    const outer = parseTlv(extension, 0);
+    if (outer.tag !== 0x30) return false;
+    const first = children(extension, outer)[0];
+    if (!first || first.tag !== 0x01) return false;
+    const value = content(extension, first);
+    return value.length === 1 && value[0] === 0xff;
+  } catch {
+    // A basicConstraints we cannot parse is not a basicConstraints we may
+    // read as TRUE.
+    return false;
+  }
+}
+
+/**
  * Verifies `leaf → … → root`, where `root` is the pinned Apple certificate.
  *
  * Each certificate must be signed by the next, its issuer name must match that
  * signer's subject, and it must be inside its validity window. The root is
  * trusted because it was configured, not because it is self-signed — checking
  * a self-signature proves nothing about who issued it.
+ *
+ * Every certificate that ISSUES another must also assert it is a CA. Without
+ * that, a leaf is a usable signer: anyone holding a genuine App Attest device
+ * certificate could sign a second certificate with it and present
+ * `[forged, theirLeaf, …]`, and every other check here would pass. The `cA`
+ * flag is what makes a leaf a dead end.
  */
 async function verifyChain(chain: Certificate[], root: Certificate, now: Date): Promise<void> {
   const path = [...chain, root];
@@ -250,6 +296,14 @@ async function verifyChain(chain: Certificate[], root: Certificate, now: Date): 
   for (const cert of path) {
     if (now < cert.notBefore || now > cert.notAfter) {
       throw new AttestError('a certificate in the chain is outside its validity window', 'cert_expired');
+    }
+  }
+
+  // Index 0 is the leaf, which signs nothing. Everything above it does.
+  for (let i = 1; i < path.length; i++) {
+    const issuer = path[i];
+    if (!issuer || !isCertificateAuthority(issuer)) {
+      throw new AttestError('a signing certificate is not a CA', 'issuer_not_ca');
     }
   }
 
@@ -339,6 +393,9 @@ export async function verifyAttestation(
   const x5cRaw = mapField(attStmt, 'x5c');
   if (!Array.isArray(x5cRaw) || x5cRaw.length < 2) {
     throw new AttestError('attestation statement has no certificate chain', 'no_chain');
+  }
+  if (x5cRaw.length > MAX_X5C_CERTIFICATES) {
+    throw new AttestError('certificate chain is longer than any real one', 'chain_too_long');
   }
 
   let chain: Certificate[];
@@ -467,11 +524,21 @@ export async function verifyAssertion(
  * A short-lived bearer token, minted after a successful assertion.
  *
  * `jat.<payload>.<mac>`, both base64url. The payload names the install, the
- * key and an expiry; the MAC is HMAC-SHA256 under the app secret. Note this
- * means the token's unforgeability rests on a secret that also ships in the
- * binary — so a token is NOT stronger than Phase 1 on its own. What it is, is
- * a receipt that a real attestation happened within the last hour, which an
- * extracted secret alone cannot produce.
+ * attested key and an expiry; the MAC is HMAC-SHA256 under `ATTEST_TOKEN_SECRET`.
+ *
+ * TWO things make this a real receipt rather than decoration, and the token is
+ * worthless without either:
+ *
+ *  1. The MAC key is a SERVER-ONLY secret. It was `APP_SECRET` — which ships
+ *     inside the IPA — so anyone who unzipped a build could mint a token that
+ *     verified, and the ~600 lines of attestation verification above bought
+ *     nothing. A secret the client holds cannot certify anything about the
+ *     client.
+ *  2. `k` is CHECKED. The MAC proves `k` is the key id we wrote, but a name
+ *     nobody looks up is not a binding. `verifyToken` loads that key from KV
+ *     and refuses a token for a key that was never attested, or that some other
+ *     install attested. That lookup is what connects `/v1/messages` back to the
+ *     Secure Enclave key, and it is the reason `verifyToken` needs KV at all.
  */
 interface TokenPayload {
   i: string;
@@ -509,13 +576,25 @@ export type TokenFailure =
   | 'malformed'
   | 'bad_signature'
   | 'expired'
-  | 'wrong_install';
+  | 'wrong_install'
+  | 'unknown_key'
+  | 'key_install_mismatch';
 
 export type TokenResult =
   | { ok: true; keyId: string }
   | { ok: false; reason: TokenFailure };
 
+/**
+ * Verifies a token AND the attested key it names.
+ *
+ * KV is a required argument rather than an optional second step on purpose.
+ * The previous shape — a pure MAC check whose `keyId` the caller was trusted to
+ * do something with — is exactly how `payload.k` ended up with zero consumers
+ * and the attestation ended up unreachable from `/v1/messages`. There is now no
+ * way to ask "is this token good?" without the storage that can answer it.
+ */
 export async function verifyToken(
+  kv: KVNamespace,
   secret: string,
   token: string,
   installId: string,
@@ -548,13 +627,32 @@ export async function verifyToken(
   } catch {
     return { ok: false, reason: 'malformed' };
   }
-  if (typeof payload.e !== 'number' || typeof payload.i !== 'string') {
+  if (
+    typeof payload.e !== 'number' ||
+    typeof payload.i !== 'string' ||
+    typeof payload.k !== 'string'
+  ) {
     return { ok: false, reason: 'malformed' };
   }
   if (payload.e * 1000 <= now.getTime()) return { ok: false, reason: 'expired' };
   // A token is bound to the install that earned it, so a leaked token cannot
   // be pasted into someone else's credential to dodge their spend cap.
   if (payload.i !== installId) return { ok: false, reason: 'wrong_install' };
+  // Shape-check before the key id reaches KV. The MAC already proves we wrote
+  // it, so this cannot fire in practice — but it means a leaked signing secret
+  // buys a forger no ability to aim arbitrary strings at the keyspace.
+  if (!isPlausibleKeyId(payload.k)) return { ok: false, reason: 'malformed' };
+
+  // THE BINDING. Everything above this line is true of a token minted by
+  // whoever holds the signing secret; only this line ties the request to a key
+  // the Secure Enclave generated and Apple's chain vouched for.
+  const stored = await loadAttestedKey(kv, payload.k);
+  if (!stored) return { ok: false, reason: 'unknown_key' };
+  // Belt and braces with the `i` check above: that one compares the token's
+  // claim against the caller, this one compares it against what enrolment
+  // actually recorded. They come apart if a key is ever re-attested by a
+  // different install while an old token is still inside its hour.
+  if (stored.installId !== installId) return { ok: false, reason: 'key_install_mismatch' };
 
   return { ok: true, keyId: payload.k };
 }

--- a/services/proxy/src/index.ts
+++ b/services/proxy/src/index.ts
@@ -68,6 +68,13 @@ export interface Env {
   APP_ATTEST_ROOT_CA?: string;
   /** `"true"` to also accept development attestations. Never in production. */
   APP_ATTEST_ALLOW_DEVELOPMENT?: string;
+  /**
+   * Secret. HMAC key for attestation tokens — and, unlike `APP_SECRET`, it is
+   * NEVER shared with the app. That asymmetry is the whole point: a token
+   * signed with a secret the client holds proves nothing the client could not
+   * have claimed for itself. Required before `ATTEST_MODE` may leave `off`.
+   */
+  ATTEST_TOKEN_SECRET?: string;
 }
 
 const DEFAULT_DAILY_CAP_USD = 25;
@@ -152,25 +159,64 @@ async function addSpend(kv: KVNamespace, key: string, delta: number): Promise<vo
 
 export function attestMode(env: Env): AttestMode {
   const raw = env.ATTEST_MODE?.trim().toLowerCase();
-  if (raw === 'monitor' || raw === 'enforce') return raw;
+  if (raw === 'monitor' || raw === 'enforce' || raw === 'off') return raw;
   // Anything else — unset, a typo, an empty string — is `off`. A misspelled
   // mode must not fail into rejecting every request in the field.
+  //
+  // But it must not be SILENT either. `off` is also what a correct deployment
+  // looks like, so an operator who typed `enfroce` sees a service behaving
+  // exactly as they configured it, forever. Truncated because it is echoed
+  // into a log line; it is operator config, not caller input, so there is no
+  // privacy question here — no request body is involved.
+  if (raw !== undefined && raw !== '') {
+    console.warn(
+      JSON.stringify({ event: 'attest_mode_unrecognised', value: raw.slice(0, 32), using: 'off' }),
+    );
+  }
   return 'off';
 }
 
+interface AttestSetup {
+  appId: string;
+  rootCaPem: string;
+  allowDevelopment: boolean;
+  /** Server-only HMAC key. Never `APP_SECRET` — see below. */
+  tokenSecret: string;
+}
+
 /**
- * The attestation config, or `null` if it is incomplete.
+ * The attestation config, or the name of the first thing wrong with it.
+ *
+ * One function rather than a boolean and a message, so the two can never
+ * disagree about what "configured" means. The reason is carried because "the
+ * proxy is not configured" is a fine thing to tell a caller and a useless thing
+ * to tell the operator who has to fix it.
  *
  * Incomplete config in `enforce` mode is a hard 500 at the call site rather
  * than a silent downgrade: an operator who asked for enforcement and quietly
  * got none is strictly worse off than one whose deploy visibly fails.
  */
-function attestConfig(env: Env) {
-  if (!env.APP_ATTEST_APP_ID || !env.APP_ATTEST_ROOT_CA) return null;
+function attestSetup(env: Env): { ok: true; config: AttestSetup } | { ok: false; problem: string } {
+  const appId = env.APP_ATTEST_APP_ID;
+  const rootCaPem = env.APP_ATTEST_ROOT_CA;
+  const tokenSecret = env.ATTEST_TOKEN_SECRET;
+  if (!appId) return { ok: false, problem: 'missing_app_attest_app_id' };
+  if (!rootCaPem) return { ok: false, problem: 'missing_app_attest_root_ca' };
+  if (!tokenSecret) return { ok: false, problem: 'missing_attest_token_secret' };
+  // Setting them equal is the exact failure this binding exists to prevent, and
+  // it is one copy-paste away. Fail closed rather than quietly restoring a
+  // token that anyone holding the IPA can mint.
+  if (tokenSecret === env.APP_SECRET) {
+    return { ok: false, problem: 'attest_token_secret_equals_app_secret' };
+  }
   return {
-    appId: env.APP_ATTEST_APP_ID,
-    rootCaPem: env.APP_ATTEST_ROOT_CA,
-    allowDevelopment: env.APP_ATTEST_ALLOW_DEVELOPMENT === 'true',
+    ok: true,
+    config: {
+      appId,
+      rootCaPem,
+      allowDevelopment: env.APP_ATTEST_ALLOW_DEVELOPMENT === 'true',
+      tokenSecret,
+    },
   };
 }
 
@@ -208,10 +254,12 @@ async function handleAttestRoute(
   env: Env,
   installId: string
 ): Promise<Response> {
-  const config = attestConfig(env);
-  if (!config) {
+  const setup = attestSetup(env);
+  if (!setup.ok) {
+    console.error(JSON.stringify({ event: 'attest_misconfigured', problem: setup.problem }));
     return errorResponse(503, 'api_error', 'attestation is not configured on this deployment');
   }
+  const config = setup.config;
 
   try {
     if (path === '/v1/attest/challenge') {
@@ -272,7 +320,9 @@ async function handleAttestRoute(
       );
       await saveAttestedKey(env.METER, keyId, { ...stored, counter });
 
-      const token = await mintToken(env.APP_SECRET, installId, keyId);
+      // Signed with the server-only secret, NOT `APP_SECRET`. A token the
+      // client could have minted for itself certifies nothing.
+      const token = await mintToken(config.tokenSecret, installId, keyId);
       return json(200, { token, expires_in: TOKEN_TTL_SECONDS });
     }
 
@@ -330,14 +380,19 @@ export default {
 
     const mode = attestMode(env);
     if (mode !== 'off') {
-      if (!attestConfig(env)) {
+      const setup = attestSetup(env);
+      if (!setup.ok) {
         // Asked to enforce, unable to. Fail closed and loudly rather than
         // serving traffic an operator believes is being checked.
-        console.error(JSON.stringify({ event: 'attest_misconfigured', mode }));
+        console.error(
+          JSON.stringify({ event: 'attest_misconfigured', mode, problem: setup.problem }),
+        );
         return errorResponse(500, 'api_error', 'proxy is not configured');
       }
+      // `env.METER` is passed because verifying a token means looking up the
+      // attested key it names — the check that makes the token mean anything.
       const result = attestToken
-        ? await verifyToken(env.APP_SECRET, attestToken, installId)
+        ? await verifyToken(env.METER, setup.config.tokenSecret, attestToken, installId)
         : ({ ok: false, reason: 'malformed' } as const);
 
       if (!result.ok) {

--- a/services/proxy/test/appattest-fixtures.ts
+++ b/services/proxy/test/appattest-fixtures.ts
@@ -93,6 +93,23 @@ function bitString(body: Uint8Array): Uint8Array {
   return tlv(0x03, cat(Uint8Array.of(0), body));
 }
 
+/** DER BOOLEAN. TRUE is 0xFF and nothing else. */
+function boolean(value: boolean): Uint8Array {
+  return tlv(0x01, Uint8Array.of(value ? 0xff : 0x00));
+}
+
+/**
+ * `basicConstraints` as an extension pair, ready for `CertOptions.extensions`.
+ *
+ * `cA` is DEFAULT FALSE, so a real encoder omits it when false — which is why
+ * `basicConstraintsExtension(false)` produces an EMPTY SEQUENCE rather than an
+ * explicit FALSE. That is the shape a non-CA certificate actually has, and it
+ * is what the verifier has to read as "not a CA".
+ */
+export function basicConstraintsExtension(isCa: boolean): [string, Uint8Array] {
+  return ['2.5.29.19', isCa ? seq(boolean(true)) : seq()];
+}
+
 function utcTime(date: Date): Uint8Array {
   const pad = (n: number) => String(n).padStart(2, '0');
   const text =
@@ -272,7 +289,8 @@ export async function sha256(...parts: Uint8Array[]): Promise<Uint8Array> {
 
 // -------------------------------------------------------------- the world
 
-export const TEST_APP_ID = 'ABCDE12345.com.isaacwm.sitewalk';
+/** A synthetic team id on the real bundle id. See wrangler.toml for the real one. */
+export const TEST_APP_ID = 'ABCDE12345.com.isaacwm.murmur';
 
 export interface AttestWorld {
   rootPem: string;
@@ -292,6 +310,10 @@ export interface AttestWorld {
       /** Put a different nonce in the certificate extension. */
       nonce?: Uint8Array;
       notAfter?: Date;
+      /** Issue the leaf from an intermediate that does not claim to be a CA. */
+      nonCaIntermediate?: boolean;
+      /** Pad `x5c` out to this many entries, to test the length bound. */
+      padChainTo?: number;
     }
   ): Promise<Uint8Array>;
   /** Builds an assertion signed by the device key. */
@@ -309,23 +331,38 @@ export async function buildWorld(): Promise<AttestWorld> {
   const deviceKey = await generateKeyPair('P-256');
   const keyId = await sha256(deviceKey.point);
 
+  // Every CA here carries basicConstraints cA:TRUE, because Apple's real ones
+  // do and because the verifier now requires it of anything that signs.
   const rootDer = await makeCertificate({
     subject: 'Test App Attest Root',
     issuer: 'Test App Attest Root',
     subjectKey: root,
     issuerKey: root,
+    extensions: [basicConstraintsExtension(true)],
   });
   const intermediateDer = await makeCertificate({
     subject: 'Test App Attest CA 1',
     issuer: 'Test App Attest Root',
     subjectKey: intermediate,
     issuerKey: root,
+    extensions: [basicConstraintsExtension(true)],
   });
   const rogueIntermediateDer = await makeCertificate({
     subject: 'Test App Attest CA 1',
     issuer: 'Test App Attest Root',
     subjectKey: rogueRoot,
     issuerKey: rogueRoot,
+    extensions: [basicConstraintsExtension(true)],
+  });
+  // Correctly signed by the root and correctly named, but claiming to be an
+  // end-entity certificate. Only the cA flag separates it from the real one.
+  const nonCaIntermediateDer = await makeCertificate({
+    subject: 'Test App Attest CA 1',
+    issuer: 'Test App Attest Root',
+    subjectKey: intermediate,
+    issuerKey: root,
+    serial: 2,
+    extensions: [basicConstraintsExtension(false)],
   });
 
   return {
@@ -357,10 +394,18 @@ export async function buildWorld(): Promise<AttestWorld> {
         notAfter: overrides.notAfter,
       });
 
+      const issuerDer = overrides.rogueIssuer
+        ? rogueIntermediateDer
+        : overrides.nonCaIntermediate
+          ? nonCaIntermediateDer
+          : intermediateDer;
+      const x5c: Uint8Array[] = [leafDer, issuerDer];
+      while (x5c.length < (overrides.padChainTo ?? 0)) x5c.push(intermediateDer);
+
       return encodeCbor({
         fmt: 'apple-appattest',
         attStmt: {
-          x5c: [leafDer, overrides.rogueIssuer ? rogueIntermediateDer : intermediateDer],
+          x5c,
           receipt: new Uint8Array([1, 2, 3]),
         },
         authData,

--- a/services/proxy/test/attest.test.ts
+++ b/services/proxy/test/attest.test.ts
@@ -10,6 +10,7 @@ import {
   issueChallenge,
   mintToken,
   parseAuthenticatorData,
+  saveAttestedKey,
   toBase64Url,
   verifyAssertion,
   verifyAttestation,
@@ -17,6 +18,7 @@ import {
 } from '../src/attest';
 import worker, { attestMode, type Env } from '../src/index';
 import {
+  basicConstraintsExtension,
   buildWorld,
   encodeCbor,
   generateKeyPair,
@@ -28,6 +30,8 @@ import {
 } from './appattest-fixtures';
 
 const APP_SECRET = 'test-app-secret';
+/** The one the app never sees. Distinct from APP_SECRET in every test. */
+const TOKEN_SECRET = 'server-only-token-secret';
 const INSTALL = 'install-abc-123';
 
 let world: AttestWorld;
@@ -282,6 +286,39 @@ describe('verifyAttestation', () => {
       'too_large'
     );
   });
+
+  it('refuses a chain longer than any real one, before parsing a certificate', async () => {
+    // Apple sends two. Without a bound, a hostile client picks the number of
+    // DER parses and ECDSA verifies the worker performs on its behalf.
+    const attestation = await world.attestationFor(CHALLENGE, { padChainTo: 5 });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'chain_too_long'
+    );
+  });
+
+  it('lets a chain AT the bound through the length gate', async () => {
+    // Four is allowed, so this one gets past the length check and dies later on
+    // the padding's broken issuer/subject linkage instead. That distinction is
+    // the point: it proves `chain_too_long` above is a bound at 4 and not a
+    // blanket refusal of anything the fixture pads.
+    const attestation = await world.attestationFor(CHALLENGE, { padChainTo: 4 });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'chain_broken'
+    );
+  });
+
+  it('refuses an intermediate that does not claim to be a CA', async () => {
+    // Same key, same name, same valid signature over the leaf — the ONLY
+    // difference is basicConstraints cA. Without the check, any end-entity
+    // certificate Apple ever issued is a usable signer.
+    const attestation = await world.attestationFor(CHALLENGE, { nonCaIntermediate: true });
+    await expectCode(
+      verifyAttestation(attestation, world.keyId, challengeBytes(), config()),
+      'issuer_not_ca'
+    );
+  });
 });
 
 // --------------------------------------------------------------- assertion
@@ -335,51 +372,119 @@ describe('verifyAssertion', () => {
 // ------------------------------------------------------------------ token
 
 describe('attestation token', () => {
+  const KEY_ID = toBase64Url(new Uint8Array(32).fill(3));
+  const OTHER_KEY_ID = toBase64Url(new Uint8Array(32).fill(9));
+
+  /** KV holding one attested key, as enrolment would have left it. */
+  async function kvWithKey(installId = INSTALL, keyId = KEY_ID) {
+    const kv = fakeKv();
+    await saveAttestedKey(kv, keyId, {
+      spki: '',
+      curve: 'P-256',
+      counter: 0,
+      installId,
+      attestedAt: Date.now(),
+    });
+    return kv;
+  }
+
   it('round-trips', async () => {
-    const token = await mintToken(APP_SECRET, INSTALL, 'key-1');
-    expect(await verifyToken(APP_SECRET, token, INSTALL)).toEqual({ ok: true, keyId: 'key-1' });
+    const kv = await kvWithKey();
+    const token = await mintToken(TOKEN_SECRET, INSTALL, KEY_ID);
+    expect(await verifyToken(kv, TOKEN_SECRET, token, INSTALL)).toEqual({
+      ok: true,
+      keyId: KEY_ID,
+    });
   });
 
   it('rejects a token minted under a different secret', async () => {
-    const token = await mintToken('some-other-secret', INSTALL, 'key-1');
-    expect(await verifyToken(APP_SECRET, token, INSTALL)).toEqual({
+    const kv = await kvWithKey();
+    const token = await mintToken('some-other-secret', INSTALL, KEY_ID);
+    expect(await verifyToken(kv, TOKEN_SECRET, token, INSTALL)).toEqual({
       ok: false,
       reason: 'bad_signature',
+    });
+  });
+
+  it('rejects a token signed with the secret that ships in the app', async () => {
+    // The finding this binding exists for. APP_SECRET is extractable from any
+    // IPA, so a token signed with it is a token anyone can mint — and it would
+    // have sailed through, making every attestation check above unreachable.
+    const kv = await kvWithKey();
+    const token = await mintToken(APP_SECRET, INSTALL, KEY_ID);
+    expect(await verifyToken(kv, TOKEN_SECRET, token, INSTALL)).toEqual({
+      ok: false,
+      reason: 'bad_signature',
+    });
+  });
+
+  it('rejects a token naming a key that was never attested', async () => {
+    // Correctly signed, correct install, correct expiry — and `k` names
+    // nothing. Before the lookup this was a valid token.
+    const kv = await kvWithKey();
+    const token = await mintToken(TOKEN_SECRET, INSTALL, OTHER_KEY_ID);
+    expect(await verifyToken(kv, TOKEN_SECRET, token, INSTALL)).toEqual({
+      ok: false,
+      reason: 'unknown_key',
+    });
+  });
+
+  it('rejects a token whose key was attested by a different install', async () => {
+    const kv = await kvWithKey('some-other-install');
+    const token = await mintToken(TOKEN_SECRET, INSTALL, KEY_ID);
+    expect(await verifyToken(kv, TOKEN_SECRET, token, INSTALL)).toEqual({
+      ok: false,
+      reason: 'key_install_mismatch',
     });
   });
 
   it('rejects a tampered payload', async () => {
-    const token = await mintToken(APP_SECRET, INSTALL, 'key-1');
+    const kv = await kvWithKey();
+    const token = await mintToken(TOKEN_SECRET, INSTALL, KEY_ID);
     const parts = token.split('.');
     const forged = toBase64Url(
-      new TextEncoder().encode(JSON.stringify({ i: 'someone-else', k: 'x', e: 2 ** 40 }))
+      new TextEncoder().encode(JSON.stringify({ i: 'someone-else', k: KEY_ID, e: 2 ** 40 }))
     );
-    expect(await verifyToken(APP_SECRET, `jat.${forged}.${parts[2]}`, 'someone-else')).toEqual({
-      ok: false,
-      reason: 'bad_signature',
-    });
+    expect(await verifyToken(kv, TOKEN_SECRET, `jat.${forged}.${parts[2]}`, 'someone-else')).toEqual(
+      { ok: false, reason: 'bad_signature' }
+    );
   });
 
   it('rejects an expired token', async () => {
-    const token = await mintToken(APP_SECRET, INSTALL, 'key-1', new Date(Date.now() - 7200_000));
-    expect(await verifyToken(APP_SECRET, token, INSTALL)).toEqual({ ok: false, reason: 'expired' });
+    const kv = await kvWithKey();
+    const token = await mintToken(TOKEN_SECRET, INSTALL, KEY_ID, new Date(Date.now() - 7200_000));
+    expect(await verifyToken(kv, TOKEN_SECRET, token, INSTALL)).toEqual({
+      ok: false,
+      reason: 'expired',
+    });
   });
 
   it('refuses a valid token presented by another install', async () => {
     // Without this, one attested device could mint tokens and hand them to
     // every other install id, spreading its spend across everyone's caps.
-    const token = await mintToken(APP_SECRET, INSTALL, 'key-1');
-    expect(await verifyToken(APP_SECRET, token, 'different-install')).toEqual({
+    const kv = await kvWithKey();
+    const token = await mintToken(TOKEN_SECRET, INSTALL, KEY_ID);
+    expect(await verifyToken(kv, TOKEN_SECRET, token, 'different-install')).toEqual({
       ok: false,
       reason: 'wrong_install',
     });
   });
 
   it('rejects structurally broken tokens without throwing', async () => {
+    const kv = await kvWithKey();
     for (const bad of ['', 'nope', 'jat.only-two', 'jat.a.b.c', 'xxx.a.b', 'jat.!!!.###']) {
-      const result = await verifyToken(APP_SECRET, bad, INSTALL);
+      const result = await verifyToken(kv, TOKEN_SECRET, bad, INSTALL);
       expect(result.ok, bad).toBe(false);
     }
+  });
+
+  it('never touches KV for a token it cannot authenticate', async () => {
+    // Order matters: the MAC gates the lookup, so an unauthenticated caller
+    // cannot use token verification to probe or hammer the keyspace.
+    const kv = (await kvWithKey()) as KVNamespace & { store: Map<string, string> };
+    const gets = (kv.get as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    await verifyToken(kv, TOKEN_SECRET, await mintToken(APP_SECRET, INSTALL, KEY_ID), INSTALL);
+    expect((kv.get as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(gets);
   });
 });
 
@@ -457,6 +562,7 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     UPSTREAM_BASE_URL: 'https://upstream.test',
     APP_ATTEST_APP_ID: TEST_APP_ID,
     APP_ATTEST_ROOT_CA: world.rootPem,
+    ATTEST_TOKEN_SECRET: TOKEN_SECRET,
     ...overrides,
   } as Env;
 }
@@ -492,6 +598,35 @@ describe('attest mode parsing', () => {
     expect(attestMode({ ATTEST_MODE: 'enfroce' } as Env)).toBe('off');
     expect(attestMode({ ATTEST_MODE: ' Monitor ' } as Env)).toBe('monitor');
     expect(attestMode({ ATTEST_MODE: 'enforce' } as Env)).toBe('enforce');
+  });
+
+  it('says so out loud when it does not recognise the value', () => {
+    // `off` is also what a CORRECT deployment looks like, so falling back
+    // silently means a typo is indistinguishable from working config.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(attestMode({ ATTEST_MODE: 'enfroce' } as Env)).toBe('off');
+      expect(warn).toHaveBeenCalledTimes(1);
+      const logged = JSON.parse(String(warn.mock.calls[0]?.[0])) as Record<string, unknown>;
+      expect(logged.event).toBe('attest_mode_unrecognised');
+      expect(logged.value).toBe('enfroce');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('stays quiet for the three real modes and for no value at all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (const mode of ['off', 'monitor', 'enforce', ' Monitor ']) {
+        attestMode({ ATTEST_MODE: mode } as Env);
+      }
+      attestMode({} as Env);
+      attestMode({ ATTEST_MODE: '  ' } as Env);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 
@@ -583,6 +718,67 @@ describe('worker attestation flow', () => {
     const env = makeEnv({ ATTEST_MODE: 'enforce', APP_ATTEST_ROOT_CA: undefined });
     const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
     expect(res.status).toBe(500);
+  });
+
+  it('fails closed when the token-signing secret is missing', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'enforce', ATTEST_TOKEN_SECRET: undefined });
+    const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
+    expect(res.status).toBe(500);
+  });
+
+  it('fails closed when the token secret is the secret the app already holds', async () => {
+    // Configured, complete, and worthless: signing the token with a value that
+    // ships in the IPA means anyone can mint one. Refuse to run rather than
+    // pretend to check.
+    const env = makeEnv({ ATTEST_MODE: 'enforce', ATTEST_TOKEN_SECRET: APP_SECRET });
+    const res = await worker.fetch(messagesRequest(`jefe.${INSTALL}.${APP_SECRET}`), env, ctx);
+    expect(res.status).toBe(500);
+    const enrolment = await worker.fetch(attestRequest('/v1/attest/challenge', {}), env, ctx);
+    expect(enrolment.status).toBe(503);
+  });
+
+  it('refuses a token forged with the app secret', async () => {
+    // The whole finding, end to end: an attacker with the extracted IPA secret
+    // mints a well-formed token for an install id of their choosing and names
+    // a key that WAS genuinely attested. It must not be enough.
+    const env = makeEnv({ ATTEST_MODE: 'enforce' });
+    await enrol(env);
+    const forged = await mintToken(APP_SECRET, INSTALL, toBase64Url(world.keyId));
+    const res = await worker.fetch(
+      messagesRequest(`jefeA.${INSTALL}.${forged}~${APP_SECRET}`),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('refuses a token naming a key that was never attested', async () => {
+    // Minted with the REAL signing secret — so this is what a compromised
+    // server-side minting path or a stale token looks like — but `k` points at
+    // nothing, which is what makes the attestation load-bearing.
+    const env = makeEnv({ ATTEST_MODE: 'enforce' });
+    await enrol(env);
+    const unattested = toBase64Url(new Uint8Array(32).fill(1));
+    const token = await mintToken(TOKEN_SECRET, INSTALL, unattested);
+    const res = await worker.fetch(
+      messagesRequest(`jefeA.${INSTALL}.${token}~${APP_SECRET}`),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('refuses a token for a key another install attested', async () => {
+    const env = makeEnv({ ATTEST_MODE: 'enforce' });
+    await enrol(env); // key belongs to INSTALL
+    const keyId = toBase64Url(world.keyId);
+    const token = await mintToken(TOKEN_SECRET, 'squatter-install', keyId);
+    const res = await worker.fetch(
+      messagesRequest(`jefeA.squatter-install.${token}~${APP_SECRET}`),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(401);
   });
 
   it('refuses a token minted for a different install', async () => {

--- a/services/proxy/wrangler.toml
+++ b/services/proxy/wrangler.toml
@@ -5,6 +5,7 @@ compatibility_date = "2026-07-25"
 # Secrets are NOT set here — `wrangler.toml` is committed. Set them with:
 #   wrangler secret put ANTHROPIC_API_KEY
 #   wrangler secret put APP_SECRET
+#   wrangler secret put ATTEST_TOKEN_SECRET
 # See README.md.
 
 [vars]
@@ -22,16 +23,20 @@ PER_INSTALL_DAILY_CAP_USD = "2"
 # --- App Attest (Phase 2) --------------------------------------------------
 # `off` | `monitor` | `enforce`. Ships as `off`: the device half does not exist
 # yet, and even once it does, `enforce` before a `monitor` soak would lock out
-# every already-installed build. Anything unrecognised also means `off`.
+# every already-installed build. Anything unrecognised also means `off` — and is
+# logged as `attest_mode_unrecognised`, so a typo is visible rather than
+# indistinguishable from a correct `off` deployment.
 ATTEST_MODE = "off"
 
-# Required before ATTEST_MODE can leave `off`. Both are public values, so they
-# live here rather than in secrets — but the worker fails CLOSED without them.
+# Required before ATTEST_MODE can leave `off`. These two are public values, so
+# they live here rather than in secrets — but the worker fails CLOSED without
+# them.
 #
-# APP_ATTEST_APP_ID is "<TeamID>.<bundle id>". Note the real-core build uses
-# com.isaacwm.sitewalk; the demo project's id differs, and a mismatch shows up
-# as `app_id_mismatch` on every attestation.
-# APP_ATTEST_APP_ID = "TEAMID.com.isaacwm.sitewalk"
+# APP_ATTEST_APP_ID is "<TeamID>.<bundle id>". The shipped app is bundle id
+# com.isaacwm.murmur (the product is named Sitewalk; the bundle id predates the
+# rename — see apps/ios/project-release.yml) on team 98GXNZ6NKZ. Anything else
+# shows up as `app_id_mismatch` on every single attestation.
+# APP_ATTEST_APP_ID = "98GXNZ6NKZ.com.isaacwm.murmur"
 #
 # APP_ATTEST_ROOT_CA is Apple's App Attest root, PEM. It is configured rather
 # than compiled in so it can be rotated without a code change:
@@ -41,6 +46,13 @@ ATTEST_MODE = "off"
 # APP_ATTEST_ALLOW_DEVELOPMENT = "true" also accepts attestations from builds
 # signed with a development profile. Useful on a staging worker, never in
 # production — a development attestation is a far lower bar to clear.
+#
+# ATTEST_TOKEN_SECRET is a SECRET (`wrangler secret put`), and it is the one
+# value here that must never reach the app. It signs the hourly attestation
+# token. Signing that token with APP_SECRET — which ships inside the IPA — would
+# mean anyone who unzipped a build could mint one, and the attestation would
+# certify nothing. The worker refuses to run attestation if it is missing, or if
+# it equals APP_SECRET.
 
 [[kv_namespaces]]
 binding = "METER"


### PR DESCRIPTION
The cryptographic engineering in `26f8cca` is good — hand-rolled DER with real WebCrypto ECDSA, root-by-configuration rather than by self-signature, deliberate strictness with the reasoning written down. The failures here are **absences**, not bad lines. Four of them, in order of what they cost.

**`ATTEST_MODE` remains `"off"`.** This does not enable enforcement; it makes enforcement safe to enable later. What still has to happen before it can move is listed at the bottom.

---

## 1. The token was not bound to the attested key

**What was broken.** `/v1/messages` accepted an hourly token that never had to reference the attested key, and that was signed with a key the client already holds. Two independent absences, either one fatal:

- `mintToken(env.APP_SECRET, …)` — `APP_SECRET` ships inside the IPA (`auth.ts` is explicit about this). Anyone who unzips a build extracts it and mints a token that verifies. The token was strictly no stronger than the Phase 1 credential it rode inside.
- `payload.k` — the attested key id, the entire purpose of the attestation — had **zero consumers**. `verifyToken` returned it; `index.ts:340` used only `result.ok`. `grep -n keyId src/index.ts` on `main` shows every hit inside `handleAttestRoute`, none on the `/v1/messages` path.

Together: the ~626 lines of chain verification, nonce checking, key-id hashing, app-id matching, counter and aaguid checks were unreachable from the only route that spends money. An attacker with the extracted app secret minted their own token and never touched a Secure Enclave.

**What changed.**

- **A signing secret the client does not have.** New binding `ATTEST_TOKEN_SECRET` (a `wrangler secret`, not a `[vars]` entry — it is the one attestation value that must never reach the app). `attestSetup()` replaces `attestConfig()` and fails closed on it exactly as the worker already fails closed on `APP_ATTEST_APP_ID` / `APP_ATTEST_ROOT_CA`: 503 on the attest routes, hard 500 on `/v1/messages` when the mode is not `off`. It **also** fails closed when `ATTEST_TOKEN_SECRET === APP_SECRET`, because that is one copy-paste away from silently restoring the hole. The misconfiguration log now names which value is wrong instead of just saying "misconfigured".
- **The key is looked up.** `verifyToken` now takes the KV namespace and, after the MAC check, resolves `payload.k` against what enrolment stored — refusing `unknown_key` (never attested) and `key_install_mismatch` (attested by a different install). KV is a *required argument* rather than a second step the caller is trusted to perform, which is precisely how the check went missing the first time: there is now no way to ask "is this token good?" without the storage that can answer.
- The lookup sits **after** the MAC check, so an unauthenticated caller cannot use token verification to probe or hammer the keyspace. `payload.k` is also shape-checked and `payload.k`'s type is now validated alongside `i` and `e`.

**Evidence the tests bite.** Every new test was verified by mutating the guard, confirming red, restoring, confirming green:

| Test | Mutation | Result |
|---|---|---|
| `refuses a token forged with the app secret` (worker, end to end) | restore `verifyToken(env.METER, env.APP_SECRET, …)` | 1 failed → restored 1 passed |
| `rejects a token signed with the secret that ships in the app` (unit) | `macKey` ignores its `secret` argument | 1 failed → 1 passed |
| `rejects/refuses a token naming a key that was never attested` (unit + worker) | drop `if (!stored) return unknown_key` | 2 failed → 2 passed |
| `rejects/refuses a token for a key another install attested` (unit + worker) | drop the `stored.installId !== installId` check | 2 failed → 2 passed |
| `never touches KV for a token it cannot authenticate` | let an unauthenticated token past the MAC gate | 1 failed → 1 passed |
| `fails closed when the token-signing secret is missing` | drop the `!tokenSecret` check | 1 failed → 1 passed |
| `fails closed when the token secret is the secret the app already holds` | drop the equality check | 1 failed → 1 passed |

The worker-level forgery test is the one that matters most: it runs a **full genuine enrolment** (challenge → attest → assert) so a real attested key exists, then presents a token minted with `APP_SECRET` naming that real key. 401.

---

## 2. `APP_ATTEST_APP_ID` documented the wrong app id

**What was broken.** `wrangler.toml` documented `TEAMID.com.isaacwm.sitewalk`, and a comment asserted "the real-core build uses com.isaacwm.sitewalk". It does not. `apps/ios/project-release.yml` sets `PRODUCT_BUNDLE_IDENTIFIER: com.isaacwm.murmur` and the team is `98GXNZ6NKZ` — the product was renamed to Sitewalk, the bundle id was not. Copied as written, **every** attestation fails on `app_id_mismatch`, and the failure looks like a broken verifier rather than a typo'd config.

**What changed.** The documented example is now `98GXNZ6NKZ.com.isaacwm.murmur`, with a note on why the bundle id and the product name differ so the next reader does not "correct" it back. There is no default in code — the value is required, and the worker fails closed without it — so this was documentation only. The test fixture's synthetic app id moved to the real bundle id too, so nothing in the tree still says `sitewalk`.

**Evidence.** Not a behavioural change, so no test claims to bite. Verified by grep against the shipped project file rather than against the comment.

---

## 3. An unparseable `ATTEST_MODE` was silent

**What was broken.** `attestMode()` fell through to `off` for anything unrecognised. Falling back is right — a typo must not lock the fleet out mid-walk. Being silent is not: `off` is *also* what a correct deployment looks like, so an operator who typed `enfroce` gets a service behaving exactly as they believe they configured it, forever.

**What changed.** An unrecognised non-empty value logs `attest_mode_unrecognised` with the value (truncated to 32 chars; it is operator config, never caller input, and no request body is involved — the privacy rule is untouched). Unset and empty stay quiet: those are "not configured", not "misconfigured". `off` is now matched explicitly so the recognised set is one list.

**Evidence.**

| Test | Mutation | Result |
|---|---|---|
| `says so out loud when it does not recognise the value` | remove the `console.warn` | 1 failed → 1 passed |
| `stays quiet for the three real modes and for no value at all` | log unconditionally | 1 failed → 1 passed |

The second test is what stops the fix from becoming noise on every valid deploy.

---

## 4. `x5c` was unbounded, and nothing checked `basicConstraints`

**What was broken.** The chain arrived from the client and was walked with only a `length < 2` floor. A hostile client chose how many DER parses and ECDSA verifies the worker performed on its behalf — and the parsing happened *before* any of the cheap rejections. Separately, nothing required a signing certificate to claim it was a CA: with valid names and a valid signature, an end-entity certificate was a usable issuer.

**What changed.**

- `MAX_X5C_CERTIFICATES = 4`, checked **before** a single certificate is parsed. Apple sends exactly two (credential certificate + `Apple App Attestation CA 1`; the root is configured, not sent), so four leaves room for two more intermediates without a code change and still bounds the work hard.
- `verifyChain` requires `basicConstraints` with `cA` TRUE on every certificate that issues another — indices 1..n, the leaf excepted since it signs nothing. Encoding note: `cA` is `DEFAULT FALSE`, so a real encoder *omits* it when false; an absent extension, an empty SEQUENCE, and a SEQUENCE starting with the pathLen INTEGER all correctly read as "not a CA", and only an explicit BOOLEAN `0xFF` reads as true. The fixtures now stamp `cA:TRUE` on the test root and intermediates, as Apple's real certificates do.

**Evidence.**

| Test | Mutation | Result |
|---|---|---|
| `refuses a chain longer than any real one, before parsing a certificate` | remove the length check | 1 failed → 1 passed |
| `lets a chain AT the bound through the length gate` | move the bound from 4 to 3 | 1 failed → 1 passed |
| `refuses an intermediate that does not claim to be a CA` | remove the CA loop | 1 failed → 1 passed |

The non-CA intermediate fixture is the same key, the same subject name, and a signature over the leaf that genuinely verifies — the **only** difference from the real intermediate is the `cA` flag, so the test cannot pass for any other reason. The "at the bound" test asserts a chain of 4 dies *later* (`chain_broken`) rather than on length, which proves the bound is at 4 and not a blanket refusal of anything the fixture pads.

---

## Verification

- **104 tests pass** (90 on `main`, 14 added). `npm run typecheck` clean.
- Every one of the 14 new tests was proven to bite by the 12 mutations tabled above — guard broken, red observed; guard restored, green observed. No test was accepted on the strength of passing alone.
- Nothing was deployed and the live worker was not probed. `CLOUDFLARE_API_TOKEN` is unset, so the deploy job still skips with a notice.
- No request or response body is logged, stored, or forwarded anywhere in this diff. The new log lines carry an event name, an install id, a config problem name, and a mode string.

## Before `ATTEST_MODE` can leave `off`

1. **Set `ATTEST_TOKEN_SECRET`** (`wrangler secret put`) — a fresh random string, **different from `APP_SECRET`**, never given to the app. The worker fails closed without it, so the attest routes 503 until it exists.
2. **Set `APP_ATTEST_APP_ID`** to `98GXNZ6NKZ.com.isaacwm.murmur` and `APP_ATTEST_ROOT_CA` to Apple's root PEM.
3. **Build the device half.** `DCAppAttestService` key generation, the three enrolment calls, token caching, and the `jefeA.` credential. None of it exists yet.
4. **Soak in `monitor` on real devices.** This is the one that cannot be skipped or simulated. **The verifier has never seen a genuine Apple certificate chain** — the tests build a synthetic one, deliberately, because holding the private keys is what lets a test change exactly one field and prove that *that* check is what fires. What a synthetic chain cannot prove is that we accept Apple's real material. That risk is now slightly larger than it was, not smaller: this PR adds two strictness checks (`basicConstraints cA:TRUE` on every issuer, `x5c ≤ 4`) that are asserted only against our own certificates. Both should hold for Apple — their CAs are RFC 5280 CAs and their chain is two long — but "should" is what a `monitor` soak exists to replace. Watch `attest_token_rejected` and `attest_failed` codes; `issuer_not_ca` or `chain_too_long` appearing against real devices means back it out, not push forward.
5. Only then `enforce`, and only after the rejection count has fallen to roughly zero as builds carrying the device half roll out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
