### PR TITLE
fix(core): schema selection is deterministic, and its tiebreak test can no longer pass without the tiebreak

### DIFF
--- a/apps/ios/Sources/Engine/DocumentSchemaModel.swift
+++ b/apps/ios/Sources/Engine/DocumentSchemaModel.swift
@@ -149,22 +149,78 @@ struct DocumentSchemaModel: Identifiable, Hashable {
         let matching = schemas.filter { $0.tradeKey == tradeKey || $0.tradeKey == nil }
         return Dictionary(grouping: matching, by: \.kind)
             .compactMap { _, group in
-                // Mirrors the resolver's ORDER BY exactly: a trade-specific
-                // schema beats a universal one for the same kind whatever the
-                // timestamps say, so an operator's own version is never
-                // shadowed by a shared default. Newest breaks the remaining tie.
-                // Trade-specific ranks 1, universal ranks 0, so `max` picks
-                // the specific one. (Getting this backwards made the shared
-                // default win — caught by
-                // `testATradeSpecificSchemaBeatsAUniversalOneOfTheSameKind`.)
-                // Core expresses the same order as `ORDER BY (trade_key IS
-                // NULL) ASC` with LIMIT 1.
-                group.max {
-                    ($0.tradeKey == nil ? 0 : 1, $0.updatedAt)
-                        < ($1.tradeKey == nil ? 0 : 1, $1.updatedAt)
+                // The winner is the FIRST row under core's ORDER BY, term
+                // for term:
+                //
+                //   (trade_key IS NULL) ASC — a trade-specific schema beats a
+                //     universal one for the same kind whatever the timestamps
+                //     say, so an operator's own version is never shadowed by a
+                //     shared default. (Getting this backwards made the shared
+                //     default win — caught by
+                //     `testATradeSpecificSchemaBeatsAUniversalOneOfTheSameKind`.)
+                //   updated_at DESC — newest breaks the remaining tie.
+                //   id ASC — closes the order. Without it a tie (two universal
+                //     rows, same `updatedAt` — the state a device is in the
+                //     moment it duplicates a built-in and has not edited the
+                //     copy) is broken by whichever order the rows happened to
+                //     arrive in, and the mirror can disagree with the resolver
+                //     on the same data.
+                group.min { a, b in
+                    if (a.tradeKey == nil) != (b.tradeKey == nil) { return b.tradeKey == nil }
+                    if a.updatedAt != b.updatedAt { return a.updatedAt > b.updatedAt }
+                    return a.id < b.id
                 }
             }
             .sorted { $0.label < $1.label }
+    }
+
+    /// The stable `kind` derived from an operator-typed name: lowercased, every
+    /// run of non-alphanumerics collapsed to one underscore, no leading or
+    /// trailing underscore.
+    static func slug(_ s: String) -> String {
+        s.lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "_" }
+            .joined()
+            .split(separator: "_", omittingEmptySubsequences: true)
+            .joined(separator: "_")
+    }
+
+    /// What the Document Builder actually sends to `save_document_schema` when
+    /// the operator saves `draft`, which they opened from `original`.
+    ///
+    /// Only a BUILT-IN is reshaped; an operator's own type saves as-is.
+    ///
+    /// `save` upserts BY ID, so sending a built-in's id back overwrites the
+    /// built-in in place — while the screen promised "saving creates your own
+    /// copy, the default stays available." That was simply false, and it took
+    /// the shipped default with it. Clearing the id makes core mint a new one,
+    /// so the copy is real.
+    ///
+    /// Two things deliberately survive the copy:
+    ///
+    /// 1. **The kind, unless the operator renamed it.** A built-in keeps its
+    ///    kind frozen (that is what `buildDocument` resolves against), but a
+    ///    RENAMED copy is a different document type and must not keep answering
+    ///    to "estimate" — otherwise a button labelled RFP builds an estimate.
+    /// 2. **The source's trade.** #283 stamped the operator's current trade
+    ///    here, to work around a nil-trade copy being unbuildable. Core now
+    ///    treats nil as universal (#306), so the workaround is not only
+    ///    unnecessary but backwards: stamping would pin a copy of the universal
+    ///    Report to one trade, and Isaac's call (2026-07-30) is the opposite —
+    ///    *"They should come in regardless of trade!"* A duplicate of Report
+    ///    stays universal; a duplicate of the landscape Estimate stays
+    ///    landscape. The copy keeps whatever scope the thing it came from had.
+    static func saveShape(
+        of draft: DocumentSchemaModel, editedFrom original: DocumentSchemaModel
+    ) -> DocumentSchemaModel {
+        guard draft.isBuiltin else { return draft }
+        var copy = draft
+        copy.id = ""            // create, don't overwrite the shipped default
+        copy.isBuiltin = false
+        if draft.label != original.label {
+            copy.kind = slug(draft.label)
+        }
+        return copy
     }
 
     init(

--- a/apps/ios/Sources/Flow/DocumentBuilderView.swift
+++ b/apps/ios/Sources/Flow/DocumentBuilderView.swift
@@ -42,7 +42,6 @@ struct DocumentBuilderView: View {
             if let editing {
                 SchemaEditor(
                     schema: editing,
-                    tradeKey: model.trade.key,
                     onCancel: { self.editing = nil },
                     onSave: { save($0) },
                     onDelete: editing.isBuiltin || editing.id.isEmpty
@@ -245,18 +244,14 @@ private struct SchemaEditor: View {
     let onSave: (DocumentSchemaModel) -> Void
     /// nil for built-ins and unsaved drafts — neither can be deleted.
     let onDelete: (() -> Void)?
-    /// The operator's trade, stamped onto a copy of a built-in. See `saveShape`.
-    private let tradeKey: String?
 
     init(
         schema: DocumentSchemaModel,
-        tradeKey: String?,
         onCancel: @escaping () -> Void,
         onSave: @escaping (DocumentSchemaModel) -> Void,
         onDelete: (() -> Void)?
     ) {
         self.original = schema
-        self.tradeKey = tradeKey
         _draft = State(initialValue: schema)
         self.onCancel = onCancel
         self.onSave = onSave
@@ -266,36 +261,9 @@ private struct SchemaEditor: View {
     private var problem: String? { SchemaValidation.firstProblem(in: draft) }
 
     /// What actually gets sent to `save_document_schema`.
-    ///
-    /// `save` upserts BY ID, so sending a built-in's id back overwrites the
-    /// built-in in place — while this screen promised "saving creates your own
-    /// copy, the default stays available." That was simply false, and it took
-    /// the shipped default with it.
-    ///
-    /// Clearing the id makes core mint a new one, so the copy is real. If the
-    /// operator also renamed it, the kind is re-derived: a built-in keeps its
-    /// kind frozen (that is what `buildDocument` resolves against), but a
-    /// RENAMED copy is a different document type and must not keep answering
-    /// to "estimate" — otherwise a button labelled RFP builds an estimate.
+    /// Lives on the model so it can be tested — see `DocumentSchemaModel`.
     private func saveShape(of draft: DocumentSchemaModel) -> DocumentSchemaModel {
-        guard draft.isBuiltin else { return draft }
-        var copy = draft
-        copy.id = ""            // create, don't overwrite the shipped default
-        copy.isBuiltin = false
-        // INHERIT the source's trade — do not stamp the operator's.
-        //
-        // #283 stamped the current trade here, to work around a nil-trade copy
-        // being unbuildable. Core now treats nil as universal, so the
-        // workaround is not only unnecessary but backwards: stamping would pin
-        // a copy of the universal Report to one trade, and Isaac's call
-        // (2026-07-30) is the opposite — "They should come in regardless of
-        // trade!" A duplicate of Report stays universal; a duplicate of the
-        // landscape Estimate stays landscape. The copy keeps whatever scope the
-        // thing it was copied from had.
-        if draft.label != original.label {
-            copy.kind = Self.slug(draft.label)
-        }
-        return copy
+        DocumentSchemaModel.saveShape(of: draft, editedFrom: original)
     }
 
     var body: some View {
@@ -367,7 +335,7 @@ private struct SchemaEditor: View {
                     // saved once. After that the key is frozen: it is what core
                     // resolves `buildDocument(kind:)` against, so renaming a
                     // saved type must not silently orphan its documents.
-                    if original.id.isEmpty { draft.kind = Self.slug(new) }
+                    if original.id.isEmpty { draft.kind = DocumentSchemaModel.slug(new) }
                 }
             LabeledField(
                 title: "Number prefix", text: $draft.numberPrefix, placeholder: "EST"
@@ -381,14 +349,6 @@ private struct SchemaEditor: View {
     private var prefixPreview: String {
         let p = draft.numberPrefix.trimmingCharacters(in: .whitespaces).uppercased()
         return p.isEmpty ? "EST" : p
-    }
-
-    private static func slug(_ s: String) -> String {
-        s.lowercased()
-            .map { $0.isLetter || $0.isNumber ? String($0) : "_" }
-            .joined()
-            .split(separator: "_", omittingEmptySubsequences: true)
-            .joined(separator: "_")
     }
 
     private var sections: some View {

--- a/apps/ios/Tests/DocumentChoiceTests.swift
+++ b/apps/ios/Tests/DocumentChoiceTests.swift
@@ -119,6 +119,24 @@ final class DocumentChoiceTests: XCTestCase {
         )
     }
 
+    func testAnExactTieIsBrokenByIdSoThePickerAgreesWithCore() {
+        // Two schemas of equal rank — same trade-ness, same `updatedAt` — must
+        // collapse to the SAME one the resolver picks, whatever order they
+        // arrive in. Core closes its ORDER BY with `id ASC`; this mirrors it.
+        //
+        // Not a synthetic tie: every seeded built-in carries `updatedAt = 0`,
+        // so a device that has duplicated one and not yet edited the copy is in
+        // exactly this state.
+        let a = schema("report", label: "A report", trade: nil, updatedAt: 0, id: "aaa")
+        let z = schema("report", label: "Z report", trade: nil, updatedAt: 0, id: "zzz")
+        for input in [[z, a], [a, z]] {
+            XCTAssertEqual(
+                DocumentSchemaModel.buildable(from: input, tradeKey: "landscape").first?.id, "aaa",
+                "a tie must resolve by lowest id, not by input order"
+            )
+        }
+    }
+
     func testDistinctKindsAreAllKeptAndSortedByLabel() {
         let all = [
             schema("work_order", label: "Work Order", trade: "landscape"),

--- a/apps/ios/Tests/SchemaDuplicateTests.swift
+++ b/apps/ios/Tests/SchemaDuplicateTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+
+@testable import SitewalkGallery
+
+/// Gates on `DocumentSchemaModel.saveShape(of:editedFrom:)` — what the Document
+/// Builder's SAVE button actually sends to `save_document_schema`.
+///
+/// The un-renamed duplicate is the case that had nothing pinning it. #306
+/// changed exactly this path (it dropped #283's trade stamp), and the change is
+/// invisible when the operator renames: renaming re-derives the kind, so the
+/// copy is obviously a new type either way. It is the operator who taps SAVE on
+/// a built-in and changes only its SECTIONS — the "I want the standard Report,
+/// but with my paragraph" case — who is exposed to whether the trade is
+/// inherited or stamped, and to whether the id is really cleared.
+final class SchemaDuplicateTests: XCTestCase {
+    private func builtin(
+        _ kind: String, label: String, trade: String?, id: String
+    ) -> DocumentSchemaModel {
+        DocumentSchemaModel(
+            id: id,
+            kind: kind,
+            label: label,
+            numberPrefix: String(kind.prefix(3)).uppercased(),
+            tradeKey: trade,
+            updatedAt: 0,
+            isBuiltin: true
+        )
+    }
+
+    // MARK: The un-renamed duplicate
+
+    func testDuplicatingTheUniversalReportWithoutRenamingStaysUniversal() {
+        // Isaac, 2026-07-30: "They should come in regardless of trade!" A
+        // landscaper who takes the shipped Report and edits its sections must
+        // end up with a Report that still builds on every walk. Stamping their
+        // trade here (what #283 did) would pin the copy to landscape and make
+        // it vanish the day they walk a property.
+        let original = builtin("report", label: "Report", trade: nil, id: "…0004")
+        var draft = original
+        draft.numberPrefix = "RPT"      // edited, but NOT renamed
+
+        let saved = DocumentSchemaModel.saveShape(of: draft, editedFrom: original)
+
+        XCTAssertNil(saved.tradeKey, "an un-renamed copy of a universal built-in stays universal")
+        XCTAssertEqual(saved.kind, "report", "no rename means the kind is not re-derived")
+        XCTAssertEqual(saved.id, "", "the copy must be a CREATE, not an overwrite of the built-in")
+        XCTAssertFalse(saved.isBuiltin, "the copy is the operator's, not a shipped default")
+        XCTAssertEqual(saved.numberPrefix, "RPT", "the operator's edit survives")
+    }
+
+    func testDuplicatingATradeScopedBuiltinWithoutRenamingKeepsThatTrade() {
+        // The other half of "inherit, don't stamp": scope is not widened either.
+        //
+        // Move-Out is also the built-in whose label does not slug back to its
+        // own kind ("Move-Out Report" -> "move_out_report", kind "move_out"), so
+        // this is where re-deriving the kind on a save that did NOT rename would
+        // show up — as a copy that answers to a kind core has no items for.
+        let original = builtin("move_out", label: "Move-Out Report", trade: "property", id: "…0006")
+        var draft = original
+        draft.numberPrefix = "MO"
+
+        let saved = DocumentSchemaModel.saveShape(of: draft, editedFrom: original)
+
+        XCTAssertEqual(saved.tradeKey, "property", "the copy keeps the scope it was copied from")
+        XCTAssertEqual(saved.kind, "move_out", "no rename means the kind is NOT re-derived")
+        XCTAssertEqual(saved.id, "")
+    }
+
+    func testAnUnrenamedCopyStillCollidesWithItsBuiltinAndWinsOnlyByBeingNewer() {
+        // The consequence of keeping the kind: the copy and the built-in share
+        // one kind, so `buildable` collapses them to one button. Core stamps a
+        // real clock on the save while every built-in sits at updatedAt 0, so
+        // the operator's copy is the one that builds.
+        let original = builtin("report", label: "Report", trade: nil, id: "…0004")
+        var saved = DocumentSchemaModel.saveShape(of: original, editedFrom: original)
+        saved.id = "minted-by-core"
+        saved.updatedAt = 1_700_000_000
+
+        let winners = DocumentSchemaModel.buildable(from: [original, saved], tradeKey: "landscape")
+        XCTAssertEqual(winners.count, 1, "one kind, one button")
+        XCTAssertEqual(winners.first?.id, "minted-by-core", "the operator's copy is what builds")
+    }
+
+    // MARK: Rename, and the non-built-in passthrough
+
+    func testRenamingRederivesTheKindSoTheButtonBuildsWhatItSays() {
+        let original = builtin("report", label: "Report", trade: nil, id: "…0004")
+        var draft = original
+        draft.label = "Property Request Form"
+
+        let saved = DocumentSchemaModel.saveShape(of: draft, editedFrom: original)
+
+        XCTAssertEqual(saved.kind, "property_request_form")
+        XCTAssertNil(saved.tradeKey, "renaming does not scope it either")
+        XCTAssertEqual(saved.id, "")
+    }
+
+    func testTheOperatorsOwnTypeIsSavedUnchanged() {
+        // Not a built-in: this is an EDIT of something they already own, so the
+        // id must survive or the edit forks a second copy on every save.
+        var original = builtin("hoa_addendum", label: "HOA Addendum", trade: nil, id: "mine-1")
+        original.isBuiltin = false
+        var draft = original
+        draft.label = "HOA Addendum v2"
+
+        let saved = DocumentSchemaModel.saveShape(of: draft, editedFrom: original)
+
+        XCTAssertEqual(saved.id, "mine-1", "editing your own type updates it in place")
+        XCTAssertEqual(saved.kind, "hoa_addendum", "a saved type's kind is frozen")
+        XCTAssertEqual(saved.label, "HOA Addendum v2")
+    }
+
+    // MARK: slug
+
+    func testSlugCollapsesPunctuationAndTrimsUnderscores() {
+        XCTAssertEqual(DocumentSchemaModel.slug("Move-Out Report"), "move_out_report")
+        XCTAssertEqual(DocumentSchemaModel.slug("  RFP!!  "), "rfp")
+        XCTAssertEqual(DocumentSchemaModel.slug("Punch List 2"), "punch_list_2")
+    }
+}

--- a/crates/murmur-core/src/store/schemas.rs
+++ b/crates/murmur-core/src/store/schemas.rs
@@ -305,14 +305,20 @@ impl Store {
         Ok(())
     }
 
-    /// The active schema for `(kind, template)` (Plan 19 §4): trade must
-    /// match exactly — a NULL-trade schema (e.g. `report`) resolves ONLY for
-    /// a None-template session, so it stays illegal on a landscape session,
-    /// matching today. Newest `updated_at` wins (a custom save shadows the
-    /// fixed-timestamp built-in). `None` when nothing resolves (e.g. an
-    /// operator tombstoned a built-in) — the caller fails truthfully, never
-    /// falls back to a hardcoded shape (that would resurrect a deleted
-    /// built-in).
+    /// The active schema for `(kind, template)` (Plan 19 §4, as amended by
+    /// #306): a row resolves when its trade matches the template OR its trade
+    /// is NULL, because a NULL trade means UNIVERSAL — a `report` resolves on
+    /// a landscape walk, a property walk, and a trade the app has never heard
+    /// of. A row naming a DIFFERENT trade never resolves.
+    ///
+    /// Ranked, in order: trade-specific over universal (an operator's
+    /// landscape `report` beats the shared one), then newest `updated_at` (a
+    /// custom save shadows the fixed-timestamp built-in), then lowest `id` so
+    /// two otherwise-equal rows always resolve to the same one.
+    ///
+    /// `None` when nothing resolves (e.g. an operator tombstoned a built-in) —
+    /// the caller fails truthfully, never falls back to a hardcoded shape
+    /// (that would resurrect a deleted built-in).
     pub fn resolve_active_schema(
         &self,
         kind: &str,
@@ -340,6 +346,16 @@ impl Store {
         // remaining tie, preserving the `updated_at DESC` behaviour the app's
         // picker mirrors.
         //
+        // `id ASC` closes the ordering. Without it two rows of equal rank —
+        // same trade-ness, same `updated_at` — come back in whatever order the
+        // scan happens to produce, so which document the operator gets is a
+        // property of SQLite's plan rather than of the data. Two rows do tie in
+        // practice: every seeded built-in carries the fixed `updated_at = 0`,
+        // and a save that lands in the same clock tick as another ties too.
+        // A total order also means the answer cannot change under an index
+        // change or a VACUUM. (Pinned by
+        // `resolve_breaks_an_exact_tie_deterministically_by_id`.)
+        //
         // Does NOT widen across trades: a `property` schema still has
         // `trade_key = 'property'`, which matches neither clause under a
         // landscape session.
@@ -348,7 +364,7 @@ impl Store {
              WHERE kind = ?1
                AND (trade_key = ?2 OR trade_key IS NULL)
                AND deleted_at IS NULL
-             ORDER BY (trade_key IS NULL) ASC, updated_at DESC LIMIT 1"
+             ORDER BY (trade_key IS NULL) ASC, updated_at DESC, id ASC LIMIT 1"
         ))?;
         let mut rows = stmt.query(rusqlite::params![kind, template])?;
         match rows.next()? {
@@ -766,19 +782,61 @@ mod tests {
 
     /// Trade-specific beats universal for the same kind, whatever the clock
     /// says — otherwise a shared default could shadow the operator's own.
+    ///
+    /// The fixture is deliberately stacked AGAINST the trade term, because a
+    /// version of this test that was not could be deleted along with the clause
+    /// it guards and stay green: the universal row is the NEWER one (so
+    /// `updated_at DESC` alone picks it) and the alphabetically LOWER one (so
+    /// `id ASC` alone picks it too). `(trade_key IS NULL) ASC` is the only term
+    /// that can produce the asserted answer.
     #[test]
     fn a_trade_specific_schema_wins_over_a_universal_one() {
         let s = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(|| 1000));
-        // Universal, and NEWER than the trade-specific one saved next.
-        s.save_document_schema(&custom_schema("universal-rfp", "rfp", None)).unwrap();
+        // Trade-specific first, at the OLDER clock.
+        s.save_document_schema(&custom_schema("b-landscape-rfp", "rfp", Some("landscape")))
+            .unwrap();
         let s = s.with_clock(Arc::new(|| 2000));
-        s.save_document_schema(&custom_schema("landscape-rfp", "rfp", Some("landscape"))).unwrap();
+        s.save_document_schema(&custom_schema("a-universal-rfp", "rfp", None)).unwrap();
 
         let resolved = s.resolve_active_schema("rfp", Some("landscape")).unwrap().unwrap();
-        assert_eq!(resolved.id, "landscape-rfp", "the trade-specific schema must win");
+        assert_eq!(
+            resolved.id, "b-landscape-rfp",
+            "the trade-specific schema must win, though it is older and sorts later"
+        );
         // And on a trade with no specific version, the universal one serves.
         let elsewhere = s.resolve_active_schema("rfp", Some("property")).unwrap().unwrap();
-        assert_eq!(elsewhere.id, "universal-rfp");
+        assert_eq!(elsewhere.id, "a-universal-rfp");
+    }
+
+    /// Two rows of EQUAL rank resolve to the same one every time.
+    ///
+    /// Both are universal `rfp`s saved on the same clock tick, so the trade term
+    /// and `updated_at DESC` are both exhausted and only `id ASC` is left. The
+    /// rows are inserted in DESCENDING id order, so the unordered scan — which
+    /// is what SQLite gives back without a total order — returns the wrong one.
+    ///
+    /// This is not a synthetic tie. Every seeded built-in carries the fixed
+    /// `updated_at = 0`, so a device that has duplicated one and not yet edited
+    /// the copy is in exactly this state.
+    #[test]
+    fn resolve_breaks_an_exact_tie_deterministically_by_id() {
+        let s = Store::open_in_memory("device-a").unwrap().with_clock(Arc::new(|| 1000));
+        s.save_document_schema(&custom_schema("rfp-z", "rfp", None)).unwrap();
+        s.save_document_schema(&custom_schema("rfp-a", "rfp", None)).unwrap();
+
+        for template in [None, Some("landscape"), Some("property")] {
+            let resolved = s.resolve_active_schema("rfp", template).unwrap().unwrap();
+            assert_eq!(
+                resolved.id, "rfp-a",
+                "an exact tie must resolve by lowest id, not by scan order ({template:?})"
+            );
+        }
+
+        // Same, one rank up: a tie between two TRADE-SPECIFIC rows.
+        s.save_document_schema(&custom_schema("hoa-z", "hoa_addendum", Some("landscape"))).unwrap();
+        s.save_document_schema(&custom_schema("hoa-a", "hoa_addendum", Some("landscape"))).unwrap();
+        let resolved = s.resolve_active_schema("hoa_addendum", Some("landscape")).unwrap().unwrap();
+        assert_eq!(resolved.id, "hoa-a");
     }
 
     /// The resurrection consequence: a tombstoned built-in does not resolve —


### PR DESCRIPTION
Five follow-ups from reviewing #306 after it merged. None were blocking; all are real. Every test below was proved to bite — the code it guards was broken, the test confirmed red, then restored and confirmed green.

## 1. The tiebreak test was vacuous

`a_trade_specific_schema_wins_over_a_universal_one` was set up inverted against its own docstring. The comment read "Universal, and NEWER than the trade-specific one saved next" — but the universal row was saved at clock 1000 and the trade-specific one at 2000, so the trade-specific row was the newer of the two and `updated_at DESC` alone produced the asserted answer. The `(trade_key IS NULL) ASC` clause the test exists to pin was never exercised.

**Evidence it was vacuous:** deleted that clause from the `ORDER BY` on merge-base and ran `cargo test --workspace` — 23 suites, **zero failures**. The clause could be deleted outright and nothing on main would notice.

**Changed:** the fixture is now stacked *against* the trade term. The trade-specific row is saved first at the older clock and given the id `b-landscape-rfp`; the universal row is saved second at the newer clock as `a-universal-rfp`. So `updated_at DESC` alone picks universal, and `id ASC` alone picks universal — `(trade_key IS NULL) ASC` is the only term that can produce the asserted answer.

**Evidence it now bites:** with the clause removed, `a_trade_specific_schema_wins_over_a_universal_one` **FAILED**. Restored: 25/25 green.

## 2. Stale doc comment on `resolve_active_schema`

It still described the pre-#306 rule: *"trade must match exactly — a NULL-trade schema (e.g. `report`) resolves ONLY for a None-template session, so it stays illegal on a landscape session, matching today."* That is the exact behavior #306 reversed. Rewritten to describe what the code does now, including the full ranking.

## 3. Non-deterministic ordering

The query ordered by `(trade_key IS NULL) ASC, updated_at DESC` with no final tiebreak, so two rows of equal rank came back in whatever order the scan produced — which document the operator got was a property of SQLite's plan rather than of the data.

This is not a synthetic tie. Every seeded built-in carries the fixed `updated_at = 0`, so a device that has duplicated a built-in and not yet edited the copy sits on exactly two tied rows.

**Changed:** `, id ASC` is now the last ordering term. The app-side mirror `DocumentSchemaModel.buildable(from:tradeKey:)` gets the same term — it is documented as a mirror of the resolver, and the two disagreeing on the same data is the drift that produced the original field bug, so making core deterministic while leaving the mirror arbitrary would have reopened it. Its comparator is now written out term-for-term against the SQL.

**New test (core):** `resolve_breaks_an_exact_tie_deterministically_by_id` — two universal rows of the same kind saved on the same clock tick, inserted in *descending* id order, asserted to resolve to the lower id across three templates; plus the same one rank up, between two trade-specific rows.

**Evidence it bites:** removing `id ASC` → `FAILED: left: "rfp-z", right: "rfp-a"`.

**New test (app):** `testAnExactTieIsBrokenByIdSoThePickerAgreesWithCore`, asserted over both input orders.

**Evidence it bites:** removing the id term from the comparator → `FAILED: ("Optional("zzz")") is not equal to ("Optional("aaa")")`.

## 4. Dead `SchemaEditor.tradeKey`

Confirmed zero consumers: within `SchemaEditor` the name appeared only at its declaration, its init parameter, and the assignment — never read. It lost its last reader when #306 removed `copy.tradeKey = tradeKey`. Deleted, along with the init parameter and the argument at the call site. (`DocumentBuilderView`'s other uses of `model.trade.key` — stamping a brand-new document type, and `listDocumentSchemas` — are live and untouched.)

## 5. The un-renamed duplicate had nothing pinning it

#306 changed this path: it dropped #283's trade stamp so a copy inherits the source's scope. The change is invisible when the operator renames, because renaming re-derives the kind and the copy is obviously a new type either way. It is the operator who taps SAVE on a built-in and changes only its **sections** — "I want the standard Report, but with my paragraph" — who is exposed to whether the trade is inherited or stamped, and to whether the id is really cleared.

The shaping logic was `private func saveShape` inside a `private struct` view, which `@testable import` cannot reach. It moved onto `DocumentSchemaModel` as `saveShape(of:editedFrom:)` (with `slug` alongside it), **no behavior change** — the view now calls through to it.

**New file** `apps/ios/Tests/SchemaDuplicateTests.swift`, 6 tests. Each mutation below was applied to `saveShape` and the suite confirmed red:

| Mutation | Result |
|---|---|
| Re-introduce #283's `copy.tradeKey = "landscape"` stamp | **3 failures** — universal Report copy came back scoped to landscape; property-scoped copy came back landscape |
| Drop `copy.id = ""` | **3 failures** — the copy would upsert over the shipped built-in |
| Always re-derive the kind (drop the `label != original.label` guard) | **1 failure** — `move_out` became `move_out_report`, a kind core has no items for |
| Drop the `guard draft.isBuiltin` passthrough | **2 failures** — editing your own type forked a new copy and un-froze its kind |

## Gates

All three CI jobs run clean locally:

- `nix develop -c cargo test --workspace` — 23 suites, 0 failures
- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — clean
- `./apps/ios/check-bindings.sh` — `ffi.swift is up to date`
- `xcodebuild ... test` on iPhone 17 simulator — **166 tests, 0 failures**

## Nothing contradicted the review

Every one of the five findings reproduced as described.
