### PR TITLE
feat: the crew gets a paragraph of its own

### DIFF
--- a/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
+++ b/apps/ios/Sources/Engine/MurmurEngineFormatting.swift
@@ -191,6 +191,9 @@ extension MurmurEngine {
         case "work": return "WORK PERFORMED"
         case "assignment": return "ASSIGNMENT"
         case "site": return "SITE NOTES"
+        // The default would already uppercase this key correctly; it is here
+        // so the work order's three blocks read as one set in this switch.
+        case "instructions": return "INSTRUCTIONS"
         case "summary": return "SUMMARY"
         default: return key.replacingOccurrences(of: "_", with: " ").uppercased()
         }

--- a/crates/ffi/src/schemas.rs
+++ b/crates/ffi/src/schemas.rs
@@ -393,8 +393,8 @@ mod tests {
         // this short walk never mentioned.
         assert_eq!(
             payload.fields.iter().map(|f| f.key.as_str()).collect::<Vec<_>>(),
-            vec!["crew", "schedule", "access", "safety"],
-            "the assignment block, in schema order"
+            vec!["crew", "schedule", "access", "safety", "instructions"],
+            "the assignment, site and instructions blocks, in schema order"
         );
         assert_eq!(payload.fields[0].value.as_deref(), Some("Jose"));
         assert!(payload.fields[1].is_gap, "no schedule was stated — a gap, not an invented date");

--- a/crates/murmur-core/src/domain.rs
+++ b/crates/murmur-core/src/domain.rs
@@ -528,6 +528,31 @@ pub fn builtin_schemas() -> Vec<DocumentSchema> {
                          chemicals. Only what was said.",
                     ),
                 ]),
+                // The crew's paragraph, and the reason this section exists:
+                // every other document type had prose and this one had none,
+                // so a walk that named no crew and no gate code rendered a
+                // work order as a bare checklist (Isaac's WO-0001,
+                // 2026-08-12). Worse, the sequencing he DID state — "compost
+                // and mulch after weeding is complete" — reached the client
+                // in the estimate's scope paragraph and reached the crew only
+                // as a grey sub-line on one row. The reader who has to act on
+                // an ordering was the one getting it as a fragment.
+                //
+                // Deliberately NOT the estimate's scope paragraph reworded.
+                // That one sells; this one instructs, and the difference is
+                // the whole point of keying prose to its reader.
+                filled("instructions", "Instructions", vec![walk_field(
+                    "instructions", "long_text", "Instructions",
+                    "The crew's only paragraph: 2-4 imperative sentences telling the people \
+                     doing this job how to run it. WRITE THIS whenever the operator said \
+                     anything about how the work goes — an order or a prerequisite (\"strip \
+                     the old bark before laying\"), who takes which part, a method or material \
+                     they specified, or what finished looks like. Naming a task while \
+                     sequencing it is correct and expected; listing the tasks back is not, \
+                     because the crew is holding that list already. Leave it blank only when \
+                     the walk said nothing at all about how — an invented order of operations \
+                     is worse than none. No prices, no client-facing framing.",
+                )]),
             ],
         ),
         // CONDITION REPORT — evidence of a property's state at a moment,

