### PR TITLE
core: the harness can send an image or a PDF to the model

### DIFF
--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -12,8 +12,9 @@ pub use agent::{Agent, AgentConfig, RunError, TurnOutcome};
 pub use context::{approx_tokens, budget_chars, AssembledContext, ContextAssembler, ContextSection};
 pub use error::HarnessError;
 pub use llm::{
-    CompletionRequest, CompletionResponse, ContentBlock, LlmProvider, Message, Role, StopReason,
-    ToolSpec, Usage,
+    CitationsConfig, CompletionRequest, CompletionResponse, ContentBlock, DocumentMediaType,
+    DocumentSource, ImageMediaType, ImageSource, LlmProvider, Message, Role, StopReason, ToolSpec,
+    Usage,
 };
 pub use mock::MockProvider;
 pub use providers::AnthropicProvider;

--- a/crates/harness/src/llm.rs
+++ b/crates/harness/src/llm.rs
@@ -25,11 +25,96 @@ pub enum ContentBlock {
         content: String,
         is_error: bool,
     },
+    /// An image the model can see. Send-only: the API never returns one.
+    ///
+    /// Image and Document are two variants rather than one merged `Media`
+    /// variant because the `#[serde(tag = "type")]` above already maps the
+    /// variant name to the wire `type` string for free. A merged variant would
+    /// have to choose between `"image"` and `"document"` at runtime, which
+    /// means a hand-written Serialize impl reimplementing the discriminator the
+    /// enum already provides. The block shapes differ anyway — document blocks
+    /// carry optional `title`/`context`/`citations` that image blocks do not.
+    Image {
+        source: ImageSource,
+    },
+    /// A document (today: a PDF) the model can read. Send-only.
+    Document {
+        source: DocumentSource,
+        /// Passed to the model but never cited from; length-limited by the API.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        /// Metadata about the document. Passed to the model, never cited from —
+        /// this is where longer provenance belongs, since `title` is short.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        citations: Option<CitationsConfig>,
+    },
     /// Any block type this crate doesn't know yet (e.g. thinking, server_tool_use).
     /// Lenient on purpose. Unknown blocks are dropped before messages are re-sent
     /// to a provider (see Agent::run) — we can't faithfully round-trip them.
     #[serde(other)]
     Unknown,
