### PR TITLE
feat: a tap that commits something answers back

### DIFF
--- a/apps/ios/Sources/Components/Controls.swift
+++ b/apps/ios/Sources/Components/Controls.swift
@@ -125,6 +125,40 @@ struct FieldRowStyle: ButtonStyle {
     }
 }
 
+/// Tier 5: a bare tap that still answers. Looks exactly like `.plain` — no
+/// chrome, no fill, no travel — but dims under the finger and ticks on
+/// touch-down like every other control.
+///
+/// It exists because of what the tick MEANS. Isaac, 2026-08-12: *"I like how
+/// START WALK and my business have a physical click feel… can we make the
+/// other buttons like that? Maybe not every single one but the ones that make
+/// sense."* The ones that make sense are the ones where something HAPPENS —
+/// a line saved or removed, notes exported, a photo deleted. A tick is the
+/// phone saying "that landed", which is worth most when the screen's answer
+/// is a sheet closing behind your own thumb, or when you are wearing gloves
+/// and looking at a yard instead of the glass.
+///
+/// Deliberately NOT applied to CLOSE, CANCEL, `‹ NOTES`, or a photo zoom.
+/// Those navigate: nothing committed, nothing to confirm, and a tick that
+/// fires when nothing happened teaches the hand to stop trusting it. Same
+/// reason `FieldRowStyle` (tier 4) stays silent — twenty job rows buzzing
+/// past under a scrolling thumb is noise, and worse, it fires on the drag
+/// that was meant to scroll.
+struct BareTapStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        let down = configuration.isPressed
+        return configuration.label
+            .opacity(down ? 0.55 : 1)
+            .contentShape(Rectangle())
+            .animation(.easeOut(duration: 0.09), value: down)
+            // Touch-down only, matching the other tiers — a second tick on
+            // release reads as a double-tap.
+            .sensoryFeedback(trigger: down) { _, isDown in
+                isDown ? .impact(flexibility: .rigid) : nil
+            }
+    }
+}
+
 // MARK: - Tier presets
 //
 // Named so a call site picks a TIER, never a colour. One amber fill per screen
@@ -211,6 +245,12 @@ extension ButtonStyle where Self == WellChipStyle {
 extension ButtonStyle where Self == FieldRowStyle {
     /// Tier 4 — a list row with a fill under the finger.
     static var fieldRow: FieldRowStyle { FieldRowStyle() }
+}
+
+extension ButtonStyle where Self == BareTapStyle {
+    /// Tier 5 — an unchromed tap that COMMITS something. Use `.plain` when it
+    /// only navigates.
+    static var bareTap: BareTapStyle { BareTapStyle() }
 }
 
 // MARK: - Labels

--- a/apps/ios/Sources/Flow/NotesView.swift
+++ b/apps/ios/Sources/Flow/NotesView.swift
@@ -607,7 +607,7 @@ struct NotesView: View {
                     .frame(maxWidth: .infinity).frame(height: 40)
                     .overlay(RoundedRectangle(cornerRadius: Theme.S.radiusCard).stroke(Theme.C.hairline, lineWidth: 1.5))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.bareTap)  // commits: EXPORT NOTES leaves the phone
         }
         .padding(.horizontal, Theme.S.screenPad)
         .padding(.top, 11).padding(.bottom, 10)
@@ -845,7 +845,7 @@ private struct NoteItemEditSheet: View {
                             .overlay(RoundedRectangle(cornerRadius: Theme.S.radius)
                                 .stroke(Theme.C.redTag, lineWidth: 2))
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.bareTap)  // commits: REMOVE deletes a line
                 }
                 Button { commitSave() } label: {
                     Text(isEdit ? "SAVE" : "ADD")
@@ -854,7 +854,7 @@ private struct NoteItemEditSheet: View {
                         .frame(maxWidth: .infinity).frame(height: 54)
                         .background(RoundedRectangle(cornerRadius: Theme.S.radius).fill(Theme.C.orange))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.bareTap)  // commits: SAVE/ADD writes the line
                 .disabled(!canSave)
                 .opacity(canSave ? 1 : 0.4)
             }

--- a/apps/ios/Sources/Flow/ReviewView.swift
+++ b/apps/ios/Sources/Flow/ReviewView.swift
@@ -287,7 +287,7 @@ struct ReviewView: View {
                         .frame(width: 18, height: 18)
                         .background(Theme.C.ink)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.bareTap)  // commits: removing a photo is a deletion
             }
             HStack(spacing: 4) {
                 Text(String(format: "PH-%02d", index + 1))


### PR DESCRIPTION
feat: a tap that commits something answers back

Isaac, 2026-08-12: *"I like how START WALK and my business have a
physical click feel when you press on them, can we make the other
buttons like that? Maybe not every single one but the ones that make
sense to have that."*

## Thinking

The feel he likes is already a tier system — `RaisedBlockStyle` (travel
+ a rigid tick) on START WALK and SEND, `WellChipStyle` (recessed, same
tick) on the board chips including MY BUSINESS. What has no feel at all
is `.buttonStyle(.plain)`, used 43 times.

So the question is which of the 43, and "the ones that make sense" has a
principle behind it: **a tick means something happened.** Not "you
touched glass" — the screen already says that — but "that landed". It
is worth most exactly where the app's own answer is weakest: a sheet
closing behind your own thumb, or a phone you are not looking at
because you are looking at a yard.

That splits the 43 cleanly, and the split is mostly the other way:

**Commits — now `.bareTap`:** EXPORT NOTES (leaves the phone), REMOVE
and SAVE/ADD in the line editor (writes or deletes a line), and the
photo's ✕ (a deletion, on the smallest target in the app).

**Navigates — stays `.plain`:** CLOSE, CANCEL, `‹ NOTES`, `‹ CLOSE`,
the paywall dismiss, a photo zoom. Nothing is committed and nothing
needs confirming. A tick that fires when nothing happened is worse than
no tick, because it teaches the hand to stop reading them.

Tier 4 (`FieldRowStyle`, the job rows) stays silent for a second reason
as well: twenty rows buzzing past under a scrolling thumb is noise, and
it would fire on the drag that was meant to scroll.

## The style

`BareTapStyle` looks exactly like `.plain` — no chrome, no fill, no
travel, so nothing on screen moves — and adds the press dim plus the
same touch-down `.impact(flexibility: .rigid)` every other tier uses.
Touch-down only: a second tick on release reads as a double-tap, which
is the reason the existing tiers do it that way.

Deliberately a STYLE rather than a `.sensoryFeedback` sprinkled at four
call sites. The next person adding a button picks a tier, and the tier
carries the rule — which is how `Controls.swift` already prevents
hand-rolled face colours.

## Not included

Outcome feedback — `.success` when a document finishes building, an
error tick when a walk fails to save — is a different and probably
better idea, since the app currently gives the same tick for "I pressed"
and nothing at all for "it worked". Left out because he asked about
press feel and that one deserves its own decision.

## Verified

iOS build + 166 tests. Haptics cannot be felt in the simulator; the
press-dim is visible there and the tick is the same call the shipped
tiers already make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)