### PR TITLE
core: a walk summary is the record of the job, not of the recording

### DIFF
--- a/crates/evals/fixtures/README.md
+++ b/crates/evals/fixtures/README.md
@@ -4,9 +4,9 @@ Each scenario is a paired `<id>.txt` (transcript) + `<id>.json` (typed ground
 truth) sharing a stem. The loader (`corpus::load_corpus`) errors loudly on any
 orphan file, so the two halves cannot silently drift.
 
-Four seeds ship today: `punch_list_short`, `deck_walk_contacts`,
-`rambling_long_walk`, `empty_session`. Grow the corpus to **8–12 total**
-fixtures following these rules:
+Five seeds ship today: `punch_list_short`, `deck_walk_contacts`,
+`rambling_long_walk`, `empty_session`, `quiet_mulch_walk`. Grow the corpus to
+**8–12 total** fixtures following these rules:
 
 - Each scenario's ground truth must be traceable to a literal span in its
   transcript — no inferred items.
@@ -29,3 +29,17 @@ fixtures following these rules:
   same fixture — `load_corpus` enforces this and errors loudly if violated,
   since an overlapping distractor would wrongly count a correct extraction as
   an R6 false positive.
+
+## What a scenario measures
+
+Two independent axes, both reported per scenario by the runner:
+
+- **extraction** — F0.5 over the board, plus the distractor false-positive
+  rate. Driven by the ground truth above.
+- **summary voice** (#298) — does the summary read as a record of the JOB?
+  `summary::grade_summary` is lexical and deterministic: it flags a preamble
+  that names the session ("Field session to discuss…") and any narration of
+  the recording ("only the word 'mulch' was clearly audible"), and reports the
+  word count. It needs no ground truth, so it applies to every scenario for
+  free — but a quiet fixture like `quiet_mulch_walk` is where it bites, since
+  a walk with little in it is where a model reaches for prose about the audio.

--- a/crates/evals/fixtures/quiet_mulch_walk.json
+++ b/crates/evals/fixtures/quiet_mulch_walk.json
@@ -1,0 +1,12 @@
+{
+  "description": "A quiet walk (#298, from a device): wind and filler, one word audible. Nothing about scope, timing, or price was said, so nothing is an item — R6 says the single word 'mulch' must not be promoted to a line on a client's paperwork. The honest outcome is an empty board and a short summary that names the work and stops, not a paragraph explaining what the recording missed.",
+  "tags": ["quiet", "edge", "summary-voice", "landscaping"],
+  "items": [],
+  "contacts": [],
+  "distractors": [
+    "mulch",
+    "yeah that right okay",
+    "uh mm-hm"
+  ],
+  "expects_summary": true
+}

--- a/crates/evals/fixtures/quiet_mulch_walk.txt
+++ b/crates/evals/fixtures/quiet_mulch_walk.txt
@@ -1,0 +1,1 @@
+Okay so — [wind] — yeah. Uh. Mulch. Mm-hm. Yeah, that. Right, okay.

--- a/crates/evals/src/grade.rs
+++ b/crates/evals/src/grade.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::corpus::GroundTruth;
 use crate::normalize::{dice, token_set};
+use crate::summary::{grade_summary, SummaryScore};
 
 /// Dice threshold for "these two texts are the same item". 0.5 = at least half
 /// the combined token mass overlaps. Tuned once, fixed — moving it per-corpus
@@ -22,17 +23,23 @@ const BETA_SQ: f64 = 0.25;
 
 /// Pipeline output as plain data (built from store rows by `run.rs`).
 ///
-/// Plan 14 D3-14/WE-B: `summary_present` is the ONLY summary field the
-/// grader reads — no text/length pin — and there is no artifact read at
-/// all, so a longer narrative summary (D2-14: 2-4 sentences) plus a notes
-/// artifact (written to `kind="notes"`, never to item rows) cannot move
-/// the F0.5 score. `cargo test -p evals` (Task 4 gate) is the byte-identical
-/// pin for every corpus scenario.
+/// Plan 14 D3-14/WE-B: `summary_present` is the only summary field the
+/// EXTRACTION score reads, and there is no artifact read at all, so the
+/// summary text plus a notes artifact (written to `kind="notes"`, never to
+/// item rows) cannot move the F0.5 score. `cargo test -p evals` (Task 4 gate)
+/// is the byte-identical pin for every corpus scenario.
+///
+/// #298 adds `summary_text`, graded SEPARATELY by `summary::grade_summary`
+/// into `ScenarioScore::summary_voice`. It is reported alongside F0.5 and
+/// deliberately kept out of it: extraction quality and summary voice are
+/// different defects and averaging them would hide both.
 #[derive(Clone, Debug)]
 pub struct Observed {
     pub items: Vec<ObservedItem>,
     pub contacts: Vec<ObservedContact>,
     pub summary_present: bool,
+    /// The summary text as stored, `None` when the session has none.
+    pub summary_text: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -99,6 +106,10 @@ pub struct ScenarioScore {
     /// hits / distractor_count — the R6 over-extraction signal (lower better).
     pub distractor_fp_rate: f64,
     pub summary_ok: bool,
+    /// #298: does the summary read as a record of the JOB? Presence
+    /// (`summary_ok`) and voice are separate questions — the TestFlight
+    /// summaries were present and wrong.
+    pub summary_voice: SummaryScore,
 }
 
 fn ratio(num: usize, den: usize) -> f64 {
@@ -207,6 +218,7 @@ pub fn grade(truth: &GroundTruth, obs: &Observed) -> ScenarioScore {
         distractor_hits,
         distractor_fp_rate,
         summary_ok: obs.summary_present == truth.expects_summary,
+        summary_voice: grade_summary(obs.summary_text.as_deref().unwrap_or("")),
     }
 }
 
@@ -265,7 +277,7 @@ mod tests {
         let obs = Observed {
             items: vec![obs_item("todo", "order the lumber"), obs_item("safety", "railing is loose")],
             contacts: vec![],
-            summary_present: true,
+            summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         };
         let s = grade(&gt, &obs);
         assert_eq!(s.overall.true_positives, 2);
@@ -285,12 +297,12 @@ mod tests {
                 obs_item("todo", "order lumber"), obs_item("todo", "call inspector"),
                 obs_item("todo", "paint the fence"), obs_item("todo", "buy coffee"),
             ],
-            contacts: vec![], summary_present: true,
+            contacts: vec![], summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         // under-extraction: got one, missed one -> P=1.0, R=0.5
         let under = grade(&gt, &Observed {
             items: vec![obs_item("todo", "order lumber")],
-            contacts: vec![], summary_present: true,
+            contacts: vec![], summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         // R6: F0.5 weights precision, so the under-extractor scores HIGHER
         assert!(under.f_half > over.f_half, "under {} !> over {}", under.f_half, over.f_half);
@@ -302,7 +314,7 @@ mod tests {
         // right text, wrong kind (todo) -> FP + FN, and a confusion entry
         let s = grade(&gt, &Observed {
             items: vec![obs_item("todo", "loose railing")],
-            contacts: vec![], summary_present: true,
+            contacts: vec![], summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         assert_eq!(s.overall.true_positives, 0);
         assert_eq!(s.overall.false_positives, 1);
@@ -317,7 +329,7 @@ mod tests {
         // model wrongly turned a distractor into an item
         let s = grade(&gt, &Observed {
             items: vec![obs_item("todo", "order lumber"), obs_item("todo", "grab lunch sometime")],
-            contacts: vec![], summary_present: true,
+            contacts: vec![], summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         assert_eq!(s.distractor_count, 2);
         assert_eq!(s.distractor_hits, 1);
@@ -340,7 +352,7 @@ mod tests {
                 // Hank present, trade unknown — acceptable since expected trade is None
                 ObservedContact { name: "Hank".into(), trade: None },
             ],
-            summary_present: true,
+            summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         assert_eq!(s.contacts_expected, 2);
         assert_eq!(s.contacts_matched, 2);
@@ -356,7 +368,7 @@ mod tests {
         let s = grade(&gt, &Observed {
             items: vec![],
             contacts: vec![ObservedContact { name: "Dev".into(), trade: Some("plumber".into()) }],
-            summary_present: true,
+            summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         assert_eq!(s.contacts_matched, 0);
     }
@@ -364,9 +376,9 @@ mod tests {
     #[test]
     fn summary_presence_is_scored_against_expectation() {
         let gt = truth(vec![]);
-        let missing = grade(&gt, &Observed { items: vec![], contacts: vec![], summary_present: false });
+        let missing = grade(&gt, &Observed { items: vec![], contacts: vec![], summary_present: false, summary_text: None });
         assert!(!missing.summary_ok, "expected a summary, none produced");
-        let present = grade(&gt, &Observed { items: vec![], contacts: vec![], summary_present: true });
+        let present = grade(&gt, &Observed { items: vec![], contacts: vec![], summary_present: true, summary_text: Some("Deck rebuild, north side.".into()) });
         assert!(present.summary_ok);
     }
 
@@ -375,7 +387,7 @@ mod tests {
         let gt = truth(vec![item("todo", "order lumber"), item("safety", "loose railing")]);
         let s = grade(&gt, &Observed {
             items: vec![obs_item("todo", "order lumber")], // missed the safety item
-            contacts: vec![], summary_present: true,
+            contacts: vec![], summary_present: true, summary_text: Some("Deck rebuild, north side.".into()),
         });
         let todo = s.per_kind.iter().find(|k| k.kind == "todo").unwrap();
         assert!((todo.recall - 1.0).abs() < 1e-9);

--- a/crates/evals/src/lib.rs
+++ b/crates/evals/src/lib.rs
@@ -8,3 +8,4 @@ pub mod grade;
 pub mod normalize;
 pub mod report;
 pub mod run;
+pub mod summary;

--- a/crates/evals/src/report.rs
+++ b/crates/evals/src/report.rs
@@ -39,6 +39,11 @@ pub struct ScenarioReport {
     pub id: String,
     pub score: ScenarioScore,
     pub cost: CostReport,
+    /// The summary text itself (#298). Scores say a voice regressed; only the
+    /// sentence says how — and a prompt change is argued with the two
+    /// summaries side by side, not with a number.
+    #[serde(default)]
+    pub summary: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -50,6 +55,12 @@ pub struct Aggregate {
     pub mean_distractor_fp_rate: f64,
     pub mean_contact_accuracy: f64,
     pub summaries_ok: usize,
+    /// #298: summaries that read as a record of the job — no preamble, no
+    /// narration of the recording.
+    pub summary_voice_ok: usize,
+    /// Mean summary length in words. The verbosity half of #298; reported,
+    /// never a pass/fail threshold.
+    pub mean_summary_words: f64,
     pub total_cost_usd: f64,
 }
 
@@ -72,13 +83,17 @@ impl SuiteReport {
         let mean_distractor_fp_rate = scenarios.iter().map(|s| s.score.distractor_fp_rate).sum::<f64>() / n;
         let mean_contact_accuracy = scenarios.iter().map(|s| s.score.contact_accuracy).sum::<f64>() / n;
         let summaries_ok = scenarios.iter().filter(|s| s.score.summary_ok).count();
+        let summary_voice_ok = scenarios.iter().filter(|s| s.score.summary_voice.ok).count();
+        let mean_summary_words =
+            scenarios.iter().map(|s| s.score.summary_voice.words as f64).sum::<f64>() / n;
         let total_cost_usd = scenarios.iter().map(|s| s.cost.est_usd).sum();
         SuiteReport {
             model: model.into(),
             aggregate: Aggregate {
                 scenarios: scenarios.len(),
                 mean_f_half, micro_precision, micro_recall,
-                mean_distractor_fp_rate, mean_contact_accuracy, summaries_ok, total_cost_usd,
+                mean_distractor_fp_rate, mean_contact_accuracy, summaries_ok,
+                summary_voice_ok, mean_summary_words, total_cost_usd,
             },
             scenarios,
         }
@@ -89,18 +104,35 @@ impl SuiteReport {
 pub fn render_table(suite: &SuiteReport) -> String {
     let mut out = String::new();
     out.push_str(&format!("model: {}\n", suite.model));
-    out.push_str(&format!("{:<24} {:>6} {:>6} {:>6} {:>7} {:>8} {:>8}\n",
-        "scenario", "F0.5", "P", "R", "distFP", "contact", "usd"));
+    out.push_str(&format!("{:<24} {:>6} {:>6} {:>6} {:>7} {:>8} {:>6} {:>5} {:>8}\n",
+        "scenario", "F0.5", "P", "R", "distFP", "contact", "voice", "words", "usd"));
     for s in &suite.scenarios {
-        out.push_str(&format!("{:<24} {:>6.2} {:>6.2} {:>6.2} {:>7.2} {:>8.2} {:>8.4}\n",
+        let v = &s.score.summary_voice;
+        out.push_str(&format!("{:<24} {:>6.2} {:>6.2} {:>6.2} {:>7.2} {:>8.2} {:>6} {:>5} {:>8.4}\n",
             s.id, s.score.f_half, s.score.overall.precision, s.score.overall.recall,
-            s.score.distractor_fp_rate, s.score.contact_accuracy, s.cost.est_usd));
+            s.score.distractor_fp_rate, s.score.contact_accuracy,
+            if v.ok { "ok" } else { "BAD" }, v.words, s.cost.est_usd));
     }
     let a = &suite.aggregate;
-    out.push_str(&format!("{:<24} {:>6.2} {:>6.2} {:>6.2} {:>7.2} {:>8.2} {:>8.4}\n",
+    out.push_str(&format!("{:<24} {:>6.2} {:>6.2} {:>6.2} {:>7.2} {:>8.2} {:>6} {:>5.0} {:>8.4}\n",
         "TOTAL (mean)", a.mean_f_half, a.micro_precision, a.micro_recall,
-        a.mean_distractor_fp_rate, a.mean_contact_accuracy, a.total_cost_usd));
+        a.mean_distractor_fp_rate, a.mean_contact_accuracy,
+        format!("{}/{}", a.summary_voice_ok, a.scenarios), a.mean_summary_words, a.total_cost_usd));
     out.push_str(&format!("summaries ok: {}/{}\n", a.summaries_ok, a.scenarios));
+
+    // #298: the summaries themselves, with whatever the voice grader caught.
+    // A voice regression is argued from the sentence, not from the column.
+    out.push_str("\nsummaries:\n");
+    for s in &suite.scenarios {
+        let v = &s.score.summary_voice;
+        out.push_str(&format!("  {}: {}\n", s.id, s.summary.as_deref().unwrap_or("(none)")));
+        if let Some(p) = &v.preamble {
+            out.push_str(&format!("    ! preamble: \"{p}…\"\n"));
+        }
+        if !v.narration.is_empty() {
+            out.push_str(&format!("    ! narrates the recording: {}\n", v.narration.join(", ")));
+        }
+    }
     out
 }
 
@@ -108,6 +140,9 @@ pub fn render_table(suite: &SuiteReport) -> String {
 mod tests {
     use super::*;
     use crate::grade::{PrecisionRecall, ScenarioScore};
+    use crate::summary::grade_summary;
+
+    const GOOD_SUMMARY: &str = "Unit twelve punch list: faucet cartridge, dead outlet, sprung hinge.";
 
     fn score(f_half: f64, distractor_fp: f64) -> ScenarioScore {
         ScenarioScore {
@@ -116,14 +151,24 @@ mod tests {
             contacts_expected: 0, contacts_matched: 0, contact_accuracy: 1.0,
             distractor_count: 2, distractor_hits: (distractor_fp * 2.0) as usize, distractor_fp_rate: distractor_fp,
             summary_ok: true,
+            summary_voice: grade_summary(GOOD_SUMMARY),
+        }
+    }
+
+    fn scenario(id: &str, score: ScenarioScore) -> ScenarioReport {
+        ScenarioReport {
+            id: id.into(),
+            score,
+            cost: CostReport::default(),
+            summary: Some(GOOD_SUMMARY.into()),
         }
     }
 
     #[test]
     fn suite_aggregate_means_across_scenarios() {
         let suite = SuiteReport::assemble("claude-haiku-4-5", vec![
-            ScenarioReport { id: "a".into(), score: score(1.0, 0.0), cost: CostReport::default() },
-            ScenarioReport { id: "b".into(), score: score(0.0, 1.0), cost: CostReport::default() },
+            scenario("a", score(1.0, 0.0)),
+            scenario("b", score(0.0, 1.0)),
         ]);
         assert!((suite.aggregate.mean_f_half - 0.5).abs() < 1e-9);
         assert!((suite.aggregate.mean_distractor_fp_rate - 0.5).abs() < 1e-9);
@@ -132,7 +177,7 @@ mod tests {
     #[test]
     fn report_serializes_to_stable_json() {
         let suite = SuiteReport::assemble("m", vec![
-            ScenarioReport { id: "a".into(), score: score(1.0, 0.0), cost: CostReport::default() },
+            scenario("a", score(1.0, 0.0)),
         ]);
         let json = serde_json::to_string_pretty(&suite).unwrap();
         // round-trips and contains the headline scalar
@@ -152,11 +197,36 @@ mod tests {
     #[test]
     fn table_renders_one_row_per_scenario_and_a_total() {
         let suite = SuiteReport::assemble("m", vec![
-            ScenarioReport { id: "deck".into(), score: score(0.8, 0.0), cost: CostReport::default() },
+            scenario("deck", score(0.8, 0.0)),
         ]);
         let table = render_table(&suite);
         assert!(table.contains("deck"));
         assert!(table.contains("F0.5"));
         assert!(table.contains("TOTAL") || table.contains("mean"));
+    }
+
+    /// #298: a summary that narrates the recording is visible in the report —
+    /// counted in the aggregate, flagged in the table, and quoted in full.
+    #[test]
+    fn a_summary_that_narrates_the_recording_is_visible_in_the_report() {
+        let bad = "Field session to discuss mulch work. Only the word \"mulch\" was clearly \
+                   audible in the recording, with no additional context provided.";
+        let mut bad_score = score(1.0, 0.0);
+        bad_score.summary_voice = grade_summary(bad);
+        let suite = SuiteReport::assemble("m", vec![
+            scenario("good", score(1.0, 0.0)),
+            ScenarioReport {
+                id: "mulch".into(),
+                score: bad_score,
+                cost: CostReport::default(),
+                summary: Some(bad.into()),
+            },
+        ]);
+        assert_eq!(suite.aggregate.summary_voice_ok, 1, "one of two reads as a record of the job");
+        assert!(suite.aggregate.mean_summary_words > 0.0);
+        let table = render_table(&suite);
+        assert!(table.contains("BAD"), "the offending row is flagged");
+        assert!(table.contains("narrates the recording"), "and named");
+        assert!(table.contains(bad), "and quoted verbatim for the before/after read");
     }
 }

--- a/crates/evals/src/run.rs
+++ b/crates/evals/src/run.rs
@@ -51,8 +51,9 @@ pub async fn run_scenario(
     let _ = processor.process(&sid).await;
 
     let (observed, cost) = observe(&store, &sid, model)?;
+    let summary = observed.summary_text.clone();
     let score: ScenarioScore = grade(&scenario.truth, &observed);
-    Ok(ScenarioReport { id: scenario.id.clone(), score, cost })
+    Ok(ScenarioReport { id: scenario.id.clone(), score, cost, summary })
 }
 
 /// Drives the LIVE path (`LiveExtractor`) over a scenario, hermetically, with a
@@ -130,15 +131,17 @@ pub fn observe(
         .into_iter()
         .map(|c| ObservedContact { name: c.name, trade: c.trade })
         .collect();
-    let summary_present = guard
+    // The placeholder a silent walk short-circuits to is not a summary the
+    // model wrote, so it counts as neither present nor gradeable voice (#298).
+    let stored_summary = guard
         .get_session(session_id)?
         .summary
-        .map(|s| !s.trim().is_empty() && s != "(empty session)")
-        .unwrap_or(false);
+        .filter(|s| !s.trim().is_empty() && s != "(empty session)");
+    let summary_present = stored_summary.is_some();
     let (input_tokens, output_tokens) = guard
         .list_llm_usage_for_session(session_id)?
         .iter()
         .fold((0u64, 0u64), |(i, o), r| (i + r.input_tokens, o + r.output_tokens));
     let cost = CostReport::estimate(model, input_tokens, output_tokens);
-    Ok((Observed { items, contacts, summary_present }, cost))
+    Ok((Observed { items, contacts, summary_present, summary_text: stored_summary }, cost))
 }

--- a/crates/evals/src/summary.rs
+++ b/crates/evals/src/summary.rs
@@ -1,0 +1,203 @@
+//! Deterministic summary-voice grader (#298).
+//!
+//! The extraction grader in `grade.rs` reads exactly one thing about the
+//! summary — whether there IS one. So the failure Isaac hit on TestFlight was
+//! invisible to the suite: a summary can narrate the recording, apologise for
+//! the audio, and open every walk with the same preamble while scoring a
+//! perfect `summaries ok: 4/4`.
+//!
+//! This grader scores the summary TEXT for the two defects named in #298,
+//! both of which are lexical and therefore deterministic — no judge model, no
+//! network, comparable across prompt variants exactly like F0.5:
+//!
+//!   1. **preamble** — the summary opens by naming the session ("Field session
+//!      to discuss mulch work"). The operator knows it was a field session;
+//!      that is what the app is.
+//!   2. **narration** — the summary is about the RECORDING rather than the job
+//!      ("Only the word 'mulch' was clearly audible in the recording"). This is
+//!      R6-adjacent: the model fills a gap with prose instead of declining to
+//!      fill it.
+//!
+//! Length is measured and reported but deliberately does NOT gate `ok`: a
+//! whole-house walk earns more words than a one-bed mulch job, and a threshold
+//! picked to split them would be a number pretending to be a rule. The word
+//! count moves visibly in the report; the two boolean defects are the pins.
+
+use serde::{Deserialize, Serialize};
+
+/// Openers that name the session instead of the job. Matched at the START of
+/// the summary only — "we walked the site" mid-sentence is ordinary English,
+/// while leading with it spends a third of a board row saying nothing.
+const PREAMBLES: [&str; 12] = [
+    "field session",
+    "a field session",
+    "field walk",
+    "a field walk",
+    "field-work session",
+    "a field-work session",
+    "a brief field",
+    "site visit",
+    "a site visit",
+    "session recorded",
+    "the operator",
+    "the user",
+];
+
+/// Vocabulary of the recording itself. Any occurrence, anywhere, is the
+/// defect: these words describe the medium, and the summary is a record of the
+/// job. Kept to nouns/adjectives that cannot plausibly describe field work —
+/// "recorded" is excluded, since a client can genuinely authorise a recording
+/// of a meeting and that IS a job fact.
+const NARRATION_TERMS: [&str; 10] = [
+    "recording",
+    "transcript",
+    "audio",
+    "audible",
+    "inaudible",
+    "discernible",
+    "ambient noise",
+    "speech",
+    "microphone",
+    "no additional context",
+];
+
+/// One summary's voice score. `ok` is the headline boolean: this summary reads
+/// as a record of the job.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct SummaryScore {
+    /// The preamble the summary opened with, if any.
+    pub preamble: Option<String>,
+    /// Every recording-narration term found, in `NARRATION_TERMS` order.
+    pub narration: Vec<String>,
+    /// Sentence count (terminator runs), min 1 for any non-empty text.
+    pub sentences: usize,
+    /// Whitespace-separated word count.
+    pub words: usize,
+    /// No preamble AND no narration. Length is reported, never gated.
+    pub ok: bool,
+}
+
+/// Grades one summary string. Empty/absent text is not `ok` — there is nothing
+/// for the operator to read.
+pub fn grade_summary(summary: &str) -> SummaryScore {
+    let text = summary.trim();
+    let lower = text.to_lowercase();
+
+    // Longest match first: "a field session" must win over "field session" so
+    // the reported preamble is the phrase actually used.
+    let mut candidates: Vec<&str> = PREAMBLES.to_vec();
+    candidates.sort_by_key(|p| std::cmp::Reverse(p.len()));
+    let preamble = candidates
+        .into_iter()
+        .find(|p| lower.starts_with(p))
+        .map(str::to_string);
+
+    let narration: Vec<String> = NARRATION_TERMS
+        .iter()
+        .filter(|t| lower.contains(**t))
+        .map(|t| (*t).to_string())
+        .collect();
+
+    let words = text.split_whitespace().count();
+    let sentences = count_sentences(text);
+    let ok = !text.is_empty() && preamble.is_none() && narration.is_empty();
+    SummaryScore { preamble, narration, sentences, words, ok }
+}
+
+/// Counts sentences as runs of terminators, so "3 sq. ft." style abbreviations
+/// inflate the count a little but a trailing "." never adds a phantom one. A
+/// non-empty summary with no terminator at all is one sentence.
+fn count_sentences(text: &str) -> usize {
+    if text.is_empty() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut in_run = false;
+    for c in text.chars() {
+        if matches!(c, '.' | '!' | '?') {
+            if !in_run {
+                count += 1;
+                in_run = true;
+            }
+        } else if !c.is_whitespace() {
+            in_run = false;
+        }
+    }
+    count.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim from a device, quoted in #298. Both must fail — if they pass,
+    /// this grader is measuring nothing.
+    const DEVICE_MULCH: &str = "Field session to discuss mulch work. Only the word \"mulch\" was \
+                                clearly audible in the recording, with no additional context \
+                                provided about scope, timing, or constraints.";
+    const DEVICE_SILENT: &str = "No actionable session content was captured. The transcript \
+                                 contained only ambient noise with no discernible speech.";
+
+    #[test]
+    fn the_device_summaries_from_the_issue_fail() {
+        let mulch = grade_summary(DEVICE_MULCH);
+        assert!(!mulch.ok);
+        assert_eq!(mulch.preamble.as_deref(), Some("field session"));
+        assert!(mulch.narration.contains(&"audible".to_string()));
+        assert!(mulch.narration.contains(&"recording".to_string()));
+
+        let silent = grade_summary(DEVICE_SILENT);
+        assert!(!silent.ok);
+        assert!(silent.narration.contains(&"transcript".to_string()));
+        assert!(silent.narration.contains(&"ambient noise".to_string()));
+    }
+
+    #[test]
+    fn a_record_of_the_job_passes() {
+        for s in [
+            "North wall: water damage below the window, about 3 sq ft.",
+            "Mulch and compost, three beds in the front yard; Juan starts Thursday.",
+            "Unit twelve punch list: faucet cartridge, dead bedroom outlet, sprung closet hinge.",
+        ] {
+            let score = grade_summary(s);
+            assert!(score.ok, "{s} should read as a record of the job: {score:?}");
+        }
+    }
+
+    /// The honest short answer #298 asks for on a quiet walk.
+    #[test]
+    fn a_short_true_line_passes_and_is_short() {
+        let score = grade_summary("Mulch work discussed.");
+        assert!(score.ok);
+        assert_eq!(score.sentences, 1);
+        assert_eq!(score.words, 3);
+    }
+
+    #[test]
+    fn an_empty_summary_is_not_ok() {
+        let score = grade_summary("   ");
+        assert!(!score.ok);
+        assert_eq!(score.words, 0);
+        assert_eq!(score.sentences, 0);
+    }
+
+    #[test]
+    fn the_preamble_is_only_a_defect_when_it_leads() {
+        // Same words, mid-sentence: ordinary English, not a board-row tax.
+        assert!(grade_summary("Roof tear-off scheduled; site visit set for Tuesday.").ok);
+        assert!(!grade_summary("Site visit to the Alder Ct roof.").ok);
+    }
+
+    #[test]
+    fn the_longest_matching_preamble_is_the_one_reported() {
+        let score = grade_summary("A field session to procure materials.");
+        assert_eq!(score.preamble.as_deref(), Some("a field session"));
+    }
+
+    #[test]
+    fn sentence_and_word_counts_measure_verbosity() {
+        let score = grade_summary("First thing. Second thing. Third thing.");
+        assert_eq!(score.sentences, 3);
+        assert_eq!(score.words, 6);
+    }
+}

--- a/crates/evals/tests/summary_voice.rs
+++ b/crates/evals/tests/summary_voice.rs
@@ -1,0 +1,88 @@
+//! #298 — the summary-voice eval, hermetic. Mirrors `document_fill_quality.rs`:
+//! drives the REAL pipeline over a real corpus scenario with a `MockProvider`,
+//! then reads the graded result. Under a mock the summary text is whatever the
+//! script emits, so this is not a measurement of the model — it is the pin that
+//! the defect is VISIBLE END TO END. Before #298 it could not have been: the
+//! suite read `summary_present` and nothing else, so the summaries Isaac hit on
+//! TestFlight scored `summaries ok: 4/4`.
+//!
+//! Movement on real output comes from the gated runner
+//! (`cargo run -p evals --example eval`), which now prints each summary and its
+//! voice verdict.
+
+use std::sync::Arc;
+
+use evals::corpus::{load_corpus, Scenario};
+use evals::run::run_scenario;
+use harness::{CompletionResponse, ContentBlock, MockProvider, StopReason, Usage};
+
+/// Verbatim from a device, quoted in #298.
+const DEVICE_SUMMARY: &str = "Field session to discuss mulch work. Only the word \"mulch\" was \
+                              clearly audible in the recording, with no additional context \
+                              provided about scope, timing, or constraints.";
+
+/// What the same walk should read like: the job, and then stop.
+const RECORD_OF_THE_JOB: &str = "Mulch work discussed.";
+
+fn tool_use(name: &str, input: serde_json::Value) -> CompletionResponse {
+    CompletionResponse {
+        content: vec![ContentBlock::ToolUse { id: "tu".into(), name: name.into(), input }],
+        stop_reason: StopReason::ToolUse,
+        usage: Usage { input_tokens: 30, output_tokens: 8, ..Default::default() },
+    }
+}
+
+fn end_turn(t: &str) -> CompletionResponse {
+    CompletionResponse {
+        content: vec![ContentBlock::Text { text: t.into() }],
+        stop_reason: StopReason::EndTurn,
+        usage: Usage { input_tokens: 10, output_tokens: 2, ..Default::default() },
+    }
+}
+
+/// A script that extracts nothing and writes `summary` — the quiet-walk shape
+/// the issue is about.
+fn quiet_walk_script(summary: &str) -> Vec<CompletionResponse> {
+    vec![
+        end_turn("nothing to capture"),
+        tool_use("write_notes", serde_json::json!({ "summary": summary })),
+    ]
+}
+
+fn empty_scenario() -> Scenario {
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/fixtures");
+    load_corpus(dir)
+        .unwrap()
+        .into_iter()
+        .find(|s| s.id == "empty_session")
+        .expect("empty_session scenario in corpus")
+}
+
+#[tokio::test]
+async fn the_device_summary_is_caught_end_to_end() {
+    let scenario = empty_scenario();
+    let provider = Arc::new(MockProvider::new(quiet_walk_script(DEVICE_SUMMARY)));
+    let report = run_scenario(&scenario, provider, "claude-haiku-4-5").await.unwrap();
+
+    let voice = &report.score.summary_voice;
+    assert!(!voice.ok, "the summary Isaac hit must not score as ok");
+    assert_eq!(voice.preamble.as_deref(), Some("field session"));
+    assert!(voice.narration.contains(&"recording".to_string()));
+    assert_eq!(report.summary.as_deref(), Some(DEVICE_SUMMARY), "reported verbatim");
+
+    // And the extraction score is untouched by it — the two defects are
+    // separately visible, which is the whole point of a second axis.
+    assert!(report.score.summary_ok, "a present summary is still present");
+}
+
+#[tokio::test]
+async fn a_record_of_the_job_passes_the_same_path() {
+    let scenario = empty_scenario();
+    let provider = Arc::new(MockProvider::new(quiet_walk_script(RECORD_OF_THE_JOB)));
+    let report = run_scenario(&scenario, provider, "claude-haiku-4-5").await.unwrap();
+
+    let voice = &report.score.summary_voice;
+    assert!(voice.ok, "a short true line is the good outcome: {voice:?}");
+    assert_eq!(voice.sentences, 1);
+    assert!(voice.words < 10, "and it is short: {} words", voice.words);
+}

--- a/crates/murmur-core/src/pipeline/prompts.rs
+++ b/crates/murmur-core/src/pipeline/prompts.rs
@@ -74,16 +74,62 @@ pub(crate) fn extraction_system_prompt(memory_prompt: &str) -> String {
     )
 }
 
+/// System prompt for the summary/notes pass. Named (not inline) so the voice
+/// rules are pinnable by a test — #298: the summariser was writing about the
+/// RECORDING ("only the word 'mulch' was clearly audible in the recording")
+/// instead of about the job, and opening every walk with the same "Field
+/// session to…" preamble. The operator knows they were there; the summary is
+/// the first line they read afterwards and the one their customer may read too.
+pub(crate) fn summary_system_prompt() -> String {
+    "You are writing the record of one field-work session for a tradesperson \
+     and, sometimes, their customer. Everything you write is about the JOB — \
+     the site, the work, what was found — and never about the recording.\n\
+     summary: ONE sentence, naming the site and the work. \"North wall: water \
+     damage below the window, about three square feet.\" \"Mulch and compost, \
+     three beds in the front yard.\"\n\
+     - No preamble. Never open with \"Field session\", \"Field walk\", \"Site \
+     visit\", \"A brief session\", \"The operator\", \"The user\", or any other \
+     phrase naming the session itself — start with the site or the work. The \
+     operator already knows it was a walk; that is what the app is.\n\
+     - Never mention the recording, the transcript, the audio, or what was \
+     audible, unclear, garbled, or missing from it. Do not explain your own \
+     difficulty, and never narrate the operator (\"the user then walked over \
+     to…\"). Write the record, not the session.\n\
+     - Say less when less was said. If one thing was heard, the whole summary \
+     is that one thing — \"Mulch work discussed.\" is a complete summary. A \
+     short true line beats a paragraph explaining what you could not hear.\n\
+     - If nothing about the job was said at all, the entire summary is exactly: \
+     Nothing captured.\n\
+     notes: comprehensive coordination detail, grouped into three buckets: \
+     scope_of_work (directives with client detail baked in — \"darker mulch \
+     than last year\"), constraints (budget, permits, deadline, site \
+     access/gate codes, client preferences), and conditions_and_issues (site \
+     findings affecting the work). At most 12 notes entries; prefer fewer, \
+     denser entries. Each entry records something that was said about the job — \
+     never a note about what the recording failed to capture. Capture only what \
+     was said; never invent a budget, deadline, or access detail — a missed \
+     note is cheaper than a fabricated constraint."
+        .into()
+}
+
 fn notes_tool_spec() -> ToolSpec {
     ToolSpec {
         name: WRITE_NOTES.into(),
-        description: "Record the session's narrative summary, spoken total (if any), and \
+        description: "Record the session's one-sentence summary, spoken total (if any), and \
                        comprehensive coordination notes."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
-                "summary": { "type": "string", "description": "2-4 plain sentences: what, why, when" },
+                "summary": {
+                    "type": "string",
+                    "description": "ONE sentence naming the site and the work — \"North wall: water \
+                                     damage below the window, about 3 sq ft\". No preamble (\"Field \
+                                     session…\", \"Site visit…\", \"The operator…\") and no mention of \
+                                     the recording, transcript, audio, or what was audible. Say less \
+                                     when less was said (\"Mulch work discussed.\"); exactly \"Nothing \
+                                     captured.\" when nothing about the job was."
+                },
                 "spoken_total_cents": {
                     "type": "integer",
                     "description": "The operator's stated target/grand total for the WHOLE job, in cents \
@@ -96,9 +142,10 @@ fn notes_tool_spec() -> ToolSpec {
                     "description": "At most 12 entries; prefer fewer, denser entries. Each entry is a \
                                      client/team coordination detail the terse board doesn't carry — the \
                                      full spoken context behind a decision, a constraint, or a site \
-                                     condition. Capture only what was said; never invent a budget, \
-                                     deadline, or access detail — a missed note is cheaper than a \
-                                     fabricated constraint.",
+                                     condition. Never an entry about the recording itself or about what \
+                                     it failed to capture. Capture only what was said; never invent a \
+                                     budget, deadline, or access detail — a missed note is cheaper than \
+                                     a fabricated constraint.",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -145,16 +192,7 @@ pub(crate) async fn summarize(
 ) -> Result<(Option<String>, Option<i64>, Vec<NotesEntry>, Usage), HarnessError> {
     let response = provider
         .complete(CompletionRequest {
-            system: "You are building a client/team coordination artifact from one transcribed \
-                     field-work session. Write a narrative summary (2-4 plain sentences: what, \
-                     why, when) AND comprehensive notes grouped into three buckets: \
-                     scope_of_work (directives with client detail baked in — \"darker mulch than \
-                     last year\"), constraints (budget, permits, deadline, site access/gate \
-                     codes, client preferences), and conditions_and_issues (site findings \
-                     affecting the work). At most 12 notes entries; prefer fewer, denser entries. \
-                     Capture only what was said; never invent a budget, deadline, or access \
-                     detail — a missed note is cheaper than a fabricated constraint."
-                .into(),
+            system: summary_system_prompt(),
             messages: vec![Message::user_text(transcript_excerpt)],
             tools: vec![notes_tool_spec()],
             max_tokens,
@@ -364,11 +402,47 @@ mod tests {
         assert_eq!(buckets, Vec::new(), "garbled notes -> [] not a hard failure");
     }
 
+    /// #298: the two rules the summary voice turns on, in BOTH places the
+    /// model reads them (system prompt and tool schema) — a rule that lives in
+    /// only one of the two is a rule the model can miss.
+    #[test]
+    fn the_summary_asks_for_the_job_not_the_recording() {
+        let spec = notes_tool_spec();
+        let summary_desc = spec.input_schema["properties"]["summary"]["description"]
+            .as_str()
+            .unwrap()
+            .to_lowercase();
+        let system = summary_system_prompt().to_lowercase();
+        for text in [&system, &summary_desc] {
+            assert!(text.contains("one sentence"), "one sentence, not 2-4");
+            assert!(text.contains("no preamble"), "no \"Field session…\" opener");
+            assert!(text.contains("field session"), "the banned opener is named");
+            assert!(text.contains("recording"), "the recording is named as off-limits");
+            assert!(text.contains("transcript"));
+            assert!(text.contains("audible"));
+            assert!(
+                text.contains("say less when less was said"),
+                "a quiet walk gets a short summary, not an apology"
+            );
+        }
+        assert!(
+            summary_system_prompt().contains("the entire summary is exactly: Nothing captured."),
+            "the silent-walk answer is pinned verbatim, so it can't drift into an apology"
+        );
+    }
+
+    /// The apologetic paragraph moved into the notes screen would be the same
+    /// defect one level down, so the notes bucket carries the rule too.
+    #[test]
+    fn notes_entries_are_about_the_job_not_the_recording() {
+        let spec = notes_tool_spec();
+        let notes_desc = spec.input_schema["properties"]["notes"]["description"].as_str().unwrap();
+        assert!(notes_desc.contains("Never an entry about the recording itself"));
+        assert!(summary_system_prompt().contains("never a note about what the recording failed"));
+    }
+
     #[test]
     fn notes_prompt_carries_r6_and_the_entry_cap() {
-        // The system prompt text is constructed inline in `summarize`; pin the
-        // static tool schema's cap/R6 language instead (schema description is
-        // sent to the model exactly like the system prompt).
         let spec = notes_tool_spec();
         let notes_desc = spec.input_schema["properties"]["notes"]["description"].as_str().unwrap();
         assert!(notes_desc.contains("At most 12 entries"), "entry-count cap");


### PR DESCRIPTION
Closes #298.

The summariser was writing about the recording. The prompt now asks for the job.

## The change

`summarize`'s system prompt was built inline; it is now `summary_system_prompt()` — named so a test can pin it — and it asks for **one sentence naming the site and the work**, with no preamble and no mention of the recording, transcript, audio, or what was audible. Then the R6-adjacent rule you flagged: **say less when less was said**. `Mulch work discussed.` is a complete summary, and a walk with nothing in it gets exactly `Nothing captured.` rather than a paragraph explaining the silence.

The same two rules go in the tool schema's `summary` description (a rule the model reads in only one of the two places is a rule it can miss) and in the `notes` description — otherwise the apologetic paragraph just moves one screen down, onto the notes view.

`AppModel.firstSentence` keeps its lead-in strip. Walks recorded before this ships still carry `Field session…` in the database, and the board has to read correctly for those too.

## The eval, which did not exist

`crates/evals` graded extraction only. On the summary it read exactly one thing — whether there **is** one — so the summaries Isaac hit scored a perfect `summaries ok: 4/4`. A prompt change with nothing measuring it is a guess, so this adds the missing axis before touching the prompt:

`summary::grade_summary` scores the summary **text** for the two defects #298 names — a preamble that names the session, and any narration of the recording. Both are lexical, so it stays deterministic and comparable across prompt variants exactly like F0.5: no judge model, no network, runs under `cargo test --workspace`. Its unit tests pin **the two verbatim device strings from the issue** as failures — if those ever pass, the grader is measuring nothing.

Length is measured and reported but deliberately does **not** gate `ok`: a whole-house walk earns more words than a one-bed mulch job, and a threshold splitting them would be a number pretending to be a rule. The word count moves visibly in the table instead.

The voice score is reported **alongside** F0.5, never folded into it — extraction quality and summary voice are different defects, and one number carrying both would hide both. The runner now also prints every summary verbatim under the table, because a voice regression is argued from the sentence, not from the column.

`quiet_mulch_walk` joins the corpus: wind, filler, one audible word. It is the shape of walk where a model reaches for prose about the audio — and R6 says the single word "mulch" must not become a line on a client's estimate either, so it ships as a distractor, not an item.

## Before / after — real API, `claude-haiku-4-5`, same five fixtures

**quiet_mulch_walk** (the case from the issue)

> **before:** Brief field session regarding mulch work. Minimal detail captured due to poor audio conditions and speaker hesitation.
>
> **after:** Mulch work discussed.

**empty_session**

> **before:** Field session with minimal substantive discussion. No clear scope, constraints, or site conditions were articulated.
>
> **after:** Nothing captured.

**deck_walk_contacts**

> **before:** Deck repair walkthrough with framer Dev identified soft joists on the north side (likely rot under the ledger) requiring replacement. Two 16-foot pressure-treated 2×10 joists will be ordered (~$90), the loose top railing must be re-anchored before use, and hidden fasteners will be used for decking instead of face screws.
>
> **after:** Back deck: soft joists on north side with probable rot under ledger; two pressure-treated two-by-tens to be replaced.

**punch_list_short**

> **before:** Punch list for unit twelve with three remaining defects: kitchen faucet cartridge replacement, dead bedroom outlet requiring electrician callback, and closet door hinge repair.
>
> **after:** Unit twelve: kitchen faucet dripping cartridge, dead bedroom outlet by window, closet door hinge sprung and won't latch.

**rambling_long_walk**

> **before:** Full-house walk-through inspection conducted without client present (recorded for later review). Inspector identified multiple items spanning electrical safety, water/HVAC systems, structural/roofing concerns, and exterior maintenance, ranging from urgent (exposed wiring, GFCI replacement) to deferred longer-term work (insulation, roof shingles). Water heater replacement decision made at approximately $1,200 including venting changes.
>
> **after:** Full house walk: upstairs GFCI outlet replacement, exposed wiring in basement junction box, thin attic insulation, old water heater replacement with tankless unit, exterior sillplate gap, deck stair handrail wobble, north slope roof shingles curling, downstairs toilet flapper and fill valve, furnace short cycling, hardwood hallway to remain.

## Eval results

`ANTHROPIC_API_KEY=… cargo run -p evals --example eval -- --model claude-haiku-4-5`, both runs on the same corpus with the same instrumentation (the "before" run is this branch's eval code with the prompt reverted, so the two tables are comparable):

**before**

```
scenario                   F0.5      P      R  distFP  contact  voice words      usd
deck_walk_contacts         0.88   0.86   1.00    0.00     1.00     ok    50   0.0117
empty_session              1.00   1.00   1.00    0.00     1.00    BAD    15   0.0040
punch_list_short           1.00   1.00   1.00    0.00     1.00     ok    24   0.0078
quiet_mulch_walk           1.00   1.00   1.00    0.00     1.00    BAD    17   0.0043
rambling_long_walk         0.92   0.92   0.92    0.00     1.00     ok    50   0.0165
TOTAL (mean)               0.96   0.91   0.95    0.00     1.00    3/5    31   0.0443
```

**after**

```
scenario                   F0.5      P      R  distFP  contact  voice words      usd
deck_walk_contacts         0.74   0.71   0.83    0.00     1.00     ok    18   0.0118
empty_session              1.00   1.00   1.00    0.00     1.00     ok     2   0.0040
punch_list_short           1.00   1.00   1.00    0.00     1.00     ok    18   0.0081
quiet_mulch_walk           1.00   1.00   1.00    0.00     1.00     ok     3   0.0043
rambling_long_walk         1.00   1.00   1.00    0.00     1.00     ok    48   0.0170
TOTAL (mean)               0.95   0.91   0.95    0.00     1.00    5/5    18   0.0452
```

Summary voice **3/5 → 5/5**; mean summary length **31 → 18 words**.

**The F0.5 row is noise, not a cost.** The extraction pass is a separate request with a byte-identical system prompt, and it runs *before* the summary call with no cache shared between them — there is no path from this change to the board. Measured, rather than asserted: `deck_walk_contacts` alone scored **0.59–0.88 across six runs of the old prompt** and **0.59–0.74 across four runs of the new one**. It is the noisiest fixture in the corpus under both.

## Gate

```
nix develop -c cargo test --workspace      # 0 failed (evals: 38 unit + 2 new e2e)
nix develop -c cargo clippy --workspace --all-targets -- -D warnings   # clean
```

Not touched: `services/proxy/`, `crates/murmur-core/src/store/schemas.rs`, and the iOS side.