+}
+
+/// Where the bytes of an image block come from.
+///
+/// A tagged enum rather than a struct even though base64 is the only source we
+/// need today: the API also accepts `{"type":"url", ...}` and
+/// `{"type":"file", "file_id": ...}`. One level of nesting now makes adding
+/// those an additive change here instead of a breaking change at every call
+/// site — the same reason `ContentBlock` itself is an enum.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSource {
+    Base64 {
+        media_type: ImageMediaType,
+        /// Standard base64, no line breaks.
+        data: String,
+    },
+}
+
+/// The image formats the API accepts. Animations are not supported — only the
+/// first frame of a GIF or animated WebP is read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImageMediaType {
+    #[serde(rename = "image/jpeg")]
+    Jpeg,
+    #[serde(rename = "image/png")]
+    Png,
+    #[serde(rename = "image/gif")]
+    Gif,
+    #[serde(rename = "image/webp")]
+    Webp,
+}
+
+/// Where the bytes of a document block come from. Tagged for the same reason as
+/// [`ImageSource`] — `url`, `file`, `text`, and `content` sources exist on the
+/// wire and can be added without touching callers.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DocumentSource {
+    Base64 {
+        media_type: DocumentMediaType,
+        /// Standard base64, no line breaks.
+        data: String,
+    },
+}
+
+/// The only media type a base64 document source accepts. An enum with one
+/// variant on purpose: it puts "PDF is the only option" in the type system
+/// instead of a doc comment, and a second format stays additive.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DocumentMediaType {
+    #[serde(rename = "application/pdf")]
+    Pdf,
+}
+
+/// Opt in to citations for one document block. All-or-nothing per request:
+/// the API rejects a mix of cited and uncited documents.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CitationsConfig {
+    pub enabled: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -167,6 +252,106 @@ mod tests {
         assert_eq!(v["type"], "tool_result");
         let back: ContentBlock = serde_json::from_value(v).unwrap();
         assert_eq!(back, block);
+    }
+
+    #[test]
+    fn image_block_serializes_to_anthropic_wire_shape() {
+        let block = ContentBlock::Image {
+            source: ImageSource::Base64 {
+                media_type: ImageMediaType::Png,
+                data: "aGVsbG8=".into(),
+            },
+        };
+        let v = serde_json::to_value(&block).unwrap();
+        // The serde tag IS the wire type — no per-provider mapping exists to
+        // catch a rename, so pin the exact strings the API accepts.
+        assert_eq!(v["type"], "image");
+        assert_eq!(v["source"]["type"], "base64");
+        assert_eq!(v["source"]["media_type"], "image/png");
+        assert_eq!(v["source"]["data"], "aGVsbG8=");
+        let back: ContentBlock = serde_json::from_value(v).unwrap();
+        assert_eq!(back, block);
+    }
+
+    #[test]
+    fn every_image_media_type_serializes_to_its_mime_string() {
+        // A wrong variant rename here is a 400 at the API, not a compile error.
+        for (variant, mime) in [
+            (ImageMediaType::Jpeg, "image/jpeg"),
+            (ImageMediaType::Png, "image/png"),
+            (ImageMediaType::Gif, "image/gif"),
+            (ImageMediaType::Webp, "image/webp"),
+        ] {
+            assert_eq!(serde_json::to_value(variant).unwrap(), mime);
+            let back: ImageMediaType = serde_json::from_value(mime.into()).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn document_block_serializes_to_anthropic_wire_shape() {
+        let block = ContentBlock::Document {
+            source: DocumentSource::Base64 {
+                media_type: DocumentMediaType::Pdf,
+                data: "JVBERi0=".into(),
+            },
+            title: Some("Invoice template".into()),
+            context: Some("Operator-uploaded".into()),
+            citations: Some(CitationsConfig { enabled: true }),
+        };
+        let v = serde_json::to_value(&block).unwrap();
+        assert_eq!(v["type"], "document");
+        assert_eq!(v["source"]["type"], "base64");
+        assert_eq!(v["source"]["media_type"], "application/pdf");
+        assert_eq!(v["source"]["data"], "JVBERi0=");
+        assert_eq!(v["title"], "Invoice template");
+        assert_eq!(v["context"], "Operator-uploaded");
+        assert_eq!(v["citations"]["enabled"], true);
+        let back: ContentBlock = serde_json::from_value(v).unwrap();
+        assert_eq!(back, block);
+    }
+
+    #[test]
+    fn document_optional_fields_are_absent_not_null_when_unset() {
+        // `"title": null` is not the same as an omitted key to the API — a
+        // null would be rejected where an absent field is fine.
+        let block = ContentBlock::Document {
+            source: DocumentSource::Base64 {
+                media_type: DocumentMediaType::Pdf,
+                data: "JVBERi0=".into(),
+            },
+            title: None,
+            context: None,
+            citations: None,
+        };
+        let v = serde_json::to_value(&block).unwrap();
+        assert!(v.get("title").is_none(), "title must be absent: {v}");
+        assert!(v.get("context").is_none(), "context must be absent: {v}");
+        assert!(v.get("citations").is_none(), "citations must be absent: {v}");
+        let back: ContentBlock = serde_json::from_value(v).unwrap();
+        assert_eq!(back, block);
+    }
+
+    #[test]
+    fn a_whole_message_of_media_blocks_serializes_as_the_provider_sends_it() {
+        // AnthropicProvider builds its body with `"messages": req.messages`, so
+        // serde IS the wire format — this is the shape that actually goes out.
+        let msg = Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Image {
+                    source: ImageSource::Base64 {
+                        media_type: ImageMediaType::Png,
+                        data: "aGVsbG8=".into(),
+                    },
+                },
+                ContentBlock::Text { text: "what is this?".into() },
+            ],
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["role"], "user");
+        assert_eq!(v["content"][0]["type"], "image");
+        assert_eq!(v["content"][1]["type"], "text");
     }
 
     #[test]