--- a/crates/murmur-core/src/pipeline/document.rs
+++ b/crates/murmur-core/src/pipeline/document.rs
@@ -2504,11 +2504,16 @@ mod tests {
         let outcome = b.build(&sid, "work_order").await.unwrap();
         let v = decoded_document(&store, &outcome.document_artifact_id);
 
-        // The four fields a crew standing at the gate actually needs, in
-        // schema order — two written, two honestly blank.
+        // The five fields a crew standing at the gate actually needs, in
+        // schema order — two written, three honestly blank.
         let keys: Vec<&str> =
             v["fields"].as_array().unwrap().iter().map(|f| f["key"].as_str().unwrap()).collect();
-        assert_eq!(keys, vec!["crew", "schedule", "access", "safety"]);
+        assert_eq!(keys, vec!["crew", "schedule", "access", "safety", "instructions"]);
+        assert_eq!(
+            v["fields"][4]["is_gap"], true,
+            "the crew's paragraph is a gap when the walk said nothing about how — \
+             an invented order of operations is worse than none"
+        );
         assert_eq!(v["fields"][0]["value"], "Jose, Michael");
         assert_eq!(v["fields"][0]["label"], "Assigned to");
         assert_eq!(v["fields"][1]["is_gap"], true, "no date was said — never invented");

--- a/crates/murmur-core/tests/document_smoke.rs
+++ b/crates/murmur-core/tests/document_smoke.rs
@@ -273,16 +273,55 @@ async fn real_walk_becomes_a_work_order() {
     // Structure: the fields the schema authored, in order, all present.
     let keys: Vec<&str> =
         doc["fields"].as_array().unwrap().iter().map(|f| f["key"].as_str().unwrap()).collect();
-    assert_eq!(keys, vec!["crew", "schedule", "access", "safety"]);
+    assert_eq!(keys, vec!["crew", "schedule", "access", "safety", "instructions"]);
 
     // A work order NEVER carries money, whatever the model returns.
     for line in doc["lines"].as_array().unwrap() {
         assert!(line["amount_cents"].is_null(), "money on a work order: {line}");
     }
 
+    // The crew's paragraph. This walk states an ordering out loud ("strip the
+    // old bark before laying"), so on THIS transcript the block must be
+    // written rather than a gap — and it must add to the list rather than
+    // repeat it, which is the failure mode #320 hit on every other kind.
+    let instructions = doc["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["key"] == "instructions")
+        .expect("the instructions field");
+    let text = instructions["value"].as_str().unwrap_or_default();
+    assert!(!text.is_empty(), "an ordering was stated and the crew was not told it");
+    assert!(!text.contains('$'), "money reached a crew sheet through the prose: {text:?}");
+    // Naming ONE task while sequencing it is the point ("strip old bark
+    // before laying mulch" contains the line "Strip old bark", and should).
+    // Naming most of them means the paragraph became the list again.
+    let restated = doc["lines"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|line| text.contains(line["title"].as_str().unwrap()))
+        .count();
+    assert!(
+        restated <= 1,
+        "the instructions restate {restated} of the lines the crew is already holding: {text:?}"
+    );
+
     // Line count and titles are the deterministic render's, not the model's:
     // the compose pass may only write onto lines, never author them.
-    let items = guard.list_items_for_session(&session.id).unwrap();
+    //
+    // Compared against the items this KIND DRAWS, not against every item the
+    // walk captured. Since #326 a work order draws work and materials only —
+    // the gate code and the hazard belong in the blocks above, not in the
+    // crew's task list. This assertion still compared against all seven and
+    // had been failing since that merge; nothing noticed, because it is the
+    // real-API test and CI never runs it.
+    let items: Vec<_> = guard
+        .list_items_for_session(&session.id)
+        .unwrap()
+        .into_iter()
+        .filter(|i| matches!(i.kind.as_str(), "todo" | "part"))
+        .collect();
     assert_eq!(
         doc["lines"].as_array().unwrap().len(),
         items.len(),


### PR DESCRIPTION
feat: the crew gets a paragraph of its own

Isaac, on WO-0001: *"The work order should have a description box giving
more detail from the walk to the people who will be doing the work."*

## Thinking

He is right, and the evidence is sharper than the request. His estimate's
scope paragraph ended:

> Compost and mulch will be applied after weeding is complete.

That is a sequencing instruction, and it reached the CLIENT as prose. It
reached the CREW only as a grey sub-line on one row. The reader who has
to act on an ordering was the one getting it as a fragment.

The cause is structural: the work order was the only kind with no
narrative block at all. Estimate has SCOPE OF WORK, invoice WORK
PERFORMED, report/condition/inspection/move-out a SUMMARY — the work
order had ASSIGNMENT and SITE NOTES, which are metadata fields (who,
when, access, safety), not prose. So a walk that named no crew and no
gate code rendered a work order as a bare checklist. That is most walks,
and it is exactly what WO-0001 was.

Deliberately NOT the estimate's paragraph reworded. That one sells; this
one instructs. Keying prose to its reader is the whole idea behind
`line_detail`, and this extends it to the block level: the estimate says
what will be done, the invoice what was, the report what was seen, and
the work order how to run it.

## What the model actually writes

Mocks cannot answer that, so this went through the real-API smoke test:

> Strip old bark from front beds before laying mulch. Jose strips bark
> and lays mulch, Michael does edging. Work compost into rose bed.

Ordering, division of labor, and a method note — none of it a restating
of the four lines the crew is already holding.

## Two things repeated runs caught, which one run would not have

**The first prompt left it blank 2 runs in 3** on a transcript that
states an ordering out loud. The brief was competing with the per-line
`directive` detail, which had already recorded "strip old bark first" on
its own row, so the model treated the fact as said. Rewritten to name
the trigger conditions explicitly and to say that naming a task while
sequencing it is correct — 4/4, then 3/3 after the test settled.

**My first anti-restatement assertion punished the desired output.**
`!text.contains(title)` fails on "Strip old bark before laying mulch"
when extraction titles a line `Strip old bark` — which is the good
sentence. Now: at most ONE line title may appear. Naming one task while
sequencing it is the point; naming most of them means the paragraph
became the list again.

## A pre-existing failure this surfaced

`real_walk_becomes_a_work_order` compared the document's line count
against EVERY captured item. Since #326 a work order draws work and
materials only — 4 lines from 7 items — so that assertion had been
failing since it merged. Nothing noticed: it is `#[ignore]`d behind a
real API key and CI never runs it. Now compared against the kinds the
document draws.

## Verified

559 unit/integration tests, clippy clean, all 3 real-API smoke tests
green, iOS build + 166 tests. The block renders with no app change —
sections are schema-driven — so only the display label was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)