--- a/crates/harness/tests/image_block_live.rs
+++ b/crates/harness/tests/image_block_live.rs
@@ -1,0 +1,86 @@
+//! Env-gated live check that an `Image` content block survives the wire.
+//!
+//! `AnthropicProvider::complete` builds its body with `"messages": req.messages`,
+//! so serde IS the wire format — there is no per-variant provider mapping to get
+//! wrong. That also means a variant nothing sends is a variant nothing has ever
+//! proven. This test sends one, against the real API, and asserts the model
+//! actually saw the pixels.
+//!
+//! Ignored by default — it costs real tokens and needs a key. Run explicitly:
+//!
+//! ```sh
+//! ANTHROPIC_API_KEY=sk-... nix develop -c \
+//!     cargo test -p harness --test image_block_live -- --ignored --nocapture
+//! ```
+
+use harness::{
+    AnthropicProvider, CompletionRequest, ContentBlock, ImageMediaType, ImageSource, LlmProvider,
+    Message, Role,
+};
+
+/// Cheapest current haiku-class model — this is a wire check, not an eval.
+const MODEL: &str = "claude-haiku-4-5";
+
+/// A 64x64 solid red PNG, 136 bytes. Inlined rather than shipped as a binary
+/// fixture so the test is readable and the repo stays text-only.
+const RED_SQUARE_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAT0lEQVR42u3PQQkAAAgEsEty/UMZxgi+hcEKLNO+FgEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQGBywLPLIEA68ZURwAAAABJRU5ErkJggg==";
+
+#[tokio::test]
+#[ignore = "hits the real Anthropic API; set ANTHROPIC_API_KEY and run with --ignored"]
+async fn real_anthropic_accepts_an_image_block() {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .expect("set ANTHROPIC_API_KEY to run the real-provider image smoke test");
+
+    let provider = AnthropicProvider::from_env(api_key, MODEL);
+
+    let resp = provider
+        .complete(CompletionRequest {
+            system: "You answer in a single word.".into(),
+            messages: vec![Message {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::Image {
+                        source: ImageSource::Base64 {
+                            media_type: ImageMediaType::Png,
+                            data: RED_SQUARE_PNG_BASE64.into(),
+                        },
+                    },
+                    ContentBlock::Text {
+                        text: "What is the dominant color of this image? \
+                               Reply with exactly one word."
+                            .into(),
+                    },
+                ],
+            }],
+            tools: vec![],
+            max_tokens: 16,
+            tool_choice: None,
+            cache_prefix: false,
+        })
+        .await
+        .expect("live image request failed");
+
+    let text = resp
+        .content
+        .iter()
+        .find_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .expect("no text block in response");
+
+    eprintln!(
+        "live: model said {text:?}; stop_reason={:?}; usage={:?}",
+        resp.stop_reason, resp.usage
+    );
+
+    // Not just "it was a 200": a 200 proves the block parsed, this proves the
+    // pixels reached the model. A block that serialized to the wrong shape
+    // would 400; one the model couldn't see would answer something else.
+    assert!(
+        text.to_lowercase().contains("red"),
+        "model did not see the red image; it said: {text:?}"
+    );
+    assert!(resp.usage.input_tokens > 0, "no input tokens billed");
+    assert!(resp.usage.output_tokens > 0, "no output tokens billed");
+}


### PR DESCRIPTION
Closes #263 — the narrowed ask from the comments: **the capability alone**. Variants on `main`, nothing consuming them, so operator template upload becomes a sac-side 1.1 feature instead of blocking on me being back.

Deliberately **not** here: the comprehension pass, `infer_document_schema`, any engine method, any FFI export, any UI. The diff touches `crates/harness` only.

## The shape

```rust
ContentBlock::Image    { source: ImageSource }
ContentBlock::Document { source: DocumentSource, title, context, citations }
```

**Two variants, not one merged `Media`.** `ContentBlock` is `#[serde(tag = "type", rename_all = "snake_case")]`, so the Rust variant name already *is* the wire `type` string. A merged variant would have to choose between `"image"` and `"document"` at runtime — which means a hand-written `Serialize` impl reintroducing by hand the discriminator the enum already provides for free. The blocks aren't the same shape anyway: document blocks carry optional `title` / `context` / `citations` that image blocks don't.

**The source is a tagged enum, not a struct**, even though base64 is the only source needed today. The API also accepts `{"type":"url", …}` and `{"type":"file","file_id":…}` for both, plus `text` and `content` sources for documents. One level of nesting now makes adding any of those an additive change here instead of a breaking change at every call site — the same reason `ContentBlock` itself is an enum.

`media_type` is an enum rather than a `String` so "which formats the API accepts" is a compile-time fact rather than a doc comment. `DocumentMediaType` has exactly one variant on purpose.

Additive and backward-compatible: `#[serde(other)] Unknown` means nothing that parses today stops parsing, and there is no exhaustive `match` on `ContentBlock` anywhere in the workspace (`clippy --all-targets -D warnings` is clean, which proves it).

## Wire shapes

Verified against current docs before writing, not from memory — [Vision](https://platform.claude.com/docs/en/build-with-claude/vision), [PDF support](https://platform.claude.com/docs/en/build-with-claude/pdf-support), [Citations](https://platform.claude.com/docs/en/build-with-claude/citations).

```json
{"type": "image",
 "source": {"type": "base64", "media_type": "image/png", "data": "…"}}

{"type": "document",
 "source": {"type": "base64", "media_type": "application/pdf", "data": "…"},
 "title": "…", "context": "…", "citations": {"enabled": true}}
```

- Image `media_type`: exactly `image/jpeg`, `image/png`, `image/gif`, `image/webp`. Animations unsupported — only the first frame is read.
- Document base64 `media_type`: `application/pdf` only.
- Document optionals: `title` (short, length-limited by the API), `context` (metadata; where longer provenance belongs since `title` is short), `citations: {enabled: bool}`. `title` and `context` are passed to the model but never cited from. Optional fields serialize as **absent, not `null`** — there's a test pinning that, since `null` and omitted are not the same thing to the API.

Nothing in the docs contradicted the proposed shape.

## Proof it works on the wire

Serde round-trip tests are in `llm.rs`, but a variant with zero consumers is unverified by construction — so there's also an env-gated end-to-end test that sends a real image to the real API through `AnthropicProvider`, gated the same way the repo's other real-API tests are (`#[ignore = "hits the real Anthropic API; …"]` + `ANTHROPIC_API_KEY`):

```sh
ANTHROPIC_API_KEY=sk-… nix develop -c \
    cargo test -p harness --test image_block_live -- --ignored --nocapture
```

The fixture is a 64×64 solid-red PNG (136 bytes) base64-inlined in the test source — no binary fixture added. It asserts the model **saw the pixels**, not merely that the call was a 200: a block that serialized to the wrong shape would 400, and one the model couldn't see would answer something else.

Run once against the real API on `claude-haiku-4-5`, verbatim:

```
running 1 test
live: model said "Red"; stop_reason=EndTurn; usage=Usage { input_tokens: 42, output_tokens: 4, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
test real_anthropic_accepts_an_image_block ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.91s
```

Note `AnthropicProvider::complete` builds its body as `serde_json::json!({… "messages": req.messages …})` — **serde is the wire format**. There is no per-variant provider mapping, so nothing in `providers/anthropic.rs` needed to change, and the serde tests are testing the actual outgoing bytes.

## Two things for whoever builds the consumer

**Proxy model allowlist — untouched, but coupled.** `services/proxy/src/pricing.ts` prefix-matches an allowlist of `claude-haiku-4-5` and `claude-sonnet-4-5`. If the comprehension pass wants a different model (the issue floats Sonnet, or Opus for messy scans), the proxy allowlist and its rate table have to grow to match or the request is rejected at the proxy. That's a decision for whoever builds the pass, not for this PR — the proxy also can't currently be deployed. **Nothing under `services/proxy/` is changed here.**

**Payload size is a real concern, and there is no bound yet.** `ContentBlock` derives `Clone` and `PartialEq`; a base64 PDF becomes a large `String` cloned through the message vec on every turn, and the Cloudflare Worker that proxies it holds the body as text against a 128 MB memory ceiling. Base64 is also ~1.33× the raw bytes, and the proxy meters spend on the resulting token count. I deliberately did **not** add a limit — there's no consumer to enforce it at, and a bound guessed now would be a bound nobody chose. Whoever builds the upload path should pick one deliberately rather than discovering an OOM on a contractor's phone.

## Gate

- `nix develop -c cargo test --workspace` — 0 failures
- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings` — clean
